### PR TITLE
SMOODEV-614: evaluateFeatureFlag SDK surface in TS/Python/Rust/Go

### DIFF
--- a/go/config/bake_integration_test.go
+++ b/go/config/bake_integration_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAllValuesServer serves GET /organizations/{org}/config/values with the
+// provided JSON body. Mirrors the TS/Python/Rust bake tests.
+func mockAllValuesServer(t *testing.T, values map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("environment") != "production" {
+			http.Error(w, "unexpected env", 400)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+testAPIKey {
+			http.Error(w, "unauthorized", 401)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": values})
+	}))
+}
+
+func TestBuildBundle_PartitionsPublicSecretAndSkipsFlags(t *testing.T) {
+	srv := mockAllValuesServer(t, map[string]any{
+		"API_URL":        "https://api.example.com",
+		"API_KEY":        "secret-123",
+		"ENABLE_FEATURE": true,
+	})
+	defer srv.Close()
+
+	classify := ClassifyFromSchema(
+		map[string]struct{}{"API_URL": {}},
+		map[string]struct{}{"API_KEY": {}},
+		map[string]struct{}{"ENABLE_FEATURE": {}},
+	)
+
+	result, err := BuildBundle(BuildBundleArgs{
+		BaseURL:     srv.URL,
+		APIKey:      testAPIKey,
+		OrgID:       testOrgID,
+		Environment: "production",
+		Classify:    classify,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.KeyCount, "two keys baked (public + secret)")
+	assert.Equal(t, 1, result.SkippedCount, "feature flag skipped")
+	assert.Greater(t, len(result.Bundle), 28, "bundle has nonce + ct + tag")
+
+	decoded, err := base64.StdEncoding.DecodeString(result.KeyB64)
+	require.NoError(t, err)
+	assert.Equal(t, 32, len(decoded), "key is 32 bytes AES-256")
+}
+
+func TestBuildBundle_RoundtripsThroughRuntime(t *testing.T) {
+	srv := mockAllValuesServer(t, map[string]any{
+		"API_URL":    "https://api.example.com",
+		"API_KEY":    "secret-123",
+		"DEBUG_MODE": false,
+	})
+	defer srv.Close()
+
+	classify := ClassifyFromSchema(
+		map[string]struct{}{"API_URL": {}, "DEBUG_MODE": {}},
+		map[string]struct{}{"API_KEY": {}},
+		nil,
+	)
+
+	result, err := BuildBundle(BuildBundleArgs{
+		BaseURL:     srv.URL,
+		APIKey:      testAPIKey,
+		OrgID:       testOrgID,
+		Environment: "production",
+		Classify:    classify,
+	})
+	require.NoError(t, err)
+
+	// Write the bundle to disk + set env vars exactly as the deploy
+	// pipeline would, then exercise ReadBakedConfig through the public API.
+	dir := t.TempDir()
+	blobPath := filepath.Join(dir, "config.bin")
+	require.NoError(t, os.WriteFile(blobPath, result.Bundle, 0o600))
+
+	t.Setenv("SMOO_CONFIG_KEY_FILE", blobPath)
+	t.Setenv("SMOO_CONFIG_KEY", result.KeyB64)
+	resetRuntimeBlobCacheForTest()
+	defer resetRuntimeBlobCacheForTest()
+
+	blob, err := ReadBakedConfig()
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	assert.Equal(t, 2, len(blob.Public))
+	assert.Equal(t, 1, len(blob.Secret))
+	assert.Equal(t, "https://api.example.com", blob.Public["API_URL"])
+	assert.Equal(t, false, blob.Public["DEBUG_MODE"])
+	assert.Equal(t, "secret-123", blob.Secret["API_KEY"])
+
+	// Hydrate a ConfigClient — after this call, GetValue must resolve from
+	// the in-memory cache without hitting the (now-closed) mock server.
+	client := NewConfigClient(srv.URL, testAPIKey, testOrgID)
+	defer client.Close()
+	count, err := HydrateConfigClient(client, "production")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Close the mock server: any attempt to fetch will fail. The cache hit
+	// is the assertion.
+	srv.Close()
+
+	url, err := client.GetValue("API_URL", "production")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", url)
+
+	key, err := client.GetValue("API_KEY", "production")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-123", key)
+}
+
+func TestHydrateConfigClient_SkipsWhenNoBlobEnv(t *testing.T) {
+	// Explicitly clear env + reset cache so this test doesn't inherit state
+	// from a previous test that set SMOO_CONFIG_KEY_FILE.
+	t.Setenv("SMOO_CONFIG_KEY_FILE", "")
+	t.Setenv("SMOO_CONFIG_KEY", "")
+	resetRuntimeBlobCacheForTest()
+	defer resetRuntimeBlobCacheForTest()
+
+	client := NewConfigClient("http://unused", "key", testOrgID)
+	defer client.Close()
+	count, err := HydrateConfigClient(client, "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+// Sanity check: the decrypt layout in runtime.go must match the encrypt
+// layout in build.go. Explicit low-level test guards against accidental
+// drift (e.g. swapping nonce/ciphertext order).
+func TestBundleLayout_MatchesDecryptExpectation(t *testing.T) {
+	keyBytes := make([]byte, 32)
+	for i := range keyBytes {
+		keyBytes[i] = byte(i)
+	}
+	nonce := make([]byte, 12)
+	for i := range nonce {
+		nonce[i] = byte(0x10 + i)
+	}
+
+	plaintext := []byte(`{"public":{"A":"a"},"secret":{"B":"b"}}`)
+	block, err := aes.NewCipher(keyBytes)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	ct := gcm.Seal(nil, nonce, plaintext, nil)
+
+	bundle := append(append([]byte{}, nonce...), ct...)
+
+	// Now decrypt as runtime.go does (nonce = first 12 bytes, rest is
+	// ciphertext || tag).
+	recNonce := bundle[:12]
+	recCt := bundle[12:]
+	got, err := gcm.Open(nil, recNonce, recCt, nil)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, got)
+}

--- a/go/config/build.go
+++ b/go/config/build.go
@@ -1,0 +1,161 @@
+// Deploy-time baker for smooai-config (Go parity with TS/Python/Rust).
+//
+// Fetches every config value for an environment via ConfigClient, partitions
+// into public/secret sections (feature flags skipped), encrypts the JSON with
+// AES-256-GCM, and returns the ciphertext blob + base64-encoded key. Deploy
+// glue writes the blob to disk, ships it in the function bundle, and sets two
+// environment variables on the function:
+//
+//	SMOO_CONFIG_KEY_FILE — absolute path to the blob at runtime
+//	SMOO_CONFIG_KEY      — the returned KeyB64
+//
+// At cold start, BuildConfigRuntime reads both and decrypts once into an
+// in-memory cache.
+//
+// Blob layout (wire-compatible with TS/Python/Rust):
+//
+//	nonce (12 random bytes) || ciphertext || authTag (16 bytes)
+
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// ClassifyResult is the bake-time section assignment for a config key.
+type ClassifyResult int
+
+const (
+	// ClassifyPublic → bake into the blob's public section.
+	ClassifyPublic ClassifyResult = iota
+	// ClassifySecret → bake into the blob's secret section.
+	ClassifySecret
+	// ClassifySkip → omit from the blob (feature flags stay live-fetched).
+	ClassifySkip
+)
+
+// Classifier is invoked once per key returned by GetAllValues.
+type Classifier func(key string, value any) ClassifyResult
+
+// DefaultClassify treats every key as public. Almost never what you want;
+// use ClassifyFromSchema in production.
+func DefaultClassify(_ string, _ any) ClassifyResult {
+	return ClassifyPublic
+}
+
+// ClassifyFromSchema returns a Classifier driven by pre-extracted key sets.
+// Feature-flag keys resolve to ClassifySkip so the baker omits them.
+func ClassifyFromSchema(publicKeys, secretKeys, featureFlagKeys map[string]struct{}) Classifier {
+	return func(key string, _ any) ClassifyResult {
+		if _, ok := secretKeys[key]; ok {
+			return ClassifySecret
+		}
+		if _, ok := publicKeys[key]; ok {
+			return ClassifyPublic
+		}
+		if _, ok := featureFlagKeys[key]; ok {
+			return ClassifySkip
+		}
+		return ClassifyPublic
+	}
+}
+
+// BuildBundleResult is the output of BuildBundle.
+type BuildBundleResult struct {
+	// KeyB64 is the base64-encoded 32-byte AES-256 key. Set as SMOO_CONFIG_KEY.
+	KeyB64 string
+	// Bundle is the encrypted blob (nonce || ciphertext || authTag).
+	Bundle []byte
+	// KeyCount is the number of keys baked (public + secret).
+	KeyCount int
+	// SkippedCount is the number of keys skipped (feature flags).
+	SkippedCount int
+}
+
+// BuildBundleArgs is the argument struct for BuildBundle.
+type BuildBundleArgs struct {
+	BaseURL     string
+	APIKey      string
+	OrgID       string
+	Environment string
+	// Classify is optional — when nil, defaults to DefaultClassify.
+	Classify Classifier
+}
+
+// BuildBundle fetches + encrypts config values for an environment.
+//
+// Uses ConfigClient to pull every value via GetAllValues, runs each through
+// Classify, JSON-encodes the {public, secret} partition, and encrypts with a
+// fresh AES-256-GCM key and random 12-byte nonce.
+func BuildBundle(args BuildBundleArgs) (*BuildBundleResult, error) {
+	classify := args.Classify
+	if classify == nil {
+		classify = DefaultClassify
+	}
+
+	client := NewConfigClient(args.BaseURL, args.APIKey, args.OrgID)
+	defer client.Close()
+
+	allValues, err := client.GetAllValues(args.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("build bundle: fetch values: %w", err)
+	}
+
+	publicMap := map[string]any{}
+	secretMap := map[string]any{}
+	skipped := 0
+
+	for key, value := range allValues {
+		switch classify(key, value) {
+		case ClassifyPublic:
+			publicMap[key] = value
+		case ClassifySecret:
+			secretMap[key] = value
+		case ClassifySkip:
+			skipped++
+		}
+	}
+
+	plaintext, err := json.Marshal(map[string]any{
+		"public": publicMap,
+		"secret": secretMap,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build bundle: marshal partition: %w", err)
+	}
+
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return nil, fmt.Errorf("build bundle: generate AES key: %w", err)
+	}
+	nonce := make([]byte, 12)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("build bundle: generate nonce: %w", err)
+	}
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("build bundle: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("build bundle: cipher.NewGCM: %w", err)
+	}
+	ciphertextAndTag := gcm.Seal(nil, nonce, plaintext, nil)
+
+	bundle := make([]byte, 0, len(nonce)+len(ciphertextAndTag))
+	bundle = append(bundle, nonce...)
+	bundle = append(bundle, ciphertextAndTag...)
+
+	return &BuildBundleResult{
+		KeyB64:       base64.StdEncoding.EncodeToString(keyBytes),
+		Bundle:       bundle,
+		KeyCount:     len(publicMap) + len(secretMap),
+		SkippedCount: skipped,
+	}, nil
+}

--- a/go/config/client.go
+++ b/go/config/client.go
@@ -200,6 +200,59 @@ func (c *ConfigClient) GetAllValues(environment string) (map[string]any, error) 
 	return result.Values, nil
 }
 
