### PR TITLE
SMOODEV-617 hotfix: add .d.ts stub for generated worker source

### DIFF
--- a/src/server/sync-worker-source.generated.d.ts
+++ b/src/server/sync-worker-source.generated.d.ts
@@ -1,0 +1,8 @@
+// Ambient declaration for the build-time-generated worker source.
+//
+// The actual `sync-worker-source.generated.ts` is emitted by
+// `scripts/build-sync-worker.mjs` before `tsup` runs, and gitignored
+// because it carries the full bundled worker source (~1.5 MiB). This
+// tiny `.d.ts` stub lets `pnpm typecheck` find the module before the
+// generator has run.
+export const WORKER_SOURCE: string;


### PR DESCRIPTION
Release.yml failed on main because `pnpm typecheck` runs before `pnpm build` (and before `scripts/build-sync-worker.mjs` generates `sync-worker-source.generated.ts`). Adding a tiny checked-in `.d.ts` stub declaring `WORKER_SOURCE: string` so TypeScript resolves the import ahead of the generator running.

CI passes locally now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)