### PR TITLE
feat: unified client env bag + sync-worker sidecar + drop fetch/logger aliases

### DIFF
--- a/.changeset/unified-client-env-and-sync-worker-sidecar.md
+++ b/.changeset/unified-client-env-and-sync-worker-sidecar.md
@@ -1,0 +1,38 @@
+---
+'@smooai/config': minor
+---
+
+**Unified client env bag + sidecar sync-worker + drop fetch/logger aliases**
+
+Three related cleanups that remove long-standing workarounds.
+
+### 1. Unified `__SMOO_CLIENT_ENV__` (fixes Next.js "(unset)" + Vite dynamic-lookup)
+
+The browser SDK helpers `getClientPublicConfig(key)` / `getClientFeatureFlag(key)` use dynamic-key env lookups (`obj[computedKey]`). Bundlers only static-replace literal `process.env.X` / `import.meta.env.X`, so those lookups always returned `undefined` at runtime — Next.js showed `(unset)` for baked public config; Vite relied on a `globalThis.__VITE_ENV__` shim injected by `smooConfigPlugin`.
+
+Both bundler plugins now define a single namespaced global:
+
+- `smooConfigPlugin` (Vite) — adds `__SMOO_CLIENT_ENV__` to Vite's `define`
+- `withSmooConfig` (Next.js) — registers a webpack `DefinePlugin` that substitutes `__SMOO_CLIENT_ENV__` with the same literal object
+
+The SDK reads through that one global. No `globalThis` fallback, no `process.env` shim, one code path.
+
+Existing `next.config.env` + per-key `process.env.NEXT_PUBLIC_*` and `import.meta.env.VITE_*` substitutions are untouched — the normal ergonomic of direct static reads still works.
+
+### 2. Sync worker sidecar file (optional `copyFiles` optimisation)
+
+`buildConfig(schema).*.getSync(...)` previously extracted the embedded worker source to `/tmp` on first use in every process (SMOODEV-617). The SDK now tries a sidecar file at `./sync-worker.mjs` (next to the compiled `server/index.mjs`) first, and only falls back to `/tmp` extraction when the sidecar isn't present.
+
+Consumers that want zero `/tmp` writes on Lambda can copy the sidecar into the deploy package — recommended via SST `$transform`:
+
+```typescript
+$transform(sst.aws.Function, (fn) => {
+    fn.copyFiles = [...(fn.copyFiles ?? []), { from: 'node_modules/@smooai/config/dist/server/sync-worker.mjs' }];
+});
+```
+
+No consumer action required — the `/tmp` fallback keeps existing deployments working. Full documentation in the README under "How `.getSync()` works".
+
+### 3. Drop `@smooai/fetch` + `@smooai/logger/Logger` aliases in the browser build
+
+`@smooai/fetch@3.1.0` and `@smooai/logger@4.0.4+` both added top-level `browser` export conditions, so `platform: 'browser'` bundles pick the right entry automatically. Removed the `esbuild-plugin-alias` workarounds + the `@smooai/fetch/browser/index` path rewrite. Schema-serializer stubs (`arktype`, `effect`, `@valibot/to-json-schema`, `json-schema-to-zod`, `esm-utils`, `rotating-file-stream`) are unchanged.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,44 @@ const isNewUi = configObj.featureFlag.getSync(FeatureFlagKeys.ENABLE_NEW_UI);
 const apiKey = await configObj.secretConfig.getAsync(SecretConfigKeys.API_KEY);
 ```
 
+### How `.getSync()` works (and how to optimise it on Lambda)
+
+Sync accessors run an async config read to completion on the caller thread via
+`synckit` — a Node `Worker` pool + `Atomics.wait` on a `SharedArrayBuffer`.
+`createSyncFn` only accepts a `file://` URL, so the worker body has to live on
+disk. The SDK resolves it in two stages:
+
+1. **Sidecar file** — `sync-worker.mjs` sitting next to `dist/server/index.mjs`
+   in the installed package. This is the normal case for plain Node resolution
+   (no bundling) or when the bundler copies the sidecar to the deploy output.
+   Zero `/tmp` writes.
+
+2. **Extract-to-`/tmp` fallback** — if the sidecar isn't found on disk (e.g.
+   a single-file bundled Lambda handler with no copyFiles), the SDK writes
+   an embedded copy of the worker source to `mkdtempSync()/sync-worker.mjs`
+   once per process and hands that path to synckit. One ~1-2 MiB write at
+   cold start. Works anywhere with a writable temp dir.
+
+Both paths are transparent — existing code keeps working either way. To keep
+path (1) on AWS Lambda via SST, copy the sidecar alongside each function:
+
+```typescript
+// sst.config.ts — per function
+new sst.aws.Function('Api', {
+    handler: 'src/api.handler',
+    copyFiles: [{ from: 'node_modules/@smooai/config/dist/server/sync-worker.mjs' }],
+});
+
+// Or at the stack level via $transform (every Function gets it automatically)
+$transform(sst.aws.Function, (fn) => {
+    fn.copyFiles = [...(fn.copyFiles ?? []), { from: 'node_modules/@smooai/config/dist/server/sync-worker.mjs' }];
+});
+```
+
+Vercel edge runtimes don't expose `worker_threads`, so `.getSync()` is a no-go
+there by design — use `.get()` (async) everywhere that needs to run on the
+edge. The error surface makes this explicit.
+
 ---
 
 ## React Hooks (framework-agnostic)

