### PR TITLE
SMOODEV-78: Add missing PyPI publish task

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smooai-config"
-version = "1.0.7"
+version = "1.1.0"
 description = "Smoo AI Configuration Management Library"
 requires-python = ">=3.13"
 dependencies = ["pydantic>=2.0.0", "httpx>=0.27.0"]
@@ -24,6 +24,12 @@ typecheck = "basedpyright src/"
 test = "pytest tests/ -v"
 build = "uv build --wheel --sdist"
 "install-dev" = "uv sync"
+
+[tool.poe.tasks.publish]
+sequence = [
+  { cmd = "uv build --wheel --sdist" },
+  { cmd = "uv publish" },
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Add missing `publish` poe task (release.yml called `uv run poe publish` but the task didn't exist)
- Publish task rebuilds wheel first (needed because `version:sync` runs before publish in CI)
- Sync pyproject.toml version `1.0.7` → `1.1.0`

## Test plan
- [ ] Verify `poe publish` task exists and works
- [ ] After merge, trigger a changeset release and confirm PyPI publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)