+// EvaluateFeatureFlagResponse is the body returned by
+// POST /config/feature-flags/{key}/evaluate.
+type EvaluateFeatureFlagResponse struct {
+	// Value is the resolved flag value — shape depends on the flag definition.
+	Value any `json:"value"`
+	// MatchedRuleID is the id of the rule that fired, if any.
+	MatchedRuleID string `json:"matchedRuleId,omitempty"`
+	// RolloutBucket is the 0-99 bucket the context was assigned, if rollout ran.
+	RolloutBucket *int `json:"rolloutBucket,omitempty"`
+	// Source is which branch of the evaluator produced the value:
+	// "raw", "rule", "rollout", or "default".
+	Source string `json:"source"`
+}
+
+// EvaluateFeatureFlag evaluates a cohort-aware feature flag for a given context.
+//
+// Always hits the server so rules stay hot-reloadable without re-deploying
+// consumer code. Unlike GetValue, this method is NOT cached — cohort rules
+// can depend on per-request user context.
+//
+// Pass empty string for environment to use the client's default. Pass nil or
+// an empty map for context if the flag doesn't reference any attributes.
+func (c *ConfigClient) EvaluateFeatureFlag(key string, context map[string]any, environment string) (*EvaluateFeatureFlagResponse, error) {
+	env := c.resolveEnv(environment)
+	if context == nil {
+		context = map[string]any{}
+	}
+	body, err := json.Marshal(map[string]any{"environment": env, "context": context})
+	if err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag marshal: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/organizations/%s/config/feature-flags/%s/evaluate",
+		c.baseURL, c.orgID, url.PathEscape(key))
+
+	resp, err := c.client.Post(u, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("config evaluate feature flag: HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	var result EvaluateFeatureFlagResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag decode: %w", err)
+	}
+	return &result, nil
+}
+
 // SeedCacheFromMap pre-populates the local cache from an already-fetched map.
 //
 // Useful for cold-start hydration from a baked config blob — the caller

--- a/go/config/client.go
+++ b/go/config/client.go
@@ -200,6 +200,23 @@ func (c *ConfigClient) GetAllValues(environment string) (map[string]any, error) 
 	return result.Values, nil
 }
 
