### PR TITLE
SMOODEV-642: getSource() now reflects sync reads

### DIFF
--- a/.changeset/smoodev-642-getsync-source-tracking.md
+++ b/.changeset/smoodev-642-getsync-source-tracking.md
@@ -1,0 +1,9 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-642: `getSource()` now reflects sync reads**
+
+`cfg.getSource(key)` used to return `undefined` for any key that had only been read via `.getSync()`. Each synckit worker has its own module scope, so the worker's `lastSource` map never propagated back to the parent thread.
+
+Fix: the synckit worker now returns a `{ value, source }` envelope. The parent-thread wrapper in `/server/index.ts` calls a new internal `recordSource(key, source)` helper to copy the source into its own `lastSource` map. `getSource` works identically for sync + async reads now.

--- a/scripts/smoke-inline-worker.mjs
+++ b/scripts/smoke-inline-worker.mjs
@@ -57,7 +57,16 @@ try {
     if (apiUrlAsync !== 'https://api.smoke.example') throw new Error(`async apiUrl mismatch: ${apiUrlAsync}`);
     if (tavilySync !== 'tvly-smoke') throw new Error(`sync tavily mismatch: ${tavilySync}`);
 
-    console.log('\n✅ SMOOTH: inline worker + priority chain work end-to-end');
+    // SMOODEV-642 — after a sync read, getSource must return the tier the
+    // worker actually used. Before the fix this was always undefined for
+    // keys that were only ever read via .getSync().
+    const tavilySrc = cfg.getSource('tavilyApiKey');
+    const apiUrlSrc = cfg.getSource('apiUrl');
+    console.log('getSource sync :', `tavilyApiKey=${tavilySrc} apiUrl=${apiUrlSrc}`);
+    if (tavilySrc !== 'blob') throw new Error(`getSource(tavilyApiKey) expected 'blob' after sync read, got: ${tavilySrc}`);
+    if (apiUrlSrc !== 'blob') throw new Error(`getSource(apiUrl) expected 'blob', got: ${apiUrlSrc}`);
+
+    console.log('\n✅ SMOOTH: inline worker + priority chain + getSource(sync) work end-to-end');
     process.exit(0);
 } catch (err) {
     console.error('\n❌ FAILED:', err);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -105,18 +105,31 @@ export function buildConfig<Schema extends ReturnType<typeof defineConfig>>(sche
     const secretSync = createSyncFn(workerUrl);
     const flagSync = createSyncFn(workerUrl);
 
+    // The synckit worker returns `{ value, source }`. Unpack it, record the
+    // source on the parent-thread's `lastSource` map (each worker has its
+    // own module scope, so without this `getSource` never sees sync reads),
+    // and hand the value back to the caller.
+    type WorkerEnvelope = { value: unknown; source: 'blob' | 'env' | 'http' | 'file' | undefined };
+    const unpack = <T>(envelope: WorkerEnvelope, key: string): T | undefined => {
+        asyncCore.recordSource(key, envelope.source);
+        return envelope.value as T | undefined;
+    };
+
     return {
         publicConfig: {
             get: asyncCore.publicConfig.get,
-            getSync: <K extends PublicKey>(key: K): ConfigType[K] | undefined => publicSync(schema, 'public', key) as ConfigType[K] | undefined,
+            getSync: <K extends PublicKey>(key: K): ConfigType[K] | undefined =>
+                unpack<ConfigType[K]>(publicSync(schema, 'public', key) as WorkerEnvelope, key as string),
         },
         secretConfig: {
             get: asyncCore.secretConfig.get,
-            getSync: <K extends SecretKey>(key: K): ConfigType[K] | undefined => secretSync(schema, 'secret', key) as ConfigType[K] | undefined,
+            getSync: <K extends SecretKey>(key: K): ConfigType[K] | undefined =>
+                unpack<ConfigType[K]>(secretSync(schema, 'secret', key) as WorkerEnvelope, key as string),
         },
         featureFlag: {
             get: asyncCore.featureFlag.get,
-            getSync: <K extends FlagKey>(key: K): ConfigType[K] | undefined => flagSync(schema, 'flag', key) as ConfigType[K] | undefined,
+            getSync: <K extends FlagKey>(key: K): ConfigType[K] | undefined =>
+                unpack<ConfigType[K]>(flagSync(schema, 'flag', key) as WorkerEnvelope, key as string),
         },
         invalidateCaches: asyncCore.invalidateCaches,
         getSource: asyncCore.getSource,

--- a/src/server/internal.ts
+++ b/src/server/internal.ts
@@ -141,6 +141,14 @@ export interface ConfigAsyncAccessor<ConfigType, PublicKey extends keyof ConfigT
     invalidateCaches: () => void;
     /** Diagnostic — which tier served this key in the last successful read. */
     getSource: (key: string) => 'blob' | 'env' | 'http' | 'file' | undefined;
+    /**
+     * Record a source for a key without performing a read. The sync wrapper
+     * in `/server/index.ts` uses this to copy sources reported by the
+     * synckit worker back into the parent thread's diagnostic map — each
+     * worker has its own module scope, so without this the parent's
+     * `getSource` never sees sync reads.
+     */
+    recordSource: (key: string, source: 'blob' | 'env' | 'http' | 'file' | undefined) => void;
 }
 
 const lastSource = new Map<string, 'blob' | 'env' | 'http' | 'file'>();
@@ -292,6 +300,9 @@ export function buildConfigAsync<Schema extends ReturnType<typeof defineConfig>>
         featureFlag: { get: getFlag },
         invalidateCaches,
         getSource: (key: string) => lastSource.get(key),
+        recordSource: (key: string, source) => {
+            if (source) lastSource.set(key, source);
+        },
     } satisfies ConfigAsyncAccessor<ConfigType, PublicKey, SecretKey, FlagKey>;
 }
 