--- a/src/client/clientEnvBag.test.ts
+++ b/src/client/clientEnvBag.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the bundler-baked `__SMOO_CLIENT_ENV__` read path.
+ *
+ * At runtime, both `smooConfigPlugin` (Vite) and `withSmooConfig` (Next.js)
+ * replace `__SMOO_CLIENT_ENV__` with a literal object. In test land, there's
+ * no bundler — we simulate the replacement by assigning to `globalThis`.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { getClientFeatureFlag, getClientPublicConfig } from './index';
+
+type MutableGlobal = typeof globalThis & { __SMOO_CLIENT_ENV__?: Record<string, string> };
+
+afterEach(() => {
+    delete (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__;
+});
+
+describe('getClientPublicConfig', () => {
+    it('reads NEXT_PUBLIC_CONFIG_* keys from the env bag', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            NEXT_PUBLIC_CONFIG_API_URL: 'https://api.smoo.ai',
+        };
+        expect(getClientPublicConfig('apiUrl')).toBe('https://api.smoo.ai');
+    });
+
+    it('reads VITE_CONFIG_* keys from the env bag', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            VITE_CONFIG_WEB_URL: 'https://smoo.ai',
+        };
+        expect(getClientPublicConfig('webUrl')).toBe('https://smoo.ai');
+    });
+
+    it('prefers NEXT_PUBLIC_CONFIG_* over VITE_CONFIG_* when both are present', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            NEXT_PUBLIC_CONFIG_API_URL: 'https://nextjs.value',
+            VITE_CONFIG_API_URL: 'https://vite.value',
+        };
+        expect(getClientPublicConfig('apiUrl')).toBe('https://nextjs.value');
+    });
+
+    it('returns undefined when the key is not baked', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {};
+        expect(getClientPublicConfig('nope')).toBeUndefined();
+    });
+
+    it('returns undefined when neither plugin has run', () => {
+        expect(getClientPublicConfig('apiUrl')).toBeUndefined();
+    });
+
+    it('camelCases keys to UPPER_SNAKE_CASE before lookup', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            NEXT_PUBLIC_CONFIG_API_BASE_URL: 'https://multi-word.key',
+        };
+        expect(getClientPublicConfig('apiBaseUrl')).toBe('https://multi-word.key');
+    });
+});
+
+describe('getClientFeatureFlag', () => {
+    it('parses "true" / "1" as true', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            NEXT_PUBLIC_FEATURE_FLAG_OBSERVABILITY: 'true',
+            VITE_FEATURE_FLAG_INTEGRATION_STRIPE: '1',
+        };
+        expect(getClientFeatureFlag('observability')).toBe(true);
+        expect(getClientFeatureFlag('integrationStripe')).toBe(true);
+    });
+
+    it('returns false for unrecognised values', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {
+            NEXT_PUBLIC_FEATURE_FLAG_X: 'false',
+            NEXT_PUBLIC_FEATURE_FLAG_Y: '0',
+            NEXT_PUBLIC_FEATURE_FLAG_Z: 'yes',
+        };
+        expect(getClientFeatureFlag('x')).toBe(false);
+        expect(getClientFeatureFlag('y')).toBe(false);
+        expect(getClientFeatureFlag('z')).toBe(false);
+    });
+
+    it('returns false when the flag is not baked', () => {
+        (globalThis as MutableGlobal).__SMOO_CLIENT_ENV__ = {};
+        expect(getClientFeatureFlag('aboutPage')).toBe(false);
+    });
+
+    it('returns false when neither plugin has run', () => {
+        expect(getClientFeatureFlag('aboutPage')).toBe(false);
+    });
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -39,81 +39,68 @@ export function toUpperSnakeCase(key: string): string {
 }
 
 /**
- * Get a feature flag value from build-time environment variables.
+ * Read the unified bundler-baked env bag.
  *
- * Checks for:
- * 1. NEXT_PUBLIC_FEATURE_FLAG_{KEY} (Next.js)
- * 2. VITE_FEATURE_FLAG_{KEY} (Vite)
+ * Both `smooConfigPlugin` (Vite) and `withSmooConfig` (Next.js) replace
+ * `__SMOO_CLIENT_ENV__` at build time with a literal JSON object
+ * containing all baked `*_CONFIG_*` and `*_FEATURE_FLAG_*` values.
  *
- * The key is converted from camelCase to UPPER_SNAKE_CASE.
- * e.g., "aboutPage" checks NEXT_PUBLIC_FEATURE_FLAG_ABOUT_PAGE
+ * The SDK's dynamic-key lookups (`obj[computedKey]`) only work when the
+ * env bag is a real runtime object. Per-key static substitution of
+ * `process.env.X` / `import.meta.env.X` is useless here because the key
+ * is only known at call time — so neither bundler rewrites it, and both
+ * return `undefined`. A single defined global fixes that for both.
  *
- * @param key - The camelCase feature flag key
- * @returns true if the flag is explicitly set to "true", false otherwise
+ * Falls back to `{}` if the plugin wasn't installed or the bundler didn't
+ * run (e.g. plain tsc/ts-node), preserving the old "return undefined"
+ * behaviour in unconfigured environments.
  */