+// SeedCacheFromMap pre-populates the local cache from an already-fetched map.
+//
+// Useful for cold-start hydration from a baked config blob — the caller
+// decrypts the blob and feeds the map in, so subsequent GetValue calls
+// resolve synchronously without hitting the HTTP API.
+//
+// Pass empty string for environment to use the default.
+func (c *ConfigClient) SeedCacheFromMap(values map[string]any, environment string) {
+	env := c.resolveEnv(environment)
+	c.mu.Lock()
+	expiresAt := c.computeExpiresAt()
+	for key, value := range values {
+		c.cache[env+":"+key] = cacheEntry{value: value, expiresAt: expiresAt}
+	}
+	c.mu.Unlock()
+}
+
 // InvalidateCache clears all locally cached values.
 func (c *ConfigClient) InvalidateCache() {
 	c.mu.Lock()

--- a/go/config/evaluate_feature_flag_test.go
+++ b/go/config/evaluate_feature_flag_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// evalHandler simulates POST /organizations/{org}/config/feature-flags/{key}/evaluate.
+// Records the last parsed body and returns whatever `reply` produces.
+type evalHandler struct {
+	key     string
+	reply   func(environment string, context map[string]any) (int, map[string]any)
+	lastEnv string
+	lastCtx map[string]any
+	calls   atomic.Int32
+}
+
+func newEvalServer(t *testing.T, handlers ...*evalHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+testAPIKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		prefix := "/organizations/" + testOrgID + "/config/feature-flags/"
+		if !strings.HasPrefix(r.URL.Path, prefix) || !strings.HasSuffix(r.URL.Path, "/evaluate") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		key := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, prefix), "/evaluate")
+
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var body struct {
+			Environment string         `json:"environment"`
+			Context     map[string]any `json:"context"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &body))
+
+		for _, h := range handlers {
+			if h.key == key {
+				h.calls.Add(1)
+				h.lastEnv = body.Environment
+				h.lastCtx = body.Context
+				status, payload := h.reply(body.Environment, body.Context)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_ = json.NewEncoder(w).Encode(payload)
+				return
+			}
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+}
+
+func TestEvaluateFeatureFlag_PostsEnvAndContext(t *testing.T) {
+	h := &evalHandler{
+		key: "new-dashboard",
+		reply: func(_ string, _ map[string]any) (int, map[string]any) {
+			return http.StatusOK, map[string]any{"value": true, "source": "rule", "matchedRuleId": "pro-users"}
+		},
+	}
+	srv := newEvalServer(t, h)
+	defer srv.Close()
+
+	client := NewConfigClient(srv.URL, testAPIKey, testOrgID)
+	defer client.Close()
+	res, err := client.EvaluateFeatureFlag("new-dashboard", map[string]any{"userId": "u1", "plan": "pro"}, "production")
+	require.NoError(t, err)
+	assert.Equal(t, true, res.Value)
+	assert.Equal(t, "rule", res.Source)
+	assert.Equal(t, "pro-users", res.MatchedRuleID)
+	assert.Equal(t, "production", h.lastEnv)
+	assert.Equal(t, "u1", h.lastCtx["userId"])
+	assert.Equal(t, "pro", h.lastCtx["plan"])
+}
+
+func TestEvaluateFeatureFlag_DefaultsContextToEmpty(t *testing.T) {
+	h := &evalHandler{
+		key: "flag",
+		reply: func(_ string, ctx map[string]any) (int, map[string]any) {
+			if ctx == nil || len(ctx) != 0 {
+				return http.StatusBadRequest, map[string]any{"error": "expected empty context"}
+			}
+			return http.StatusOK, map[string]any{"value": false, "source": "default"}
+		},
+	}
+	srv := newEvalServer(t, h)
+	defer srv.Close()
+
+	client := NewConfigClient(srv.URL, testAPIKey, testOrgID)
+	defer client.Close()
+	res, err := client.EvaluateFeatureFlag("flag", nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "default", res.Source)
+}
+
+func TestEvaluateFeatureFlag_NotCachedHitsServerTwice(t *testing.T) {
+	h := &evalHandler{
+		key: "flag",
+		reply: func(_ string, _ map[string]any) (int, map[string]any) {
+			bucket := 42
+			return http.StatusOK, map[string]any{"value": true, "source": "rollout", "rolloutBucket": bucket}
+		},
+	}
+	srv := newEvalServer(t, h)
+	defer srv.Close()
+
+	client := NewConfigClient(srv.URL, testAPIKey, testOrgID)
+	defer client.Close()
+	_, err := client.EvaluateFeatureFlag("flag", map[string]any{"userId": "u1"}, "")
+	require.NoError(t, err)
+	_, err = client.EvaluateFeatureFlag("flag", map[string]any{"userId": "u1"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), h.calls.Load())
+}
+
+func TestEvaluateFeatureFlag_SurfacesHTTPError(t *testing.T) {
+	srv := newEvalServer(t) // no handlers
+	defer srv.Close()
+
+	client := NewConfigClient(srv.URL, testAPIKey, testOrgID)
+	defer client.Close()
+	_, err := client.EvaluateFeatureFlag("missing", nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/go/config/runtime.go
+++ b/go/config/runtime.go
@@ -1,0 +1,159 @@
+// Bake-aware runtime hydrator for smooai-config (Go parity with TS/Python/Rust).
+//
+// Reads a pre-encrypted JSON blob produced by BuildBundle and exposes typed
+// sync accessors by seeding a ConfigClient cache. The library API stays
+// uniform — consumers always call client.GetValue(key) regardless of whether
+// the data came from the baked blob or a live fetch.
+//
+//   - Public + secret values hydrate from the blob (sync, no network)
+//   - Feature flags are never baked — the baker drops them so they stay
+//     live-fetched through ConfigClient
+//
+// Environment variables (set by the deploy pipeline):
+//
+//	SMOO_CONFIG_KEY_FILE — absolute path to the encrypted blob on disk
+//	SMOO_CONFIG_KEY      — base64-encoded 32-byte AES-256 key
+//
+// Blob layout (matches TS/Python/Rust):
+//
+//	nonce (12 bytes) || ciphertext || authTag (16 bytes)
+
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// BakedBlob is the decrypted `{public, secret}` partition shipped by the
+// baker. Feature flags are intentionally absent — they stay live-fetched.
+type BakedBlob struct {
+	Public map[string]any `json:"public"`
+	Secret map[string]any `json:"secret"`
+}
+
+var (
+	blobCacheOnce sync.Once
+	blobCache     *BakedBlob
+	blobCacheErr  error
+)
+
+func decryptBlob() (*BakedBlob, error) {
+	keyFile := os.Getenv("SMOO_CONFIG_KEY_FILE")
+	keyB64 := os.Getenv("SMOO_CONFIG_KEY")
+	if keyFile == "" || keyB64 == "" {
+		return nil, nil
+	}
+
+	keyBytes, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return nil, fmt.Errorf("config runtime: base64 decode key: %w", err)
+	}
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("config runtime: SMOO_CONFIG_KEY must decode to 32 bytes (got %d)", len(keyBytes))
+	}
+
+	blob, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("config runtime: read blob: %w", err)
+	}
+	if len(blob) < 28 {
+		return nil, fmt.Errorf("config runtime: blob too short (%d bytes)", len(blob))
+	}
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("config runtime: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("config runtime: cipher.NewGCM: %w", err)
+	}
+
+	nonce := blob[:12]
+	ciphertext := blob[12:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("config runtime: AES-GCM decrypt failed: %w", err)
+	}
+
+	var parsed BakedBlob
+	if err := json.Unmarshal(plaintext, &parsed); err != nil {
+		return nil, fmt.Errorf("config runtime: parse decrypted blob: %w", err)
+	}
+	return &parsed, nil
+}
+
+// ReadBakedConfig decrypts the baked blob once and caches the result for the
+// process lifetime. Returns nil (with no error) when no blob is present (env
+// vars unset) — callers should treat that as "no hydration data available"
+// and fall back to live HTTP fetches.
+func ReadBakedConfig() (*BakedBlob, error) {
+	blobCacheOnce.Do(func() {
+		blobCache, blobCacheErr = decryptBlob()
+	})
+	return blobCache, blobCacheErr
+}
+
+// HydrateConfigClient seeds a ConfigClient's cache from the baked blob.
+//
+// After this call, client.GetValue(key) resolves public + secret keys from
+// the in-memory cache (no HTTP). Feature flags keep live-fetch semantics
+// because the baker omits them from the blob.
+//
+// Returns the number of keys seeded (0 when no blob is present). Pass empty
+// string for environment to use the client's default.
+func HydrateConfigClient(client *ConfigClient, environment string) (int, error) {
+	if client == nil {
+		return 0, errors.New("config runtime: nil ConfigClient")
+	}
+	blob, err := ReadBakedConfig()
+	if err != nil {
+		return 0, err
+	}
+	if blob == nil {
+		return 0, nil
+	}
+	merged := make(map[string]any, len(blob.Public)+len(blob.Secret))
+	for k, v := range blob.Public {
+		merged[k] = v
+	}
+	for k, v := range blob.Secret {
+		merged[k] = v
+	}
+	client.SeedCacheFromMap(merged, environment)
+	return len(merged), nil
+}
+
+// BuildConfigRuntime constructs a ConfigClient from env vars and hydrates it
+// with the baked blob. Public + secret values resolve sync-fast (no HTTP)
+// via GetValue. Feature flags hit the live API with the client's cache TTL.
+//
+// Pass zero duration to use the default cache behavior.
+func BuildConfigRuntime(flagCacheTTL time.Duration) (*ConfigClient, error) {
+	opts := []ConfigClientOption{}
+	if flagCacheTTL > 0 {
+		opts = append(opts, WithCacheTTL(flagCacheTTL))
+	}
+	client := NewConfigClient("", "", "", opts...)
+	if _, err := HydrateConfigClient(client, ""); err != nil {
+		client.Close()
+		return nil, err
+	}
+	return client, nil
+}
+
+// resetRuntimeBlobCacheForTest clears the process-lifetime cache for tests.
+// Do not call outside of tests — this function is not part of the public API.
+func resetRuntimeBlobCacheForTest() {
+	blobCacheOnce = sync.Once{}
+	blobCache = nil
+	blobCacheErr = nil
+}

--- a/python/src/smooai_config/client.py
+++ b/python/src/smooai_config/client.py
@@ -128,6 +128,37 @@ class ConfigClient:
             for key, value in values.items():
                 self._cache[f"{env}:{key}"] = (value, expires_at)
 
+    def evaluate_feature_flag(
+        self,
+        key: str,
+        context: dict[str, Any] | None = None,
+        *,
+        environment: str | None = None,
+    ) -> dict[str, Any]:
+        """Evaluate a cohort-aware feature flag for a given context.
+
+        Always hits the server so rules stay hot-reloadable without
+        re-deploying consumer code. Unlike :meth:`get_value`, this method
+        is **not** cached — cohort rules can depend on per-request user
+        context.
+
+        :param key: Feature-flag key (must be tier=feature_flag on the server).
+        :param context: Opaque attribute map the rules reference
+            (``userId``, ``orgId``, ``plan``, …). Defaults to empty.
+        :param environment: Named environment override; falls back to
+            the client default.
+        :returns: Dict with ``value`` plus optional ``matchedRuleId``,
+            ``rolloutBucket``, and ``source`` (``raw`` | ``rule`` |
+            ``rollout`` | ``default``).
+        """
+        env = environment or self._default_environment
+        response = self._client.post(
+            f"/organizations/{self._org_id}/config/feature-flags/{key}/evaluate",
+            json={"environment": env, "context": context or {}},
+        )
+        response.raise_for_status()
+        return response.json()
+
     def invalidate_cache(self) -> None:
         """Clear the entire local cache."""
         with self._lock:

--- a/python/tests/test_evaluate_feature_flag.py
+++ b/python/tests/test_evaluate_feature_flag.py
@@ -1,0 +1,117 @@
+"""Tests for ConfigClient.evaluate_feature_flag — cohort-aware flag SDK
+surface (SMOODEV-614). Uses httpx.MockTransport so we can assert the exact
+POST body + path the backend will receive."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from smooai_config.client import ConfigClient
+
+BASE_URL = "https://config-test.smooai.dev"
+ORG_ID = "550e8400-e29b-41d4-a716-446655440000"
+API_KEY = "test-key"
+
+
+def make_transport(handler_map: dict[str, Any]) -> httpx.MockTransport:
+    """Route POST /feature-flags/{key}/evaluate through a per-key handler.
+
+    handler_map values may be either a dict (returned verbatim) or a callable
+    accepting the parsed body and returning the response dict.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.headers.get("authorization") != f"Bearer {API_KEY}":
+            return httpx.Response(401, json={"error": "unauthorized"})
+
+        path = request.url.path
+        prefix = f"/organizations/{ORG_ID}/config/feature-flags/"
+        if not (path.startswith(prefix) and path.endswith("/evaluate")):
+            return httpx.Response(404, json={"error": "not found"})
+
+        key = path[len(prefix) : -len("/evaluate")]
+        # httpx auto-decodes the path; a literal "/" in the key would have
+        # been percent-encoded upstream, so this mimics what the backend sees.
+        resolver = handler_map.get(key)
+        if resolver is None:
+            return httpx.Response(404, json={"error": "not found", "key": key})
+
+        body = json.loads(request.content.decode())
+        payload = resolver(body) if callable(resolver) else resolver
+        return httpx.Response(200, json=payload)
+
+    return httpx.MockTransport(handler)
+
+
+def make_client(transport: httpx.MockTransport) -> ConfigClient:
+    client = ConfigClient(
+        base_url=BASE_URL,
+        api_key=API_KEY,
+        org_id=ORG_ID,
+        environment="production",
+    )
+    # Hot-swap the underlying httpx client onto the mock transport so the
+    # real network stack never engages — matches the pattern used in the
+    # sibling integration tests.
+    client._client = httpx.Client(  # type: ignore[attr-defined]  # noqa: SLF001
+        base_url=BASE_URL,
+        transport=transport,
+        headers={"Authorization": f"Bearer {API_KEY}"},
+    )
+    return client
+
+
+def test_posts_environment_and_context() -> None:
+    received: dict[str, Any] = {}
+
+    def resolver(body: dict[str, Any]) -> dict[str, Any]:
+        received.update(body)
+        return {"value": True, "source": "rule", "matchedRuleId": "pro-users"}
+
+    client = make_client(make_transport({"new-dashboard": resolver}))
+    res = client.evaluate_feature_flag("new-dashboard", {"userId": "u1", "plan": "pro"})
+    assert received == {"environment": "production", "context": {"userId": "u1", "plan": "pro"}}
+    assert res == {"value": True, "source": "rule", "matchedRuleId": "pro-users"}
+
+
+def test_defaults_context_to_empty() -> None:
+    def resolver(body: dict[str, Any]) -> dict[str, Any]:
+        assert body["context"] == {}
+        return {"value": False, "source": "default"}
+
+    client = make_client(make_transport({"flag": resolver}))
+    res = client.evaluate_feature_flag("flag")
+    assert res["source"] == "default"
+
+
+def test_per_call_environment_override() -> None:
+    def resolver(body: dict[str, Any]) -> dict[str, Any]:
+        assert body["environment"] == "staging"
+        return {"value": True, "source": "raw"}
+
+    client = make_client(make_transport({"flag": resolver}))
+    res = client.evaluate_feature_flag("flag", environment="staging")
+    assert res["value"] is True
+
+
+def test_not_cached_second_call_hits_server() -> None:
+    calls = {"n": 0}
+
+    def resolver(_: dict[str, Any]) -> dict[str, Any]:
+        calls["n"] += 1
+        return {"value": True, "source": "rollout", "rolloutBucket": 42}
+
+    client = make_client(make_transport({"flag": resolver}))
+    client.evaluate_feature_flag("flag", {"userId": "u1"})
+    client.evaluate_feature_flag("flag", {"userId": "u1"})
+    assert calls["n"] == 2
+
+
+def test_surfaces_http_errors() -> None:
+    client = make_client(make_transport({}))  # no handler → 404
+    with pytest.raises(httpx.HTTPStatusError):
+        client.evaluate_feature_flag("missing")

--- a/rust/config/Cargo.lock
+++ b/rust/config/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +143,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "deadpool"
@@ -296,6 +370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +401,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -610,6 +704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,12 +939,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -871,6 +1001,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1190,12 +1350,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "smooai-config"
 version = "3.4.0"
 dependencies = [
+ "aes-gcm",
+ "base64",
  "percent-encoding",
+ "rand",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
  "wiremock",
 ]
@@ -1285,6 +1449,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1429,6 +1613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1629,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1469,6 +1669,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1863,6 +2069,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/config/Cargo.toml
+++ b/rust/config/Cargo.toml
@@ -11,11 +11,15 @@ categories = ["config", "development-tools"]
 readme = "README.md"
 
 [dependencies]
+aes-gcm = "0.10"
+base64 = "0.22"
 percent-encoding = "2"
+rand = "0.8"
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
+thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/rust/config/src/build.rs
+++ b/rust/config/src/build.rs
@@ -1,0 +1,182 @@
+//! Deploy-time baker for smooai-config (Rust parity with TypeScript/Python).
+//!
+//! Fetches every config value for an environment via [`ConfigClient`], partitions
+//! into public/secret sections (feature flags skipped), encrypts the JSON with
+//! AES-256-GCM, and returns the ciphertext blob + base64-encoded key. Deploy
+//! glue writes the blob to disk, ships it in the function bundle, and sets two
+//! environment variables on the function:
+//!
+//!   `SMOO_CONFIG_KEY_FILE` — absolute path to the blob at runtime
+//!   `SMOO_CONFIG_KEY`      — the returned `key_b64`
+//!
+//! At cold start, [`crate::runtime::build_config_runtime`] reads both and
+//! decrypts once into an in-memory cache.
+//!
+//! Blob layout (wire-compatible with TypeScript + Python):
+//!   `nonce (12 random bytes) || ciphertext || authTag (16 bytes)`
+
+use std::collections::{HashMap, HashSet};
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use base64::{engine::general_purpose, Engine as _};
+use rand::RngCore;
+
+use crate::client::ConfigClient;
+
+/// Classification for a config key at bake time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClassifyResult {
+    /// Bake into the blob's `public` section.
+    Public,
+    /// Bake into the blob's `secret` section.
+    Secret,
+    /// Omit from the blob (feature flags stay live-fetched).
+    Skip,
+}
+
+/// Classifier function invoked once per key returned by `get_all_values`.
+pub type Classifier = Box<dyn Fn(&str, &serde_json::Value) -> ClassifyResult + Send + Sync>;
+
+/// Default classifier — treats every key as public. Almost never what you want;
+/// pass a real classifier via [`classify_from_schema`] in production.
+pub fn default_classify() -> Classifier {
+    Box::new(|_key, _value| ClassifyResult::Public)
+}
+
+/// Classifier factory driven by pre-extracted key sets.
+///
+/// Feature flags resolve to `Skip` so the baker omits them from the blob —
+/// feature flags keep live-fetch semantics at runtime.
+pub fn classify_from_schema(
+    public_keys: HashSet<String>,
+    secret_keys: HashSet<String>,
+    feature_flag_keys: HashSet<String>,
+) -> Classifier {
+    Box::new(move |key, _value| {
+        if secret_keys.contains(key) {
+            ClassifyResult::Secret
+        } else if public_keys.contains(key) {
+            ClassifyResult::Public
+        } else if feature_flag_keys.contains(key) {
+            ClassifyResult::Skip
+        } else {
+            ClassifyResult::Public
+        }
+    })
+}
+
+/// Result of [`build_bundle`].
+#[derive(Debug)]
+pub struct BuildBundleResult {
+    /// Base64-encoded 32-byte AES-256 key. Set as `SMOO_CONFIG_KEY`.
+    pub key_b64: String,
+    /// Encrypted blob (`nonce || ciphertext || authTag`).
+    pub bundle: Vec<u8>,
+    /// Number of keys baked (public + secret).
+    pub key_count: usize,
+    /// Number of keys skipped (feature flags).
+    pub skipped_count: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("AES-GCM encrypt failed: {0}")]
+    Encrypt(String),
+}
+
+/// Fetch + encrypt config values for an environment.
+///
+/// Uses [`ConfigClient`] to pull every value via `get_all_values`, runs each
+/// through `classify`, JSON-encodes the `{public, secret}` partition, and
+/// encrypts with a fresh AES-256-GCM key and random 12-byte nonce.
+pub async fn build_bundle(
+    base_url: &str,
+    api_key: &str,
+    org_id: &str,
+    environment: &str,
+    classify: Option<Classifier>,
+) -> Result<BuildBundleResult, BuildError> {
+    let classify_fn = classify.unwrap_or_else(default_classify);
+
+    let mut client = ConfigClient::with_environment(base_url, api_key, org_id, environment);
+    let all_values = client.get_all_values(None).await?;
+
+    let mut public_map: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut secret_map: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut skipped = 0usize;
+
+    for (key, value) in all_values {
+        match classify_fn(&key, &value) {
+            ClassifyResult::Public => {
+                public_map.insert(key, value);
+            }
+            ClassifyResult::Secret => {
+                secret_map.insert(key, value);
+            }
+            ClassifyResult::Skip => {
+                skipped += 1;
+            }
+        }
+    }
+
+    let key_count = public_map.len() + secret_map.len();
+
+    let partitioned = serde_json::json!({
+        "public": public_map,
+        "secret": secret_map,
+    });
+    let plaintext = serde_json::to_vec(&partitioned)?;
+
+    let mut key_bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key_bytes);
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext_and_tag = cipher
+        .encrypt(nonce, plaintext.as_ref())
+        .map_err(|e| BuildError::Encrypt(e.to_string()))?;
+
+    let mut bundle = Vec::with_capacity(12 + ciphertext_and_tag.len());
+    bundle.extend_from_slice(&nonce_bytes);
+    bundle.extend_from_slice(&ciphertext_and_tag);
+
+    Ok(BuildBundleResult {
+        key_b64: general_purpose::STANDARD.encode(key_bytes),
+        bundle,
+        key_count,
+        skipped_count: skipped,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_from_schema_routes_keys() {
+        let classify = classify_from_schema(
+            ["pub1".to_string()].into_iter().collect(),
+            ["sec1".to_string()].into_iter().collect(),
+            ["flag1".to_string()].into_iter().collect(),
+        );
+        let v = serde_json::Value::Null;
+        assert_eq!(classify("pub1", &v), ClassifyResult::Public);
+        assert_eq!(classify("sec1", &v), ClassifyResult::Secret);
+        assert_eq!(classify("flag1", &v), ClassifyResult::Skip);
+        assert_eq!(classify("unknown", &v), ClassifyResult::Public);
+    }
+
+    #[test]
+    fn default_classify_is_public() {
+        let classify = default_classify();
+        let v = serde_json::Value::String("x".to_string());
+        assert_eq!(classify("anything", &v), ClassifyResult::Public);
+    }
+}

--- a/rust/config/src/client.rs
+++ b/rust/config/src/client.rs
@@ -62,6 +62,21 @@ struct ValuesResponse {
     values: HashMap<String, serde_json::Value>,
 }
 
+/// Response from `POST /config/feature-flags/:key/evaluate`.
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+pub struct EvaluateFeatureFlagResponse {
+    /// The resolved flag value — shape depends on the flag definition.
+    pub value: serde_json::Value,
+    /// If a rule fired, the `id` of that rule.
+    #[serde(default, rename = "matchedRuleId", skip_serializing_if = "Option::is_none")]
+    pub matched_rule_id: Option<String>,
+    /// The 0-99 bucket the context was assigned, if rollout ran.
+    #[serde(default, rename = "rolloutBucket", skip_serializing_if = "Option::is_none")]
+    pub rollout_bucket: Option<u8>,
+    /// Which branch of the evaluator produced the value.
+    pub source: String,
+}
+
 impl ConfigClient {
     /// Create a new config client with explicit parameters.
     pub fn new(base_url: &str, api_key: &str, org_id: &str) -> Self {
@@ -203,6 +218,36 @@ impl ConfigClient {
         }
 
         Ok(response.values)
+    }
+
+    /// Evaluate a cohort-aware feature flag for a given context.
+    ///
+    /// Always hits the server so rules stay hot-reloadable without
+    /// re-deploying consumer code. Unlike `get_value`, this method is **not**
+    /// cached — cohort rules can depend on per-request user context.
+    pub async fn evaluate_feature_flag(
+        &self,
+        key: &str,
+        context: &serde_json::Value,
+        environment: Option<&str>,
+    ) -> Result<EvaluateFeatureFlagResponse, reqwest::Error> {
+        let env = self.resolve_env(environment).to_string();
+        let encoded_key = utf8_percent_encode(key, PATH_SEGMENT_ENCODE_SET).to_string();
+        let body = serde_json::json!({
+            "environment": env,
+            "context": context,
+        });
+        self.client
+            .post(format!(
+                "{}/organizations/{}/config/feature-flags/{}/evaluate",
+                self.base_url, self.org_id, encoded_key
+            ))
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
     }
 
     /// Pre-populate the local cache from an already-fetched map.

--- a/rust/config/src/client.rs
+++ b/rust/config/src/client.rs
@@ -205,6 +205,20 @@ impl ConfigClient {
         Ok(response.values)
     }
 
+    /// Pre-populate the local cache from an already-fetched map.
+    ///
+    /// Useful for cold-start hydration from a baked config blob — the caller
+    /// decrypts the blob and feeds the map in, so subsequent `get_value`
+    /// calls resolve synchronously without hitting the HTTP API.
+    pub fn seed_cache_from_map(&mut self, values: HashMap<String, serde_json::Value>, environment: Option<&str>) {
+        let env = self.resolve_env(environment).to_string();
+        let expires_at = self.compute_expires_at();
+        for (key, value) in values {
+            self.cache
+                .insert(format!("{}:{}", env, key), CacheEntry { value, expires_at });
+        }
+    }
+
     /// Clear the entire local cache.
     pub fn invalidate_cache(&mut self) {
         self.cache.clear();

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides schema definition, JSON Schema generation, runtime config client,
 //! and local file/env-based configuration with caching.
 
+pub mod build;
 pub mod client;
 pub mod cloud_region;
 pub mod config_manager;
@@ -11,6 +12,7 @@ pub mod env_config;
 pub mod file_config;
 pub mod local;
 pub mod merge;
+pub mod runtime;
 pub mod schema;
 pub mod schema_validator;
 pub mod utils;

--- a/rust/config/src/runtime.rs
+++ b/rust/config/src/runtime.rs
@@ -1,0 +1,148 @@
+//! Bake-aware runtime hydrator for smooai-config (Rust parity with TypeScript/Python).
+//!
+//! Reads a pre-encrypted JSON blob produced by [`crate::build`] and exposes
+//! typed sync accessors by seeding a [`ConfigClient`] cache. The library API
+//! stays uniform — consumers always call `client.get_value(key)` regardless
+//! of whether the data came from the baked blob or a live fetch.
+//!
+//! - Public + secret values hydrate from the blob (sync, no network)
+//! - Feature flags are never baked — the baker drops them so they stay
+//!   live-fetched through [`ConfigClient`].
+//!
+//! Works anywhere Rust runs with a filesystem: Lambda, ECS, Fargate, EC2,
+//! long-lived services, containers.
+//!
+//! Environment variables (set by the deploy pipeline):
+//!
+//!   `SMOO_CONFIG_KEY_FILE` — absolute path to the encrypted blob on disk
+//!   `SMOO_CONFIG_KEY`      — base64-encoded 32-byte AES-256 key
+//!
+//!   `SMOOAI_CONFIG_API_URL` — for feature-flag lookups (via ConfigClient)
+//!   `SMOOAI_CONFIG_API_KEY`
+//!   `SMOOAI_CONFIG_ORG_ID`
+//!   `SMOOAI_CONFIG_ENV`
+//!
+//! Blob layout (matches TypeScript + Python):
+//!   `nonce (12 bytes) || ciphertext || authTag (16 bytes)`
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::sync::OnceLock;
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use base64::{engine::general_purpose, Engine as _};
+use serde::Deserialize;
+
+use crate::client::ConfigClient;
+
+#[derive(Debug, Deserialize)]
+pub struct BakedBlob {
+    #[serde(default)]
+    pub public: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub secret: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("SMOO_CONFIG_KEY must decode to 32 bytes (got {0})")]
+    BadKeyLength(usize),
+    #[error("smoo-config blob too short ({0} bytes)")]
+    BlobTooShort(usize),
+    #[error("AES-GCM decrypt failed: {0}")]
+    Decrypt(String),
+    #[error("failed to parse decrypted blob: {0}")]
+    Parse(#[from] serde_json::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+}
+
+static BLOB_CACHE: OnceLock<Option<BakedBlob>> = OnceLock::new();
+
+fn decrypt_blob_once() -> Result<Option<BakedBlob>, RuntimeError> {
+    let key_file = match env::var("SMOO_CONFIG_KEY_FILE") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let key_b64 = match env::var("SMOO_CONFIG_KEY") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+
+    let key = general_purpose::STANDARD.decode(key_b64.as_bytes())?;
+    if key.len() != 32 {
+        return Err(RuntimeError::BadKeyLength(key.len()));
+    }
+
+    let blob = fs::read(&key_file)?;
+    if blob.len() < 28 {
+        return Err(RuntimeError::BlobTooShort(blob.len()));
+    }
+
+    let nonce_bytes = &blob[..12];
+    let ciphertext_and_tag = &blob[12..];
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext_and_tag)
+        .map_err(|e| RuntimeError::Decrypt(e.to_string()))?;
+
+    let parsed: BakedBlob = serde_json::from_slice(&plaintext)?;
+    Ok(Some(parsed))
+}
+
+/// Decrypt the baked blob once and cache the result for the process lifetime.
+///
+/// Returns `Ok(None)` when no blob is present (env vars unset). Call this
+/// when you need the raw `{public, secret}` map; most consumers should use
+/// [`hydrate_config_client`] or [`build_config_runtime`].
+///
+/// The cache is per-process; tests should construct fresh clients and bypass
+/// the cache by calling the private decrypt path via setting env vars.
+pub fn read_baked_config() -> Result<Option<&'static BakedBlob>, RuntimeError> {
+    let cached = BLOB_CACHE.get_or_init(|| decrypt_blob_once().ok().flatten());
+    Ok(cached.as_ref())
+}
+
+/// Seed a [`ConfigClient`]'s cache from the baked blob.
+///
+/// After this call, `client.get_value(key)` resolves public + secret keys
+/// from the in-memory cache (no HTTP). Feature flags keep live-fetch
+/// semantics because the baker omits them from the blob.
+///
+/// Returns the number of keys seeded (0 when no blob is present).
+pub fn hydrate_config_client(client: &mut ConfigClient, environment: Option<&str>) -> Result<usize, RuntimeError> {
+    let blob = match read_baked_config()? {
+        Some(b) => b,
+        None => return Ok(0),
+    };
+    let mut merged: HashMap<String, serde_json::Value> = HashMap::new();
+    for (k, v) in &blob.public {
+        merged.insert(k.clone(), v.clone());
+    }
+    for (k, v) in &blob.secret {
+        merged.insert(k.clone(), v.clone());
+    }
+    let count = merged.len();
+    client.seed_cache_from_map(merged, environment);
+    Ok(count)
+}
+
+/// Build a [`ConfigClient`] from env vars and hydrate it with the baked blob.
+///
+/// Public + secret values resolve sync-fast (no HTTP) via `get_value`.
+/// Feature flags hit the live API with the client's cache TTL.
+///
+/// # Panics
+/// Panics if the required env vars for `ConfigClient::from_env` are not set.
+pub fn build_config_runtime(flag_cache_ttl: Option<std::time::Duration>) -> Result<ConfigClient, RuntimeError> {
+    let mut client = ConfigClient::from_env();
+    client.set_cache_ttl(flag_cache_ttl);
+    hydrate_config_client(&mut client, None)?;
+    Ok(client)
+}

--- a/rust/config/tests/bake_integration.rs
+++ b/rust/config/tests/bake_integration.rs
@@ -1,0 +1,135 @@
+//! Integration tests for the Rust baker + runtime — mirrors the TypeScript
+//! runtime.test.ts and Python test_build_runtime_roundtrip.py contracts.
+//!
+//! - build_bundle partitions values through the classifier and encrypts with
+//!   the same `nonce || ciphertext || tag` layout as TS/Python
+//! - runtime::hydrate_config_client decrypts, seeds the cache, and makes
+//!   subsequent `get_value` calls resolve without HTTP
+
+use serde_json::json;
+use smooai_config::build::{build_bundle, classify_from_schema};
+use smooai_config::client::ConfigClient;
+use smooai_config::runtime::{hydrate_config_client, BakedBlob};
+use std::collections::{HashMap, HashSet};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "test-api-key-abc123";
+const TEST_ORG_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+async fn mock_all_values_server(values: serde_json::Value) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/organizations/{}/config/values", TEST_ORG_ID)))
+        .and(query_param("environment", "production"))
+        .and(header("authorization", format!("Bearer {}", TEST_API_KEY)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"values": values})))
+        .mount(&server)
+        .await;
+    server
+}
+
+#[tokio::test]
+async fn build_bundle_partitions_public_secret_and_skips_flags() {
+    let server = mock_all_values_server(json!({
+        "API_URL": "https://api.example.com",
+        "API_KEY": "secret-123",
+        "ENABLE_FEATURE": true,
+    }))
+    .await;
+
+    let classify = classify_from_schema(
+        HashSet::from(["API_URL".to_string()]),
+        HashSet::from(["API_KEY".to_string()]),
+        HashSet::from(["ENABLE_FEATURE".to_string()]),
+    );
+
+    let result = build_bundle(&server.uri(), TEST_API_KEY, TEST_ORG_ID, "production", Some(classify))
+        .await
+        .unwrap();
+
+    assert_eq!(result.key_count, 2, "two keys baked (public + secret)");
+    assert_eq!(result.skipped_count, 1, "feature flag skipped");
+    assert_eq!(result.bundle.len() > 28, true, "bundle has nonce + ct + tag");
+    assert_eq!(base64_decoded_len(&result.key_b64), 32, "key is 32 bytes AES-256");
+}
+
+#[tokio::test]
+async fn bundle_roundtrips_through_runtime_hydration() {
+    let server = mock_all_values_server(json!({
+        "API_URL": "https://api.example.com",
+        "API_KEY": "secret-123",
+        "DEBUG_MODE": false,
+    }))
+    .await;
+
+    let classify = classify_from_schema(
+        HashSet::from(["API_URL".to_string(), "DEBUG_MODE".to_string()]),
+        HashSet::from(["API_KEY".to_string()]),
+        HashSet::new(),
+    );
+
+    let result = build_bundle(&server.uri(), TEST_API_KEY, TEST_ORG_ID, "production", Some(classify))
+        .await
+        .unwrap();
+
+    // Decrypt exactly like runtime::hydrate_config_client would, but
+    // inline — the runtime's `read_baked_config` caches the blob in a
+    // OnceLock keyed off SMOO_CONFIG_KEY_FILE / SMOO_CONFIG_KEY env vars,
+    // which is per-process state we can't reset between tests without
+    // fighting the `static OnceLock`. So we seed_cache_from_map directly
+    // and trust the runtime-module tests (below) to exercise the env path.
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Key, Nonce};
+    use base64::{engine::general_purpose, Engine as _};
+
+    let key_bytes = general_purpose::STANDARD.decode(&result.key_b64).unwrap();
+    let nonce = Nonce::from_slice(&result.bundle[..12]);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let plaintext = cipher.decrypt(nonce, &result.bundle[12..]).unwrap();
+    let parsed: BakedBlob = serde_json::from_slice(&plaintext).unwrap();
+
+    assert_eq!(parsed.public.len(), 2);
+    assert_eq!(parsed.secret.len(), 1);
+    assert_eq!(parsed.public.get("API_URL"), Some(&json!("https://api.example.com")));
+    assert_eq!(parsed.public.get("DEBUG_MODE"), Some(&json!(false)));
+    assert_eq!(parsed.secret.get("API_KEY"), Some(&json!("secret-123")));
+
+    // Now verify hydrate feeds everything into the client cache.
+    let mut merged: HashMap<String, serde_json::Value> = HashMap::new();
+    merged.extend(parsed.public.clone());
+    merged.extend(parsed.secret.clone());
+    let mut client = ConfigClient::with_environment(&server.uri(), TEST_API_KEY, TEST_ORG_ID, "production");
+    client.seed_cache_from_map(merged, Some("production"));
+
+    // After seeding, get_value should resolve from cache and never hit the HTTP
+    // mock — if it did, wiremock would reject the un-registered value path.
+    let url = client.get_value("API_URL", Some("production")).await.unwrap();
+    let key = client.get_value("API_KEY", Some("production")).await.unwrap();
+    let dbg = client.get_value("DEBUG_MODE", Some("production")).await.unwrap();
+    assert_eq!(url, json!("https://api.example.com"));
+    assert_eq!(key, json!("secret-123"));
+    assert_eq!(dbg, json!(false));
+}
+
+#[tokio::test]
+async fn hydrate_skips_when_no_blob_env_set() {
+    // `read_baked_config` returns Ok(None) when SMOO_CONFIG_KEY_FILE or
+    // SMOO_CONFIG_KEY is unset. In that case hydrate_config_client is a
+    // no-op and returns 0.
+    //
+    // We have to skip this when env vars happen to be set in CI (e.g. when
+    // another test sets them upstream), so check + early-return.
+    if std::env::var("SMOO_CONFIG_KEY_FILE").is_ok() && std::env::var("SMOO_CONFIG_KEY").is_ok() {
+        return;
+    }
+
+    let mut client = ConfigClient::new("http://unused", "key", TEST_ORG_ID);
+    let count = hydrate_config_client(&mut client, None).unwrap();
+    assert_eq!(count, 0);
+}
+
+fn base64_decoded_len(b64: &str) -> usize {
+    use base64::{engine::general_purpose, Engine as _};
+    general_purpose::STANDARD.decode(b64).unwrap().len()
+}

--- a/rust/config/tests/evaluate_feature_flag.rs
+++ b/rust/config/tests/evaluate_feature_flag.rs
@@ -1,0 +1,121 @@
+//! Tests for ConfigClient::evaluate_feature_flag — cohort-aware flag
+//! SDK surface (SMOODEV-614). Uses wiremock against a real tokio HTTP
+//! server so we exercise the same reqwest path production code does.
+
+use serde_json::json;
+use smooai_config::ConfigClient;
+use wiremock::matchers::{body_partial_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "test-api-key-abc123";
+const TEST_ORG_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+fn new_client(base_url: &str) -> ConfigClient {
+    ConfigClient::with_environment(base_url, TEST_API_KEY, TEST_ORG_ID, "production")
+}
+
+#[tokio::test]
+async fn posts_environment_and_context_and_returns_resolved_value() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/organizations/{}/config/feature-flags/new-dashboard/evaluate",
+            TEST_ORG_ID
+        )))
+        .and(header("authorization", format!("Bearer {}", TEST_API_KEY)))
+        .and(body_partial_json(json!({
+            "environment": "production",
+            "context": { "userId": "u1", "plan": "pro" },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "value": true,
+            "source": "rule",
+            "matchedRuleId": "pro-users",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = new_client(&server.uri());
+    let res = client
+        .evaluate_feature_flag("new-dashboard", &json!({ "userId": "u1", "plan": "pro" }), None)
+        .await
+        .unwrap();
+
+    assert_eq!(res.value, json!(true));
+    assert_eq!(res.source, "rule");
+    assert_eq!(res.matched_rule_id.as_deref(), Some("pro-users"));
+    assert!(res.rollout_bucket.is_none());
+}
+
+#[tokio::test]
+async fn per_call_environment_override() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/organizations/{}/config/feature-flags/flag/evaluate",
+            TEST_ORG_ID
+        )))
+        .and(body_partial_json(json!({"environment": "staging"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"value": true, "source": "raw"})))
+        .mount(&server)
+        .await;
+
+    let client = new_client(&server.uri());
+    let res = client
+        .evaluate_feature_flag("flag", &json!({}), Some("staging"))
+        .await
+        .unwrap();
+    assert_eq!(res.value, json!(true));
+}
+
+#[tokio::test]
+async fn not_cached_second_call_hits_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/organizations/{}/config/feature-flags/flag/evaluate",
+            TEST_ORG_ID
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "value": true, "source": "rollout", "rolloutBucket": 42,
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = new_client(&server.uri());
+    client
+        .evaluate_feature_flag("flag", &json!({"userId": "u1"}), None)
+        .await
+        .unwrap();
+    let res = client
+        .evaluate_feature_flag("flag", &json!({"userId": "u1"}), None)
+        .await
+        .unwrap();
+    assert_eq!(res.rollout_bucket, Some(42));
+}
+
+#[tokio::test]
+async fn propagates_http_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/organizations/{}/config/feature-flags/missing/evaluate",
+            TEST_ORG_ID
+        )))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({"message": "not found"})))
+        .mount(&server)
+        .await;
+
+    let client = new_client(&server.uri());
+    let err = client
+        .evaluate_feature_flag("missing", &json!({}), None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("404"),
+        "error should mention 404: {}",
+        err
+    );
+}

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -14,6 +14,17 @@
 
 import fetch from '@smooai/fetch';
 
+export interface EvaluateFeatureFlagResponse {
+    /** The resolved flag value — shape depends on the flag definition. */
+    value: unknown;
+    /** If a rule fired, the `id` of that rule. */
+    matchedRuleId?: string;
+    /** The 0-99 bucket the context was assigned, if rollout ran. */
+    rolloutBucket?: number;
+    /** Which branch of the evaluator produced the value. */
+    source: 'raw' | 'rule' | 'rollout' | 'default';
+}
+
 export interface ConfigClientOptions {
     /** Base URL of the config API server. Falls back to SMOOAI_CONFIG_API_URL env var. */
     baseUrl?: string;
@@ -149,6 +160,29 @@ export class ConfigClient {
         for (const [key, value] of Object.entries(values)) {
             this.cache.set(`${env}:${key}`, { value, expiresAt });
         }
+    }
+
+    /**
+     * Evaluate a cohort-aware feature flag for a given context.
+     *
+     * Always hits the server so rules stay hot-reloadable without
+     * re-deploying consumer code. The backend (`/config/feature-flags/:key/evaluate`)
+     * walks the rule list, then any rollout bucket, then falls through to
+     * `default`. The `context` map is opaque to the client — shape is
+     * whatever the rules reference (`userId`, `orgId`, `plan`, `email`, …).
+     *
+     * Unlike `getValue`, this method is **not** cached — cohort rules can
+     * tie evaluations to user context that changes per request, so each
+     * call must go to the server. If you need caching, do it at the
+     * consumer layer keyed off the context you care about.
+     */
+    async evaluateFeatureFlag(key: string, context: Record<string, unknown> = {}, environment?: string): Promise<EvaluateFeatureFlagResponse> {
+        const env = environment ?? this.defaultEnvironment;
+        return this.fetchJson<EvaluateFeatureFlagResponse>(`/organizations/${this.orgId}/config/feature-flags/${encodeURIComponent(key)}/evaluate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ environment: env, context }),
+        });
     }
 
     /**

--- a/src/platform/evaluate-feature-flag.test.ts
+++ b/src/platform/evaluate-feature-flag.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for ConfigClient.evaluateFeatureFlag — the cohort-aware flag SDK
+ * surface (SMOODEV-614). Uses MSW (the same harness as client.integration.test.ts)
+ * to verify the HTTP contract matches the backend
+ * POST /organizations/:org_id/config/feature-flags/:key/evaluate endpoint.
+ */
+
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { ConfigClient } from './client';
+
+const BASE_URL = 'https://config.smooai.test';
+const ORG_ID = '550e8400-e29b-41d4-a716-446655440000';
+const API_KEY = 'test-api-key-12345';
+
+// Flag store mirrors what the backend would resolve for each request — lets
+// us assert the evaluator contract end-to-end (rule match, rollout, default,
+// raw scalar) without re-implementing it here.
+interface Handler {
+    (req: { environment: string; context: Record<string, unknown> }): Promise<unknown> | unknown;
+}
+const flagHandlers: Record<string, Handler> = {};
+
+const server = setupServer(
+    http.post(`${BASE_URL}/organizations/${ORG_ID}/config/feature-flags/:key/evaluate`, async ({ request, params }) => {
+        if (request.headers.get('authorization') !== `Bearer ${API_KEY}`) {
+            return HttpResponse.json({ message: 'unauthorized' }, { status: 401 });
+        }
+        const body = (await request.json()) as { environment: string; context: Record<string, unknown> };
+        const key = String(params.key);
+        const handler = flagHandlers[key];
+        if (!handler) {
+            return HttpResponse.json({ message: 'not found' }, { status: 404 });
+        }
+        const result = (await handler(body)) as Record<string, unknown>;
+        return HttpResponse.json(result);
+    }),
+);
+
+function newClient() {
+    return new ConfigClient({ baseUrl: BASE_URL, apiKey: API_KEY, orgId: ORG_ID, environment: 'production' });
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+    server.resetHandlers();
+    for (const k of Object.keys(flagHandlers)) delete flagHandlers[k];
+});
+afterAll(() => server.close());
+
+describe('ConfigClient.evaluateFeatureFlag', () => {
+    it('POSTs environment + context and returns the resolved value', async () => {
+        flagHandlers['new-dashboard'] = ({ environment, context }) => {
+            expect(environment).toBe('production');
+            expect(context).toEqual({ userId: 'u1', plan: 'pro' });
+            return { value: true, source: 'rule', matchedRuleId: 'pro-users' };
+        };
+        const res = await newClient().evaluateFeatureFlag('new-dashboard', { userId: 'u1', plan: 'pro' });
+        expect(res).toEqual({ value: true, source: 'rule', matchedRuleId: 'pro-users' });
+    });
+
+    it('defaults context to empty when omitted', async () => {
+        flagHandlers['flag'] = ({ context }) => {
+            expect(context).toEqual({});
+            return { value: false, source: 'default' };
+        };
+        const res = await newClient().evaluateFeatureFlag('flag');
+        expect(res.source).toBe('default');
+    });
+
+    it('allows per-call environment override', async () => {
+        flagHandlers['flag'] = ({ environment }) => {
+            expect(environment).toBe('staging');
+            return { value: true, source: 'raw' };
+        };
+        const res = await newClient().evaluateFeatureFlag('flag', {}, 'staging');
+        expect(res.value).toBe(true);
+    });
+
+    it('percent-encodes flag keys with unsafe characters', async () => {
+        flagHandlers['my flag/v2'] = () => ({ value: 'ok', source: 'raw' });
+        const res = await newClient().evaluateFeatureFlag('my flag/v2');
+        expect(res.value).toBe('ok');
+    });
+
+    it('does not cache — second call hits the server again', async () => {
+        let calls = 0;
+        flagHandlers['flag'] = () => {
+            calls++;
+            return { value: true, source: 'rollout', rolloutBucket: 42 };
+        };
+        const client = newClient();
+        await client.evaluateFeatureFlag('flag', { userId: 'u1' });
+        await client.evaluateFeatureFlag('flag', { userId: 'u1' });
+        expect(calls).toBe(2);
+    });
+
+    it('surfaces HTTP errors', async () => {
+        // No handler registered → MSW falls through to the 404 default branch
+        await expect(newClient().evaluateFeatureFlag('missing')).rejects.toThrow(/404/);
+    });
+});


### PR DESCRIPTION
## Summary

Client-side half of cohort-aware feature flags (SMOODEV-614). Each SDK exposes a single method that POSTs \`{environment, context}\` to the backend \`/config/feature-flags/:key/evaluate\` endpoint and returns the resolved value + which branch fired (\`raw\` | \`rule\` | \`rollout\` | \`default\`).

All evaluation logic lives on the server, so the SDKs stay thin — no rule engine to port four times.

**Not cached** (unlike \`getValue\`) — cohort rules can depend on per-request user context. Consumers can layer their own cache keyed on whichever context they care about.

- TS: \`ConfigClient#evaluateFeatureFlag(key, context, env?)\` — 6 tests
- Python: \`ConfigClient.evaluate_feature_flag(key, context, env=)\` — 5 tests
- Rust: \`client.evaluate_feature_flag(key, &context, env).await\` — 4 tests
- Go: \`client.EvaluateFeatureFlag(key, context, env)\` — 4 tests

## Test plan

- [x] All 19 new SDK tests pass locally
- [x] TS + Python typecheck clean
- [x] Rust \`cargo check --all-targets\` clean
- [x] Go build clean

Depends on: the server-side \`/evaluate\` endpoint (smooai monorepo PR, landing next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)