### PR TITLE
SMOODEV-609: runtime + build helpers for baked-blob config deployment

### DIFF
--- a/.changeset/runtime-bake.md
+++ b/.changeset/runtime-bake.md
@@ -1,0 +1,15 @@
+---
+'@smooai/config': minor
+---
+
+Add `@smooai/config/platform/runtime` and `@smooai/config/platform/build` — framework-agnostic bake-and-decrypt pattern for shipping config to deployment targets (Lambda, ECS, Fargate, EC2, containers, anywhere Node + filesystem).
+
+**Pattern** (mirrors SST v4's `Resource.*` cold-start-decrypt, without the SST coupling):
+
+1. Deploy-time baker (`buildBundle`) calls `ConfigClient.getAllValues(env)`, partitions via `classifyFromSchema` (public + secret into the blob, feature flags skipped), encrypts with AES-256-GCM, returns `{ keyB64, bundle }`. Deploy glue writes the bundle to disk and sets `SMOO_CONFIG_KEY_FILE` + `SMOO_CONFIG_KEY` on the function.
+2. Runtime helper (`buildConfigRuntime(schema)`) decrypts the blob once at cold start and exposes the same typed `getPublicConfig` / `getSecretConfig` / `getFeatureFlag` API as the existing `buildConfigObject` — consumer code stays identical.
+3. Feature flags always hit the config API at runtime (they're designed to flip without a redeploy), routed through a cached `ConfigClient`.
+
+Blob layout: `nonce (12 random bytes) || ciphertext || authTag (16 bytes)`. Random nonce + fresh key per `buildBundle` — no key-reuse hazard across re-bakes.
+
+Paired with a deploy-pipeline adapter in your infra repo (SST, Pulumi, Vercel, whatever), this eliminates the 4 KB Lambda env-var ceiling for secrets while keeping the library API unchanged.

--- a/package.json
+++ b/package.json
@@ -164,6 +164,16 @@
             "import": "./dist/platform/client.mjs",
             "require": "./dist/platform/client.js"
         },
+        "./platform/lambda-runtime": {
+            "types": "./dist/platform/lambda-runtime.d.ts",
+            "import": "./dist/platform/lambda-runtime.mjs",
+            "require": "./dist/platform/lambda-runtime.js"
+        },
+        "./platform/build": {
+            "types": "./dist/platform/build.d.ts",
+            "import": "./dist/platform/build.mjs",
+            "require": "./dist/platform/build.js"
+        },
         "./utils": {
             "types": "./dist/utils/index.d.ts",
             "browser": {

--- a/src/platform/build.ts
+++ b/src/platform/build.ts
@@ -1,0 +1,109 @@
+import crypto from 'node:crypto';
+import { ConfigClient, ConfigClientOptions } from './client';
+
+/**
+ * Framework-agnostic deploy-time baker.
+ *
+ * Fetches `public` + `secret` config values for an environment, encrypts the
+ * JSON with AES-256-GCM, and returns the ciphertext blob + base64-encoded key.
+ * Deploy glue (SST/Vercel/Cloudflare/anything) writes the blob to disk, ships
+ * it in the function bundle, and sets two env vars on the function:
+ *
+ *   SMOO_CONFIG_KEY_FILE = <absolute path to the blob on disk at runtime>
+ *   SMOO_CONFIG_KEY      = <returned keyB64>
+ *
+ * At cold start, `@smooai/config/platform/runtime` reads both and decrypts
+ * once into an in-memory map. No runtime fetch for public + secret values.
+ *
+ * **Feature flags are intentionally NOT baked** — they're designed to flip
+ * without a redeploy, so they stay live-fetched via `ConfigClient`. Pass a
+ * `classify` function (or use `classifyFromSchema`) so the baker knows which
+ * keys to drop.
+ *
+ * Blob layout: `nonce (12 random bytes) || ciphertext || authTag (16 bytes)`.
+ * Random nonce means re-baking under the same key is safe — though every
+ * `buildBundle` call generates a new key anyway, so that's belt-and-braces.
+ */
+
+export interface BuildBundleOptions extends ConfigClientOptions {
+    /**
+     * Classifier for each key. Return `'public'` or `'secret'` to include in
+     * the blob, or `'skip'` to omit (e.g., feature flags, which stay live).
+     * Default behavior: if no classifier given, every key lands in `public`.
+     * Use `classifyFromSchema(configSchema)` for the typical case.
+     */
+    classify?: (key: string, value: unknown) => 'public' | 'secret' | 'skip';
+}
+
+export interface BuildBundleResult {
+    /** Base64-encoded 32-byte AES-256 key. Set as `SMOO_CONFIG_KEY`. */
+    keyB64: string;
+    /** Encrypted blob: `nonce || ciphertext || authTag`. Write to disk, bundle with function. */
+    bundle: Buffer;
+    /** Number of keys packed (after `skip` filter). */
+    keyCount: number;
+    /** Number of keys skipped (e.g., feature flags). */
+    skippedCount: number;
+}
+
+function defaultClassify(): 'public' {
+    return 'public';
+}
+
+export async function buildBundle(options: BuildBundleOptions): Promise<BuildBundleResult> {
+    const { classify = defaultClassify, ...clientOptions } = options;
+
+    const client = new ConfigClient(clientOptions);
+    const all = await client.getAllValues(clientOptions.environment);
+
+    const partitioned = {
+        public: {} as Record<string, unknown>,
+        secret: {} as Record<string, unknown>,
+    };
+    let skippedCount = 0;
+    for (const [k, v] of Object.entries(all)) {
+        const section = classify(k, v);
+        if (section === 'skip') {
+            skippedCount += 1;
+            continue;
+        }
+        partitioned[section][k] = v;
+    }
+
+    const plaintext = Buffer.from(JSON.stringify(partitioned), 'utf8');
+    const key = crypto.randomBytes(32);
+    const nonce = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, nonce);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const bundle = Buffer.concat([nonce, ciphertext, authTag]);
+
+    return {
+        keyB64: key.toString('base64'),
+        bundle,
+        keyCount: Object.keys(partitioned.public).length + Object.keys(partitioned.secret).length,
+        skippedCount,
+    };
+}
+
+/**
+ * Classifier factory driven by a `defineConfig` schema. Pass the schema you
+ * declared in `.smooai-config/config.ts`; each key is routed by whether it
+ * exists in `publicConfigSchema`, `secretConfigSchema`, or `featureFlagSchema`.
+ * Feature flags return `'skip'` — they stay live-fetched at runtime.
+ */
+export function classifyFromSchema(configSchema: {
+    publicConfigSchema?: Record<string, unknown>;
+    secretConfigSchema?: Record<string, unknown>;
+    featureFlagSchema?: Record<string, unknown>;
+}): (key: string) => 'public' | 'secret' | 'skip' {
+    const publicKeys = new Set(Object.keys(configSchema.publicConfigSchema ?? {}));
+    const secretKeys = new Set(Object.keys(configSchema.secretConfigSchema ?? {}));
+    const flagKeys = new Set(Object.keys(configSchema.featureFlagSchema ?? {}));
+    return (key: string) => {
+        if (secretKeys.has(key)) return 'secret';
+        if (publicKeys.has(key)) return 'public';
+        if (flagKeys.has(key)) return 'skip';
+        return 'public';
+    };
+}

--- a/src/platform/runtime.ts
+++ b/src/platform/runtime.ts
@@ -1,0 +1,177 @@
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { defineConfig, InferConfigTypes } from '@/config/config';
+import { ConfigClient, ConfigClientOptions } from './client';
+
+/**
+ * Bake-aware runtime helper for @smooai/config.
+ *
+ * Returns the same shape as the existing `buildConfigObject` server helper
+ * (`getPublicConfig` / `getSecretConfig` / `getFeatureFlag`), so consumer
+ * code stays identical regardless of where the values actually came from.
+ * The library API is uniform; only the hydration source differs.
+ *
+ * Sources:
+ *   - Public + secret values → pre-encrypted blob baked into the deployment
+ *     artifact (Lambda bundle / container image / EC2 disk).
+ *   - Feature flags           → always live-fetched from the config API
+ *     (they're designed to flip without a redeploy — never baked).
+ *
+ * The baker (`@smooai/config/platform/build`) partitions feature flags out
+ * via `classifyFromSchema`, so the blob only contains public + secret.
+ *
+ * Works anywhere Node.js runs with a filesystem: Lambda, ECS, Fargate, EC2,
+ * long-lived services, containers. For runtimes without a filesystem
+ * (Workers, Vercel edge), skip this module and use `ConfigClient` directly.
+ *
+ * Environment variables (set by your deploy pipeline):
+ *
+ *   SMOO_CONFIG_KEY_FILE  — absolute path to the encrypted blob on disk
+ *                            (Lambda:  `/var/task/smoo-config.enc`)
+ *                            (ECS/EC2: wherever the image/provisioner puts it)
+ *   SMOO_CONFIG_KEY       — base64-encoded 32-byte AES-256 key
+ *
+ *   SMOOAI_CONFIG_API_URL — for feature-flag lookups (forwarded to ConfigClient)
+ *   SMOOAI_CONFIG_API_KEY
+ *   SMOOAI_CONFIG_ORG_ID
+ *   SMOOAI_CONFIG_ENV
+ *
+ * Blob layout: `nonce (12 bytes) || ciphertext || authTag (16 bytes)`.
+ */
+
+interface DecryptedBlob {
+    public: Record<string, unknown>;
+    secret: Record<string, unknown>;
+}
+
+let decryptedCache: DecryptedBlob | undefined;
+let hydratedFlagClient: ConfigClient | undefined;
+
+function decryptBlob(): DecryptedBlob | undefined {
+    const keyFile = process.env.SMOO_CONFIG_KEY_FILE;
+    const keyB64 = process.env.SMOO_CONFIG_KEY;
+    if (!keyFile || !keyB64) return undefined;
+
+    const key = Buffer.from(keyB64, 'base64');
+    if (key.length !== 32) {
+        throw new Error(`SMOO_CONFIG_KEY must decode to 32 bytes (got ${key.length})`);
+    }
+
+    const blob = readFileSync(keyFile);
+    if (blob.length < 28) {
+        throw new Error(`smoo-config blob too short (${blob.length} bytes)`);
+    }
+
+    const nonce = blob.subarray(0, 12);
+    const authTag = blob.subarray(blob.length - 16);
+    const ciphertext = blob.subarray(12, blob.length - 16);
+
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, nonce);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+
+    const parsed = JSON.parse(plaintext);
+    return {
+        public: parsed.public ?? {},
+        secret: parsed.secret ?? {},
+    };
+}
+
+function getBlob(): DecryptedBlob {
+    if (!decryptedCache) {
+        decryptedCache = decryptBlob() ?? { public: {}, secret: {} };
+    }
+    return decryptedCache;
+}
+
+export interface BuildConfigRuntimeOptions {
+    /** Override the ConfigClient used for feature-flag lookups. */
+    flagClient?: ConfigClient;
+    /** ConfigClient construction options (when no client is supplied). Default cacheTtlMs: 30_000. */
+    flagClientOptions?: ConfigClientOptions;
+}
+
+/**
+ * Build a runtime config accessor with typed, per-tier getters.
+ *
+ * Returns the same `{ getPublicConfig, getSecretConfig, getFeatureFlag }`
+ * shape as the existing `buildConfigObject` server helper — consumer code
+ * is portable between baked + file/env modes.
+ *
+ * @example
+ *   import configSchema from '../.smooai-config/config';
+ *   import { buildConfigRuntime } from '@smooai/config/platform/runtime';
+ *
+ *   const config = buildConfigRuntime(configSchema);
+ *
+ *   const tavily = await config.getSecretConfig(configSchema.SecretConfigKeys.tavilyApiKey);
+ *   const apiUrl = await config.getPublicConfig(configSchema.PublicConfigKeys.apiUrl);
+ *   const flag   = await config.getFeatureFlag(configSchema.FeatureFlagKeys.newFlow);
+ */
+export function buildConfigRuntime<Schema extends ReturnType<typeof defineConfig>>(
+    configSchema: Schema,
+    options?: BuildConfigRuntimeOptions,
+): {
+    getPublicConfig: <
+        K extends Extract<
+            InferConfigTypes<Schema>['PublicConfigKeys'][keyof InferConfigTypes<Schema>['PublicConfigKeys']],
+            keyof InferConfigTypes<Schema>['ConfigType']
+        >,
+    >(
+        key: K,
+    ) => Promise<InferConfigTypes<Schema>['ConfigType'][K] | undefined>;
+    getSecretConfig: <
+        K extends Extract<
+            InferConfigTypes<Schema>['SecretConfigKeys'][keyof InferConfigTypes<Schema>['SecretConfigKeys']],
+            keyof InferConfigTypes<Schema>['ConfigType']
+        >,
+    >(
+        key: K,
+    ) => Promise<InferConfigTypes<Schema>['ConfigType'][K] | undefined>;
+    getFeatureFlag: <
+        K extends Extract<
+            InferConfigTypes<Schema>['FeatureFlagKeys'][keyof InferConfigTypes<Schema>['FeatureFlagKeys']],
+            keyof InferConfigTypes<Schema>['ConfigType']
+        >,
+    >(
+        key: K,
+    ) => Promise<InferConfigTypes<Schema>['ConfigType'][K] | undefined>;
+    /** Force a re-read of the baked blob. */
+    invalidateBlobCache: () => void;
+    /** Clear the feature-flag cache. */
+    invalidateFlagCache: () => void;
+} {
+    void configSchema;
+
+    const getFlagClient = () => {
+        if (options?.flagClient) return options.flagClient;
+        if (!hydratedFlagClient) {
+            hydratedFlagClient = new ConfigClient({
+                cacheTtlMs: 30_000,
+                ...(options?.flagClientOptions ?? {}),
+            });
+        }
+        return hydratedFlagClient;
+    };
+
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic relay into untyped blob
+        getPublicConfig: (async (key: any) => getBlob().public[String(key)]) as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic relay into untyped blob
+        getSecretConfig: (async (key: any) => getBlob().secret[String(key)]) as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic relay into ConfigClient
+        getFeatureFlag: (async (key: any) => (await getFlagClient().getValue(String(key))) as any) as any,
+        invalidateBlobCache: () => {
+            decryptedCache = undefined;
+        },
+        invalidateFlagCache: () => {
+            hydratedFlagClient?.invalidateCache();
+        },
+    };
+}
+
+/** Internal test helper — reset module-scope caches. */
+export function __resetRuntimeCaches(): void {
+    decryptedCache = undefined;
+    hydratedFlagClient = undefined;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,8 @@ const serverEntry = [
     'src/react/hooks.ts',
     'src/platform/server.ts',
     'src/platform/client.ts',
+    'src/platform/runtime.ts',
+    'src/platform/build.ts',
     'src/platform/server/server.secretConfig.sync.ts',
     'src/platform/server/server.publicConfig.sync.ts',
     'src/platform/server/server.featureFlag.sync.ts',


### PR DESCRIPTION
## Summary

Two new framework-agnostic exports under `@smooai/config/platform/`:

- **`build`** — deploy-time baker. `buildBundle({apiKey, orgId, environment, ...})` fetches all values via `ConfigClient`, partitions via `classifyFromSchema` (public + secret baked, feature flags skipped), encrypts with AES-256-GCM (random 12-byte nonce, 16-byte auth tag), returns `{keyB64, bundle, keyCount, skippedCount}`.
- **`runtime`** — cold-start decrypt + typed accessor. `buildConfigRuntime(schema)` returns the same `{getPublicConfig, getSecretConfig, getFeatureFlag}` shape as `buildConfigObject`. Consumer call sites don't change — only the hydration source does.

**Feature flags never baked** — they're designed to flip without a redeploy, so they always hit the config API at runtime (via a cached `ConfigClient`).

**Framework-agnostic** — works on Lambda (`copyFiles` + `environment`), ECS/Fargate (image + task-def env), EC2 (userdata + systemd env), any Node runtime with a filesystem. Workers/Vercel edge skip this module and use `ConfigClient` directly.

**Security posture**: matches SST v4's pattern (encrypted blob file + key in env). Protects against bundle/source disclosure, not against AWS-IAM adversaries. Random nonce per re-bake (defense-in-depth vs. SST's zero nonce).

## Why

- Eliminates the 4 KB Lambda env-var ceiling (114+ secrets don't fit there)
- Decouples from SST so the config package stays portable
- Keeps the library API unchanged across bake-at-deploy and live-fetch modes

## Test plan

- [x] `pnpm typecheck` + `pnpm test` + `pnpm build:lib` clean
- [ ] CI green
- [ ] Next PR (smooai monorepo): SST adapter + POC consumer swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)