-export function getClientFeatureFlag(key: string): boolean {
-    const envKey = toUpperSnakeCase(key);
+declare const __SMOO_CLIENT_ENV__: Record<string, string> | undefined;
 
-    const nextValue = typeof process !== 'undefined' ? process.env?.[`NEXT_PUBLIC_FEATURE_FLAG_${envKey}`] : undefined;
-    if (nextValue !== undefined) {
-        return nextValue === 'true' || nextValue === '1';
-    }
-
-    const viteValue = typeof process !== 'undefined' ? process.env?.[`VITE_FEATURE_FLAG_${envKey}`] : undefined;
-    if (viteValue !== undefined) {
-        return viteValue === 'true' || viteValue === '1';
-    }
-
+function readClientEnv(): Record<string, string> {
     try {
-        const viteEnv = (globalThis as Record<string, unknown>).__VITE_ENV__ as Record<string, string> | undefined;
-        const viteEnvValue = viteEnv?.[`VITE_FEATURE_FLAG_${envKey}`];
-        if (viteEnvValue !== undefined) {
-            return viteEnvValue === 'true' || viteEnvValue === '1';
+        // Each bundler's define/DefinePlugin rewrites this to the literal object.
+        if (typeof __SMOO_CLIENT_ENV__ !== 'undefined' && __SMOO_CLIENT_ENV__) {
+            return __SMOO_CLIENT_ENV__;
         }
     } catch {
-        // Vite env not available
+        // ReferenceError when neither plugin ran — fall through.
     }
-
-    return false;
+    return {};
 }
 
 /**
- * Get a public config value from build-time environment variables.
+ * Get a feature flag value from the bundler-baked env bag.
  *
- * Checks for:
- * 1. NEXT_PUBLIC_CONFIG_{KEY} (Next.js)
- * 2. VITE_CONFIG_{KEY} (Vite)
+ * Looks up (in order, first hit wins):
+ * 1. `NEXT_PUBLIC_FEATURE_FLAG_{KEY}` — populated by `withSmooConfig` (Next.js)
+ * 2. `VITE_FEATURE_FLAG_{KEY}` — populated by `smooConfigPlugin` (Vite)
  *
  * The key is converted from camelCase to UPPER_SNAKE_CASE.
- * e.g., "apiBaseUrl" checks NEXT_PUBLIC_CONFIG_API_BASE_URL
+ * e.g., `"aboutPage"` → `NEXT_PUBLIC_FEATURE_FLAG_ABOUT_PAGE`
+ */
+export function getClientFeatureFlag(key: string): boolean {
+    const envKey = toUpperSnakeCase(key);
+    const env = readClientEnv();
+    const raw = env[`NEXT_PUBLIC_FEATURE_FLAG_${envKey}`] ?? env[`VITE_FEATURE_FLAG_${envKey}`];
+    if (raw === undefined) return false;
+    return raw === 'true' || raw === '1';
+}
+
+/**
+ * Get a public config value from the bundler-baked env bag.
  *
- * @param key - The camelCase config key
- * @returns The config value as a string, or undefined if not set
+ * Looks up (in order, first hit wins):
+ * 1. `NEXT_PUBLIC_CONFIG_{KEY}` — populated by `withSmooConfig` (Next.js)
+ * 2. `VITE_CONFIG_{KEY}` — populated by `smooConfigPlugin` (Vite)
+ *
+ * The key is converted from camelCase to UPPER_SNAKE_CASE.
+ * e.g., `"apiBaseUrl"` → `NEXT_PUBLIC_CONFIG_API_BASE_URL`
  */
 export function getClientPublicConfig(key: string): string | undefined {
     const envKey = toUpperSnakeCase(key);
-
-    const nextValue = typeof process !== 'undefined' ? process.env?.[`NEXT_PUBLIC_CONFIG_${envKey}`] : undefined;
-    if (nextValue !== undefined) {
-        return nextValue;
-    }
-
-    const viteValue = typeof process !== 'undefined' ? process.env?.[`VITE_CONFIG_${envKey}`] : undefined;
-    if (viteValue !== undefined) {
-        return viteValue;
-    }
-
-    try {
-        const viteEnv = (globalThis as Record<string, unknown>).__VITE_ENV__ as Record<string, string> | undefined;
-        const viteEnvValue = viteEnv?.[`VITE_CONFIG_${envKey}`];
-        if (viteEnvValue !== undefined) {
-            return viteEnvValue;
-        }
-    } catch {
-        // Vite env not available
-    }
-
-    return undefined;
+    const env = readClientEnv();
+    return env[`NEXT_PUBLIC_CONFIG_${envKey}`] ?? env[`VITE_CONFIG_${envKey}`];
 }
 
 /**

--- a/src/nextjs/withSmooConfig.ts
+++ b/src/nextjs/withSmooConfig.ts
@@ -106,11 +106,34 @@ export function withSmooConfig(options: WithSmooConfigOptions, nextConfig: NextC
         process.env[envKey] = String(value);
     }
 
+    // `next.config.env` gives us per-key static substitution of
+    // `process.env.NEXT_PUBLIC_FOO` (the normal Next.js ergonomic). But the
+    // SDK's `getClientPublicConfig(key)` / `getClientFeatureFlag(key)` read
+    // via a dynamic key — `process.env[\`NEXT_PUBLIC_CONFIG_\${computed}\`]`
+    // — which Next.js can't rewrite per-key. On the browser `process.env`
+    // is effectively empty, so dynamic reads return `undefined` → config
+    // values appear "unset".
+    //
+    // Solution: define `__SMOO_CLIENT_ENV__` as a literal object via
+    // webpack's DefinePlugin. The SDK indexes into that constant with its
+    // computed key; each reference in the compiled bundle is replaced
+    // with the literal object at build time (identical shape to what the
+    // Vite plugin emits via `define`).
+    const originalWebpack = nextConfig.webpack as
+        | ((webpackConfig: { plugins: unknown[] }, context: { webpack: { DefinePlugin: new (defs: Record<string, string>) => unknown } }) => unknown)
+        | undefined;
+
+    const webpack = (webpackConfig: { plugins: unknown[] }, context: { webpack: { DefinePlugin: new (defs: Record<string, string>) => unknown } }) => {
+        webpackConfig.plugins.push(new context.webpack.DefinePlugin({ __SMOO_CLIENT_ENV__: JSON.stringify(env) }));
+        return originalWebpack ? originalWebpack(webpackConfig, context) : webpackConfig;
+    };
+
     return {
         ...nextConfig,
         env: {
             ...(nextConfig.env as Record<string, string> | undefined),
             ...env,
         },
+        webpack,
     };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,10 +40,10 @@
  *   // Sync (drop-in for constructors / top-level init):
  *   const supabaseUrl = config.publicConfig.getSync('supabaseUrl');
  */
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig, InferConfigTypes } from '@/config/config';
 import { createSyncFn } from 'synckit';
 import { buildConfigAsync, BuildConfigAsyncOptions } from './internal';
@@ -53,35 +53,69 @@ export type { BuildConfigAsyncOptions as BuildConfigOptions } from './internal';
 export { __resetServerCaches } from './internal';
 
 /**
- * SMOODEV-617 — materialize the bundled worker into a temp file once per
- * process so `createSyncFn` can take a real `file://` URL.
+ * Resolve the worker file URL for synckit. Two paths, in order:
  *
- * Why not a `data:` URL directly? synckit's `createSyncFn` calls
- * `fileURLToPath(url)` unconditionally in the top of its implementation
- * — it only accepts `file://`. The `dataUrl` helper exposed on the
- * synckit API is used internally to wrap the *real* worker file in a
- * global-shim injector; it is not a way for callers to avoid writing
- * a file to disk.
+ *   1. **Sidecar file** — `./sync-worker.mjs` sitting next to the compiled
+ *      SDK entry. This is the normal case when the consumer does not bundle
+ *      (plain Node resolution from `node_modules/@smooai/config/dist/server/`)
+ *      or when the bundler copies the sidecar (SST `copyFiles`, esbuild with
+ *      the `new URL(..., import.meta.url)` asset hint, etc.). Zero /tmp write,
+ *      zero cold-start cost beyond what synckit itself pays.
  *
- * So instead, at first-use time we:
- *   1. Import `WORKER_SOURCE` — the fully-bundled ESM source of
- *      `src/server/sync-worker.ts` with every dep inlined. Built ahead
- *      of tsup by `scripts/build-sync-worker.mjs` and consumed as a
- *      plain string literal; esbuild / tsup cannot tree-shake it out.
- *   2. Write it to `mkdtempSync()/sync-worker.mjs` — one-time 1-2 MiB
- *      write to `/tmp` on Lambda (512 MiB–10 GiB available).
- *   3. Hand the resulting `file://` URL to `createSyncFn`. synckit spins
- *      up a Node `Worker` as normal; the worker imports its deps from
- *      inside the bundled source, no external module resolution.
+ *   2. **Extracted from `WORKER_SOURCE`** (SMOODEV-617 fallback) — the worker
+ *      body is also embedded as a bundled ESM string literal in
+ *      `sync-worker-source.generated.ts`. If the sidecar isn't on disk
+ *      (single-file bundled Lambda with no copyFiles), we write the string
+ *      to `mkdtempSync()/sync-worker.mjs` once per process and hand that
+ *      `file://` URL to synckit. One-time ~1-2 MiB write to `/tmp`.
  *
- * Works in any Node environment with a writable temp dir: AWS Lambda,
- * ECS, Fargate, long-lived servers, CLI scripts. Vercel edge runtimes
- * don't have `worker_threads`, so `.getSync()` is a no-go there by
- * design — but `.get()` (async) still works everywhere.
+ * Why not a `data:` URL directly? `createSyncFn` passes the URL through
+ * `fileURLToPath` unconditionally — only `file://` works.
+ *
+ * How to keep this on path (1) on AWS Lambda via SST:
+ *
+ * ```ts
+ * // sst.config.ts
+ * new sst.aws.Function('Api', {
+ *   handler: 'src/api.handler',
+ *   copyFiles: [
+ *     { from: 'node_modules/@smooai/config/dist/server/sync-worker.mjs' },
+ *   ],
+ * });
+ * ```
+ *
+ * Or at the project level via `$transform` so every `Function` gets it:
+ *
+ * ```ts
+ * $transform(sst.aws.Function, (fn) => {
+ *   fn.copyFiles = [
+ *     ...(fn.copyFiles ?? []),
+ *     { from: 'node_modules/@smooai/config/dist/server/sync-worker.mjs' },
+ *   ];
+ * });
+ * ```
+ *
+ * Vercel edge runtimes don't have `worker_threads` at all, so `.getSync()`
+ * is unavailable there by design — `.get()` (async) works everywhere.
  */
 let cachedWorkerUrl: URL | undefined;
+
 function ensureWorkerFile(): URL {
     if (cachedWorkerUrl) return cachedWorkerUrl;
+
+    // Path 1 — sidecar file next to the compiled SDK entry.
+    try {
+        const sidecar = new URL('./sync-worker.mjs', import.meta.url);
+        if (existsSync(fileURLToPath(sidecar))) {
+            cachedWorkerUrl = sidecar;
+            return cachedWorkerUrl;
+        }
+    } catch {
+        // `new URL` can throw in exotic environments (Deno compile, etc.).
+        // Fall through to the embedded-source extraction path.
+    }
+
+    // Path 2 — extract the embedded worker source to /tmp.
     const dir = mkdtempSync(join(tmpdir(), 'smooai-config-'));
     const filePath = join(dir, 'sync-worker.mjs');
     writeFileSync(filePath, WORKER_SOURCE);

--- a/src/vite/smooConfigPlugin.ts
+++ b/src/vite/smooConfigPlugin.ts
@@ -77,26 +77,27 @@ export function smooConfigPlugin(options: SmooConfigPluginOptions): Plugin {
 
             // Return define map so Vite replaces these at build time.
             //
-            // Vite's `define` only substitutes STATIC references like
-            // `import.meta.env.VITE_CONFIG_API_URL`. The SDK's
-            // `getClientPublicConfig(key)` / `getClientFeatureFlag(key)`
-            // helpers use DYNAMIC access — `process.env[\`VITE_CONFIG_\${envKey}\`]`
-            // — which Vite can't rewrite per-key. For the dynamic path to
-            // work we need a runtime object the SDK can index into at
-            // runtime. The SDK already checks `globalThis.__VITE_ENV__`
-            // for exactly this; it was just never populated.
+            // Two layers:
             //
-            // We emit:
-            //   1. Per-key static substitutions under `import.meta.env.VITE_X`
-            //      and `process.env.VITE_X` — covers direct-access consumers.
-            //   2. `globalThis.__VITE_ENV__` as a JSON-baked object the SDK's
-            //      dynamic getters fall through to at runtime.
+            //   1. Per-key static substitution under `import.meta.env.VITE_X`
+            //      and `process.env.VITE_X`. This is what lets consumers
+            //      write `import.meta.env.VITE_CONFIG_API_URL` directly and
+            //      have Vite inline the value — the normal Vite ergonomic.
+            //
+            //   2. `__SMOO_CLIENT_ENV__` as a literal JSON object containing
+            //      every baked key. The SDK's `getClientPublicConfig(key)` /
+            //      `getClientFeatureFlag(key)` read via a dynamic key
+            //      (`obj[computedKey]`), which Vite's per-key substitution
+            //      can't handle because the key isn't known statically. The
+            //      SDK reads `__SMOO_CLIENT_ENV__[computedKey]` instead —
+            //      one defined global, populated identically on both Vite
+            //      and Next.js (via `withSmooConfig`'s webpack DefinePlugin).
             const define: Record<string, string> = {};
             for (const [key, value] of Object.entries(envVars)) {
                 define[`import.meta.env.${key}`] = JSON.stringify(value);
                 define[`process.env.${key}`] = JSON.stringify(value);
             }
-            define['globalThis.__VITE_ENV__'] = JSON.stringify(envVars);
+            define.__SMOO_CLIENT_ENV__ = JSON.stringify(envVars);
 
             return { define };
         },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -83,16 +83,14 @@ const browserEntry = [
 const nodeStub = path.resolve(__dirname, 'src/stubs/node-deps.stub.ts');
 const schemaStub = path.resolve(__dirname, 'src/stubs/standard-schema-serializer.stub.ts');
 
-const aliasedModules = [
-    '@smooai/logger/Logger',
-    'esm-utils',
-    '@valibot/to-json-schema',
-    'arktype',
-    'effect',
-    'effect/JSONSchema',
-    'json-schema-to-zod',
-    'rotating-file-stream',
-];
+// Node-only modules we still alias to stubs in the browser build. Schema
+// serializers (arktype / effect / valibot adapter / json-schema-to-zod) use
+// `esm-utils` (which evals CJS), so they can never ship to the browser —
+// we stub them with a schema-only no-op. `rotating-file-stream` is defensive:
+// nothing should resolve it now that `@smooai/logger` has a top-level
+// `browser` export condition, but keeping the alias means a stray import
+// from a transitive dep can't break consumer bundles.
+const aliasedModules = ['esm-utils', '@valibot/to-json-schema', 'arktype', 'effect', 'effect/JSONSchema', 'json-schema-to-zod', 'rotating-file-stream'];
 
 const aliasMap: Record<string, string> = {};
 for (const mod of aliasedModules) {
@@ -123,28 +121,12 @@ export default defineConfig((options: Options) => [
         sourcemap: true,
         target: 'es2022',
         treeShaking: true,
-        // Mark Node.js-only deps as non-external so esbuild resolves them through our alias plugin.
-        // `@smooai/fetch` is listed so the alias (→ `@smooai/fetch/browser`)
-        // is applied by esbuild — external imports bypass aliasing.
-        noExternal: [...aliasedModules, '@smooai/fetch'],
+        // Non-external so esbuild routes these through the alias plugin
+        // and substitutes the stubs. `@smooai/fetch` and `@smooai/logger`
+        // are *not* listed — both now have top-level `browser` export
+        // conditions (fetch ≥3.1.0, logger ≥4.0.4), so `platform: 'browser'`
+        // picks the right entry automatically. No alias workaround needed.
+        noExternal: aliasedModules,
         esbuildPlugins: [alias(aliasMap)],
-        // SMOODEV-645: `@smooai/fetch`'s package.json exposes a browser
-        // subpath (`./browser/*`) but has no top-level `browser`
-        // condition on `.`. In platform/client.ts we do
-        //   import fetch from '@smooai/fetch';
-        // which in the browser build otherwise resolves to the Node entry
-        // — pulling in `@smooai/logger` + `rotating-file-stream` and
-        // breaking Vite / Next.js consumer bundles with
-        //   "Module 'node:v8' has been externalized".
-        // esbuild's native `alias` (which does module-level resolution,
-        // not just path replacement like `esbuild-plugin-alias`) rewrites
-        // the bare specifier to the browser subpath for the browser bundle
-        // only.
-        esbuildOptions(opts) {
-            // The `./browser/*` subpath pattern requires a trailing segment —
-            // bare `@smooai/fetch/browser` doesn't resolve. Use the explicit
-            // `/browser/index` entry which matches the subpath pattern.
-            opts.alias = { ...(opts.alias ?? {}), '@smooai/fetch': '@smooai/fetch/browser/index' };
-        },
     },
 ]);


### PR DESCRIPTION
## Summary

Three related cleanups that button up the frontend-dogfood rough edges:

1. **Unified `__SMOO_CLIENT_ENV__`** — fixes the Next.js "(unset)" bug AND replaces the Vite `globalThis.__VITE_ENV__` shim with one bundler-defined constant. SDK has one code path; per-key static substitution still works for consumers who want it.

2. **Sync-worker sidecar resolution** — SDK tries `./sync-worker.mjs` next to the compiled server entry first; `/tmp` extraction is now a fallback, not the default. SST `\$transform` recipe documented in the README so Lambda consumers can get zero `/tmp` writes.

3. **Drop fetch/logger aliasing** — `@smooai/fetch@3.1.0` and `@smooai/logger@4.0.4+` both now have top-level `browser` export conditions, so `platform: 'browser'` picks the right entry automatically. `tsup.config.ts` no longer needs the custom `esbuildOptions.alias` or `noExternal: ['@smooai/fetch']`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] All 138 existing tests pass
- [x] 10 new tests in `src/client/clientEnvBag.test.ts` cover both bundler prefixes + fallback behaviour
- [x] Browser bundle verified: `grep -rl rotating-file-stream dist/browser/` returns empty
- [ ] Dogfood redeploys show `apiUrl=https://api.smoo.ai` on `test-nextjs-config.smoo.ai`
- [ ] Vite dogfood keeps working (no regression — same code path via `__SMOO_CLIENT_ENV__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)