### PR TITLE
SMOODEV-608: Use Zod v4 native z.toJSONSchema() (drop zod-to-json-schema)

### DIFF
--- a/.changeset/zod-native-json-schema.md
+++ b/.changeset/zod-native-json-schema.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': minor
+---
+
+Use Zod v4's built-in `z.toJSONSchema()` instead of the `zod-to-json-schema` adapter. Drops the adapter dep (typed against Zod v3 — needed `as any` casts to pass Zod v4 schemas through) and removes the related stubs from the browser-build alias map. Runtime output shape is equivalent. Also drops the `zod-to-json-schema` runtime dependency.

--- a/package.json
+++ b/package.json
@@ -247,8 +247,7 @@
         "synckit": "^0.11.6",
         "tinyglobby": "^0.2.14",
         "tsx": "^4.19.4",
-        "valibot": "^1.1.0",
-        "zod-to-json-schema": "^3.24.5"
+        "valibot": "^1.1.0"
     },
     "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.8.2)
-      zod-to-json-schema:
-        specifier: ^3.24.5
-        version: 3.24.5(zod@4.1.5)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1
@@ -3489,11 +3486,6 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
-
-  zod-to-json-schema@3.24.5:
-    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
-    peerDependencies:
-      zod: ^3.24.1
 
   zod@4.1.5:
     resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
@@ -6930,10 +6922,6 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoga-layout@3.2.1: {}
-
-  zod-to-json-schema@3.24.5(zod@4.1.5):
-    dependencies:
-      zod: 4.1.5
 
   zod@4.1.5: {}
 

--- a/src/config/standardSchemaToJson.ts
+++ b/src/config/standardSchemaToJson.ts
@@ -5,8 +5,7 @@ import type { Type as ArkType } from 'arktype';
 import { Schema as EffectSchema } from 'effect';
 import * as EffectJSONSchema from 'effect/JSONSchema';
 import type { BaseIssue, BaseSchema } from 'valibot';
-import type { ZodType } from 'zod';
-import zodToJsonSchema from 'zod-to-json-schema';
+import { z, type ZodType } from 'zod';
 
 /**
  * Zod type names that cannot be serialized to JSON Schema for config.
@@ -93,7 +92,7 @@ export function standardSchemaToJson<I, O>(schema: StandardSchemaV1<I, O> | Effe
         switch (vendor) {
             case 'zod':
                 checkZodSchema(schema as ZodType);
-                return zodToJsonSchema(schema as ZodType);
+                return z.toJSONSchema(schema as ZodType);
             case 'valibot':
                 return valibotToJsonSchema(schema as BaseSchema<unknown, unknown, BaseIssue<unknown>>);
             case 'arktype':

--- a/src/stubs/standard-schema-serializer.stub.ts
+++ b/src/stubs/standard-schema-serializer.stub.ts
@@ -13,7 +13,3 @@ export const make = (..._args: any[]) => ({});
 
 // json-schema-to-zod
 export const jsonSchemaToZod = (..._args: any[]) => '';
-
-// zod-to-json-schema
-export default (..._args: any[]) => ({});
-export const zodToJsonSchema = (..._args: any[]) => ({});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -92,19 +92,13 @@ const aliasedModules = [
     'effect',
     'effect/JSONSchema',
     'json-schema-to-zod',
-    'zod-to-json-schema',
     'rotating-file-stream',
 ];
 
 const aliasMap: Record<string, string> = {};
 for (const mod of aliasedModules) {
     aliasMap[mod] =
-        mod === '@valibot/to-json-schema' ||
-        mod === 'arktype' ||
-        mod === 'effect' ||
-        mod === 'effect/JSONSchema' ||
-        mod === 'json-schema-to-zod' ||
-        mod === 'zod-to-json-schema'
+        mod === '@valibot/to-json-schema' || mod === 'arktype' || mod === 'effect' || mod === 'effect/JSONSchema' || mod === 'json-schema-to-zod'
             ? schemaStub
             : nodeStub;
 }


### PR DESCRIPTION
## Summary

- `@smooai/config` already runs on Zod v4 (`^4.0.0`). Drop the `zod-to-json-schema` adapter — it's typed against Zod v3 and forced `as any` casts to pass v4 schemas through.
- Zod v4 ships `z.toJSONSchema()` natively with equivalent output.
- Also drops the adapter from the browser-build stub (`src/stubs/standard-schema-serializer.stub.ts`) and `tsup.config.ts` alias map, plus removes it from runtime deps.

## Test plan

- [x] 16/16 test files pass locally
- [x] TypeScript + Rust + Go typecheck clean
- [ ] CI green