### PR TITLE
SMOODEV-646: smooConfigPlugin also injects process.env.VITE_*

### DIFF
--- a/.changeset/smoodev-645-browser-fetch-alias.md
+++ b/.changeset/smoodev-645-browser-fetch-alias.md
@@ -1,0 +1,21 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-645: fix browser bundle pulling Node-only deps via `@smooai/fetch`**
+
+`@smooai/config/client` (and `/react`) broke Vite / Next.js consumer builds with `Module 'node:v8' has been externalized`. Root cause: `platform/client.ts` does `import fetch from '@smooai/fetch'`, but `@smooai/fetch`'s package.json exposes its browser entry only as the `./browser/*` subpath — it has no top-level `browser` condition. In the tsup browser build, the bare specifier resolved to the Node entry, dragging in `@smooai/logger` + `rotating-file-stream` + `import-meta-resolve`.
+
+Fix: in the browser tsup build, add `@smooai/fetch` to `noExternal` and alias the bare specifier to `@smooai/fetch/browser/index` via esbuild's native `alias`. Browser chunks now inline the browser-safe fetch implementation.
+
+Verified:
+
+```
+grep -l "rotating-file-stream\|@smooai/logger" dist/browser/chunk-*.mjs
+# (no matches)
+
+grep "@smooai/fetch/dist/browser" dist/browser/chunk-*.mjs
+# chunk-...: // node_modules/.../@smooai/fetch/dist/browser/index.mjs
+```
+
+Frontend consumers no longer need to manually alias `@smooai/fetch`.

--- a/.changeset/smoodev-646-vite-process-env-define.md
+++ b/.changeset/smoodev-646-vite-process-env-define.md
@@ -1,0 +1,9 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-646: `smooConfigPlugin` — inject `process.env.VITE_*` as well as `import.meta.env.VITE_*`**
+
+`getClientPublicConfig` / `getClientFeatureFlag` read `process.env.VITE_*` by design (so the same SDK code path works on Next.js + Vite). The Vite plugin previously only substituted `import.meta.env.VITE_*`, so at browser runtime the SDK getters returned `undefined` — no bundle-baked values.
+
+Fix: the plugin now emits **both** `import.meta.env.VITE_X` and `process.env.VITE_X` define entries. Bundled values finally make it through to `getClientPublicConfig('apiUrl')` / `getClientFeatureFlag('observability')` in Vite apps.

--- a/src/vite/smooConfigPlugin.ts
+++ b/src/vite/smooConfigPlugin.ts
@@ -75,10 +75,19 @@ export function smooConfigPlugin(options: SmooConfigPluginOptions): Plugin {
                 }
             }
 
-            // Return define map so Vite replaces these at build time
+            // Return define map so Vite replaces these at build time.
+            // We inject under BOTH `import.meta.env.X` (Vite's native pattern,
+            // works in TS/Vite code that reads env directly) AND
+            // `process.env.X` (what @smooai/config/client's
+            // `getClientPublicConfig` / `getClientFeatureFlag` helpers read
+            // — they use a shared `process.env.*` code path across Next.js
+            // and Vite consumers). Without the `process.env` substitution,
+            // the SDK's getters return `undefined` in the browser runtime
+            // because `process.env` is empty once the bundle loads.
             const define: Record<string, string> = {};
             for (const [key, value] of Object.entries(envVars)) {
                 define[`import.meta.env.${key}`] = JSON.stringify(value);
+                define[`process.env.${key}`] = JSON.stringify(value);
             }
 
             return { define };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -123,8 +123,28 @@ export default defineConfig((options: Options) => [
         sourcemap: true,
         target: 'es2022',
         treeShaking: true,
-        // Mark Node.js-only deps as non-external so esbuild resolves them through our alias plugin
-        noExternal: aliasedModules,
+        // Mark Node.js-only deps as non-external so esbuild resolves them through our alias plugin.
+        // `@smooai/fetch` is listed so the alias (→ `@smooai/fetch/browser`)
+        // is applied by esbuild — external imports bypass aliasing.
+        noExternal: [...aliasedModules, '@smooai/fetch'],
         esbuildPlugins: [alias(aliasMap)],
+        // SMOODEV-645: `@smooai/fetch`'s package.json exposes a browser
+        // subpath (`./browser/*`) but has no top-level `browser`
+        // condition on `.`. In platform/client.ts we do
+        //   import fetch from '@smooai/fetch';
+        // which in the browser build otherwise resolves to the Node entry
+        // — pulling in `@smooai/logger` + `rotating-file-stream` and
+        // breaking Vite / Next.js consumer bundles with
+        //   "Module 'node:v8' has been externalized".
+        // esbuild's native `alias` (which does module-level resolution,
+        // not just path replacement like `esbuild-plugin-alias`) rewrites
+        // the bare specifier to the browser subpath for the browser bundle
+        // only.
+        esbuildOptions(opts) {
+            // The `./browser/*` subpath pattern requires a trailing segment —
+            // bare `@smooai/fetch/browser` doesn't resolve. Use the explicit
+            // `/browser/index` entry which matches the subpath pattern.
+            opts.alias = { ...(opts.alias ?? {}), '@smooai/fetch': '@smooai/fetch/browser/index' };
+        },
     },
 ]);


### PR DESCRIPTION
`getClientPublicConfig` / `getClientFeatureFlag` read `process.env.VITE_*` by design (so the same SDK code path works for Next.js + Vite consumers). The Vite plugin previously only substituted `import.meta.env.VITE_*` — at browser runtime the SDK getters returned `undefined` because `process.env` is empty once the bundle loads.

Fix: emit both `import.meta.env.VITE_X` and `process.env.VITE_X` define entries.

Verified the Vite test app (from SMOODEV-645) bundle now includes the inlined public-config + flag-default values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)