### PR TITLE
SMOODEV-75: Publish Go config module to pkg.go.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,18 @@ jobs:
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 
+            - name: Tag and publish Go module
+              if: steps.changesets.outputs.published == 'true'
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  TAG="go/config/v${VERSION}"
+                  echo "Creating Go module tag: ${TAG}"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git tag "${TAG}"
+                  git push origin "${TAG}"
+                  echo "Go module tagged and pushed: ${TAG}"
+
             - name: Auto-Merge Changeset PR
               run: |
                   PR_NUMBER=$(gh pr list --state open --head changeset-release/main --json number --jq '.[0].number')

--- a/go/config/version.go
+++ b/go/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // Version is the current version of the smooai-config Go package.
-const Version = "1.0.7"
+const Version = "1.1.0"


### PR DESCRIPTION
## Summary
- Sync Go `version.go` constant from `1.0.7` → `1.1.0` to match npm package version
- Add automated Go module tagging step (`go/config/vX.Y.Z`) to `release.yml` CI so future changeset releases auto-publish to pkg.go.dev
- After merge, the initial tag `go/config/v1.1.0` needs to be created manually (or next changeset release will create it)

## Context
The Go module at `go/config/` had zero git tags, making it undiscoverable on pkg.go.dev. Go modules require semver tags (with subdirectory prefix for nested modules) to be indexed by the Go module proxy.

## Test plan
- [ ] Verify `version.go` shows `1.1.0`
- [ ] Verify release.yml has the Go tag step after crates.io publish
- [ ] After merge, create tag `go/config/v1.1.0` and verify pkg.go.dev indexes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)