--- a/src/server/sync-worker.ts
+++ b/src/server/sync-worker.ts
@@ -6,20 +6,31 @@
  *
  * Do NOT import `./index` here — that file creates synckit workers itself,
  * which would recurse. Use the async-only core directly.
+ *
+ * Protocol: returns `{ value, source }`. The source is the tier that
+ * actually produced the value (`'blob' | 'env' | 'http' | 'file' | undefined`).
+ * The parent thread copies `source` into its own `lastSource` map so
+ * `cfg.getSource(key)` works after a `.getSync()` call too — each worker
+ * has its own module scope, so without explicit propagation the parent's
+ * diagnostic map never sees sync reads.
  */
 import { runAsWorker } from 'synckit';
 import { buildConfigAsync } from './internal';
 
 type Tier = 'public' | 'secret' | 'flag';
+type Source = 'blob' | 'env' | 'http' | 'file' | undefined;
 
-runAsWorker(async function serverSyncWorker(...args: any[]) {
+runAsWorker(async function serverSyncWorker(...args: any[]): Promise<{ value: unknown; source: Source }> {
     const schema = args[0];
     const tier = args[1] as Tier;
     const key = args[2] as string;
 
     const cfg = buildConfigAsync(schema);
-    if (tier === 'public') return cfg.publicConfig.get(key as never);
-    if (tier === 'secret') return cfg.secretConfig.get(key as never);
-    if (tier === 'flag') return cfg.featureFlag.get(key as never);
-    throw new Error(`[server sync-worker] unknown tier: ${tier}`);
+    let value: unknown;
+    if (tier === 'public') value = await cfg.publicConfig.get(key as never);
+    else if (tier === 'secret') value = await cfg.secretConfig.get(key as never);
+    else if (tier === 'flag') value = await cfg.featureFlag.get(key as never);
+    else throw new Error(`[server sync-worker] unknown tier: ${tier}`);
+
+    return { value, source: cfg.getSource(key) };
 });


### PR DESCRIPTION
## Summary

`cfg.getSource(key)` returned `undefined` for keys that were only read via `.getSync()` — each synckit worker has its own module scope so the worker's `lastSource` map never reached the parent thread's diagnostic.

## Fix

Worker returns a `{ value, source }` envelope. Parent-thread wrapper in `/server/index.ts` calls a new internal `recordSource(key, source)` helper to copy the source into its own map. `getSource` now works identically for sync + async reads.

## Verified

`scripts/smoke-inline-worker.mjs` now asserts `getSource` after a sync-only read:

```
SYNC read  : https://api.smoke.example (~3s incl. worker spawn)
ASYNC read : https://api.smoke.example
SECRET sync: tvly-smoke
getSource  : tavilyApiKey=blob apiUrl=blob   ← was `undefined` before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)