### PR TITLE
SMOODEV-612: fix Release workflow — wrap version+sync in single pnpm script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
               with:
                   commit: '🦋 New version release'
                   title: '🦋 New version release'
-                  version: pnpm changeset version && pnpm run version:sync
+                  version: pnpm run version:bump
                   publish: pnpm ci:publish
                   createGithubReleases: true
               env:

--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
         "go:lint": "(cd go/config && go vet ./...)",
         "go:test": "(cd go/config && go test -v ./...)",
         "version:sync": "node scripts/sync-versions.mjs",
+        "version:bump": "pnpm changeset version && pnpm run version:sync",
         "format:check": "oxfmt --check ."
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

The `changesets/action@v1` `version` input doesn't run through a shell, so `pnpm changeset version && pnpm run version:sync` splits on whitespace and passes extra args to changesets (`Too many arguments passed to changesets`). The failed `changeset version` call leaves `changeset-release/main` uncreated, and the follow-up PR-creation step dies with `No commits between main and changeset-release/main`.

Fix: introduce `pnpm run version:bump` that chains both commands, and call that from the workflow. The action sees a single pnpm invocation and runs it verbatim.

Unblocks publishing `@smooai/config 3.2.0` (runtime + build helpers from PR #15) so the SMOODEV-610 SST adapter in the smooai monorepo can install them.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, Release workflow on main should produce a `changeset-release/main` PR with the queued version bumps