### PR TITLE
fix: inline fetch into browser build + bump dep to ^3.1.0

### DIFF
--- a/.changeset/fix-inline-fetch-in-browser-build.md
+++ b/.changeset/fix-inline-fetch-in-browser-build.md
@@ -1,0 +1,19 @@
+---
+'@smooai/config': patch
+---
+
+**Fix Vite/webpack consumer builds pulling `rotating-file-stream` via stale `@smooai/fetch`**
+
+The previous release (4.2.0) dropped `@smooai/fetch` from `tsup`'s browser `noExternal`, relying on `@smooai/fetch@3.1.0`'s new top-level `browser` export condition to do the right thing on consumer side. That's brittle: if a consumer's dep tree resolves `@smooai/fetch` to `2.x` elsewhere (smooai monorepo currently does), `platform: 'browser'` falls back to the Node entry, which pulls `@smooai/logger` + `rotating-file-stream`, breaking the build with:
+
+```
+"access" is not exported by "__vite-browser-external", imported by "rotating-file-stream/dist/esm/index.js"
+```
+
+This patch:
+
+1. Re-adds `@smooai/fetch` to the browser build's `noExternal` list, so fetch is bundled into `dist/browser/` and consumers never need to resolve it themselves. Adds a few KB to the browser dist for robustness — not dependent on consumer-side resolution.
+
+2. Bumps the declared `@smooai/fetch` dep from `^2.1.0` to `^3.1.0` so the inlined version benefits from the browser condition.
+
+No API changes. 4.1.x consumers upgrading to 4.2.1 get a clean browser build with zero Node-only transitive pulls.

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     },
     "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@smooai/fetch": "^2.1.0",
+        "@smooai/fetch": "^3.1.0",
         "@smooai/logger": "^3.1.1",
         "@smooai/utils": "^1.3.1",
         "@standard-schema/spec": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       '@smooai/fetch':
-        specifier: ^2.1.0
-        version: 2.1.0(@types/node@22.13.10)(typescript@5.8.2)
+        specifier: ^3.1.0
+        version: 3.1.0(@types/node@22.13.10)(typescript@5.8.2)
       '@smooai/logger':
         specifier: ^3.1.1
         version: 3.1.1
@@ -1325,15 +1325,25 @@ packages:
     peerDependencies:
       typescript: ^5.8.2
 
