### PR TITLE
SMOODEV-645: fix browser bundle pulling Node-only deps via @smooai/fetch

### DIFF
--- a/.changeset/smoodev-645-browser-fetch-alias.md
+++ b/.changeset/smoodev-645-browser-fetch-alias.md
@@ -1,0 +1,21 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-645: fix browser bundle pulling Node-only deps via `@smooai/fetch`**
+
+`@smooai/config/client` (and `/react`) broke Vite / Next.js consumer builds with `Module 'node:v8' has been externalized`. Root cause: `platform/client.ts` does `import fetch from '@smooai/fetch'`, but `@smooai/fetch`'s package.json exposes its browser entry only as the `./browser/*` subpath — it has no top-level `browser` condition. In the tsup browser build, the bare specifier resolved to the Node entry, dragging in `@smooai/logger` + `rotating-file-stream` + `import-meta-resolve`.
+
+Fix: in the browser tsup build, add `@smooai/fetch` to `noExternal` and alias the bare specifier to `@smooai/fetch/browser/index` via esbuild's native `alias`. Browser chunks now inline the browser-safe fetch implementation.
+
+Verified:
+
+```
+grep -l "rotating-file-stream\|@smooai/logger" dist/browser/chunk-*.mjs
+# (no matches)
+
+grep "@smooai/fetch/dist/browser" dist/browser/chunk-*.mjs
+# chunk-...: // node_modules/.../@smooai/fetch/dist/browser/index.mjs
+```
+
+Frontend consumers no longer need to manually alias `@smooai/fetch`.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -123,8 +123,28 @@ export default defineConfig((options: Options) => [
         sourcemap: true,
         target: 'es2022',
         treeShaking: true,
-        // Mark Node.js-only deps as non-external so esbuild resolves them through our alias plugin
-        noExternal: aliasedModules,
+        // Mark Node.js-only deps as non-external so esbuild resolves them through our alias plugin.
+        // `@smooai/fetch` is listed so the alias (→ `@smooai/fetch/browser`)
+        // is applied by esbuild — external imports bypass aliasing.
+        noExternal: [...aliasedModules, '@smooai/fetch'],
         esbuildPlugins: [alias(aliasMap)],
+        // SMOODEV-645: `@smooai/fetch`'s package.json exposes a browser
+        // subpath (`./browser/*`) but has no top-level `browser`
+        // condition on `.`. In platform/client.ts we do
+        //   import fetch from '@smooai/fetch';
+        // which in the browser build otherwise resolves to the Node entry
+        // — pulling in `@smooai/logger` + `rotating-file-stream` and
+        // breaking Vite / Next.js consumer bundles with
+        //   "Module 'node:v8' has been externalized".
+        // esbuild's native `alias` (which does module-level resolution,
+        // not just path replacement like `esbuild-plugin-alias`) rewrites
+        // the bare specifier to the browser subpath for the browser bundle
+        // only.
+        esbuildOptions(opts) {
+            // The `./browser/*` subpath pattern requires a trailing segment —
+            // bare `@smooai/fetch/browser` doesn't resolve. Use the explicit
+            // `/browser/index` entry which matches the subpath pattern.
+            opts.alias = { ...(opts.alias ?? {}), '@smooai/fetch': '@smooai/fetch/browser/index' };
+        },
     },
 ]);


### PR DESCRIPTION
`@smooai/config/client` broke Vite / Next.js consumer builds with *"Module 'node:v8' has been externalized"*. `platform/client.ts` does `import fetch from '@smooai/fetch'` — but `@smooai/fetch` has no top-level `browser` condition (only a `./browser/*` subpath pattern), so the bare specifier in the tsup browser build resolved to the Node entry, pulling `@smooai/logger` + `rotating-file-stream` + `import-meta-resolve` into the frontend bundle.

Fix: alias `@smooai/fetch` → `@smooai/fetch/browser/index` for the browser tsup build + add it to `noExternal` so esbuild bundles the browser-safe implementation.

```
grep -l 'rotating-file-stream\|@smooai/logger' dist/browser/chunk-*.mjs  # no matches
grep '@smooai/fetch/dist/browser' dist/browser/chunk-*.mjs                # inlines browser entry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)