### PR TITLE
SMOODEV-647: populate globalThis.__VITE_ENV__ in smooConfigPlugin

### DIFF
--- a/.changeset/smoodev-646-vite-process-env-define.md
+++ b/.changeset/smoodev-646-vite-process-env-define.md
@@ -1,0 +1,9 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-646: `smooConfigPlugin` — inject `process.env.VITE_*` as well as `import.meta.env.VITE_*`**
+
+`getClientPublicConfig` / `getClientFeatureFlag` read `process.env.VITE_*` by design (so the same SDK code path works on Next.js + Vite). The Vite plugin previously only substituted `import.meta.env.VITE_*`, so at browser runtime the SDK getters returned `undefined` — no bundle-baked values.
+
+Fix: the plugin now emits **both** `import.meta.env.VITE_X` and `process.env.VITE_X` define entries. Bundled values finally make it through to `getClientPublicConfig('apiUrl')` / `getClientFeatureFlag('observability')` in Vite apps.

--- a/.changeset/smoodev-647-vite-globalthis-env.md
+++ b/.changeset/smoodev-647-vite-globalthis-env.md
@@ -1,0 +1,9 @@
+---
+'@smooai/config': patch
+---
+
+**SMOODEV-647: `smooConfigPlugin` populates `globalThis.__VITE_ENV__` for dynamic SDK getters**
+
+`getClientPublicConfig(key)` / `getClientFeatureFlag(key)` use DYNAMIC property access (`process.env[\`VITE*CONFIG*\${envKey}\`]`) which Vite's `define`can't substitute per-key. The SDK's getters already had a fallback path checking`globalThis.**VITE_ENV**` at runtime — the plugin just never populated it.
+
+The plugin now emits `define: { 'globalThis.__VITE_ENV__': JSON.stringify(envVars) }` in addition to the per-key static substitutions. Bundle-baked values now flow through the SDK's dynamic getters in Vite apps.

--- a/src/vite/smooConfigPlugin.ts
+++ b/src/vite/smooConfigPlugin.ts
@@ -76,19 +76,27 @@ export function smooConfigPlugin(options: SmooConfigPluginOptions): Plugin {
             }
 
             // Return define map so Vite replaces these at build time.
-            // We inject under BOTH `import.meta.env.X` (Vite's native pattern,
-            // works in TS/Vite code that reads env directly) AND
-            // `process.env.X` (what @smooai/config/client's
-            // `getClientPublicConfig` / `getClientFeatureFlag` helpers read
-            // — they use a shared `process.env.*` code path across Next.js
-            // and Vite consumers). Without the `process.env` substitution,
-            // the SDK's getters return `undefined` in the browser runtime
-            // because `process.env` is empty once the bundle loads.
+            //
+            // Vite's `define` only substitutes STATIC references like
+            // `import.meta.env.VITE_CONFIG_API_URL`. The SDK's
+            // `getClientPublicConfig(key)` / `getClientFeatureFlag(key)`
+            // helpers use DYNAMIC access — `process.env[\`VITE_CONFIG_\${envKey}\`]`
+            // — which Vite can't rewrite per-key. For the dynamic path to
+            // work we need a runtime object the SDK can index into at
+            // runtime. The SDK already checks `globalThis.__VITE_ENV__`
+            // for exactly this; it was just never populated.
+            //
+            // We emit:
+            //   1. Per-key static substitutions under `import.meta.env.VITE_X`
+            //      and `process.env.VITE_X` — covers direct-access consumers.
+            //   2. `globalThis.__VITE_ENV__` as a JSON-baked object the SDK's
+            //      dynamic getters fall through to at runtime.
             const define: Record<string, string> = {};
             for (const [key, value] of Object.entries(envVars)) {
                 define[`import.meta.env.${key}`] = JSON.stringify(value);
                 define[`process.env.${key}`] = JSON.stringify(value);
             }
+            define['globalThis.__VITE_ENV__'] = JSON.stringify(envVars);
 
             return { define };
         },


### PR DESCRIPTION
getClientPublicConfig/getClientFeatureFlag use dynamic property access which Vite's static-define can't substitute. SDK already had a globalThis.__VITE_ENV__ fallback; plugin just needed to populate it.

Follow-up to SMOODEV-646 — previously discovered process.env was not populated in Vite browser contexts, but define substitution alone can't cover dynamic access.