-  '@smooai/fetch@2.1.0':
-    resolution: {integrity: sha512-cww14BkogDR2TBAi6zLsgwV/Cgci+fwmUDd0JeLaj4yycLPR6OkJRfJJ1P4DsQDUqLnHnDFQ4dZ48tBgY/n0EQ==}
+  '@smooai/fetch@3.1.0':
+    resolution: {integrity: sha512-0q4ZWvFWLlUWZEAQAeTHCrLGk4k2ew9/8bDLuUepqS2AyrJkDSynKzK5U5H0ZYAyEdidzh346MuE0Q//SgXUww==}
 
   '@smooai/logger@3.1.1':
     resolution: {integrity: sha512-WGjgW7wqwZ2XqcrAOCf237FmR/0bT4Cfb61vhdsaQHX7rxQhSs88VD4SxrNT53KbIcIULuj6z2TaZDCY7TJtwQ==}
     engines: {node: '>=20.0.0'}
 
+  '@smooai/logger@3.3.0':
+    resolution: {integrity: sha512-yIuKxI6M+w/pgG23EhhXdO717EGJjGFESwIoq/KwXDJqEcjq07HlfmkOzBS+wAKj1WRRz17AbmN12oSmq+oJnQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   '@smooai/utils@1.3.1':
     resolution: {integrity: sha512-y1jbOW8llHJrCuayJliSEVDSvEaj/4aKF9UP81Qo5i2wN2omFhyBtto0hAPMC3RcygYOBUPfAHJIFkSw+l4g5A==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@smooai/utils@1.3.2':
+    resolution: {integrity: sha512-OvXXcrXNH61m3udK1G0rTkSjp2dTAfRMHdfLL1NuF/wT7ld4PvuLEN1GRd7n5M+OHhqpE9WSwNx+qdXhMCEiYQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -4767,11 +4777,11 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  '@smooai/fetch@2.1.0(@types/node@22.13.10)(typescript@5.8.2)':
+  '@smooai/fetch@3.1.0(@types/node@22.13.10)(typescript@5.8.2)':
     dependencies:
       '@faker-js/faker': 9.9.0
-      '@smooai/logger': 3.1.1
-      '@smooai/utils': 1.3.1(@types/node@22.13.10)(typescript@5.8.2)
+      '@smooai/logger': 3.3.0
+      '@smooai/utils': 1.3.2(@types/node@22.13.10)(typescript@5.8.2)
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
       lodash.merge: 4.6.2
@@ -4802,12 +4812,52 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@smooai/logger@3.3.0':
+    dependencies:
+      '@aws-sdk/client-sqs': 3.883.0
+      browser-dtector: 4.1.0
+      dayjs: 1.11.18
+      esbuild-plugin-alias: 0.2.1
+      esm-utils: 4.3.0
+      json-stable-stringify: 1.3.0
+      merge-anything: 6.0.6
+      picocolors: 1.1.1
+      rotating-file-stream: 3.2.7
+      serialize-error: 11.0.3
+      source-map-support: 0.5.21
+      uuid: 9.0.1
+      zod: 4.1.5
+    transitivePeerDependencies:
+      - aws-crt
+
   '@smooai/utils@1.3.1(@types/node@22.13.10)(typescript@5.8.2)':
     dependencies:
       '@oclif/core': 2.16.0(@types/node@22.13.10)(typescript@5.8.2)
       '@oclif/plugin-help': 6.2.32
       '@oclif/plugin-plugins': 5.4.46
       '@smooai/logger': 3.1.1
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      find-up: 7.0.0
+      hono: 4.9.6
+      http-status-codes: 2.3.0
+      libphonenumber-js: 1.12.15
+      zod: 4.1.5
+      zx: 8.8.1
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - aws-crt
+      - supports-color
+      - typescript
+
+  '@smooai/utils@1.3.2(@types/node@22.13.10)(typescript@5.8.2)':
+    dependencies:
+      '@oclif/core': 2.16.0(@types/node@22.13.10)(typescript@5.8.2)
+      '@oclif/plugin-help': 6.2.32
+      '@oclif/plugin-plugins': 5.4.46
+      '@smooai/logger': 3.3.0
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
       find-up: 7.0.0

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -122,11 +122,19 @@ export default defineConfig((options: Options) => [
         target: 'es2022',
         treeShaking: true,
         // Non-external so esbuild routes these through the alias plugin
-        // and substitutes the stubs. `@smooai/fetch` and `@smooai/logger`
-        // are *not* listed — both now have top-level `browser` export
-        // conditions (fetch ≥3.1.0, logger ≥4.0.4), so `platform: 'browser'`
-        // picks the right entry automatically. No alias workaround needed.
-        noExternal: aliasedModules,
+        // and substitutes the stubs.
+        //
+        // `@smooai/fetch` is inlined (kept non-external) in the browser
+        // build on purpose: `platform: 'browser'` does pick up fetch's
+        // `browser` export condition automatically, but only if the
+        // consumer's resolution of `@smooai/fetch` lands on ≥3.1.0. If a
+        // consumer pins the old major (2.x) somewhere else in its tree,
+        // their browser build would fall back to fetch's Node entry and
+        // pull `rotating-file-stream` + logger. Bundling fetch into the
+        // browser dist here makes the browser build self-contained and
+        // immune to consumer-side resolution surprises. The cost is a
+        // small duplicated payload (~few KB) — worth it for robustness.
+        noExternal: [...aliasedModules, '@smooai/fetch'],
         esbuildPlugins: [alias(aliasMap)],
     },
 ]);


### PR DESCRIPTION
## Summary

4.2.0 exposed a fragility: dropping \`@smooai/fetch\` from tsup's browser \`noExternal\` made consumer resolution of fetch determine whether the browser bundle was clean. In the smooai monorepo, fetch was pinned to 2.x transitively, so 'platform: browser' fell back to the Node entry → pulled rotating-file-stream → broke the Vite build.

Re-inline fetch into \`dist/browser/\` (it's small), bump the declared dep to ^3.1.0, and the consumer's tree no longer matters.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] 138 tests pass
- [x] \`grep -r "rotating-file-stream" dist/browser/\` empty
- [ ] Bumping test-vite-config to 4.2.1 builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)