### PR TITLE
SMOODEV-615: Config Rust + Go parity — buildBundle + buildConfigRuntime

### DIFF
--- a/go/config/build.go
+++ b/go/config/build.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Deploy-time baker — framework-agnostic.
+//
+// Fetches `public` + `secret` config values for an environment, encrypts the
+// JSON with AES-256-GCM, and returns the ciphertext blob + base64-encoded
+// key. Deploy glue (SST/Vercel/Cloudflare/anything) writes the blob to disk,
+// ships it in the function bundle, and sets two env vars on the function:
+//
+//	SMOO_CONFIG_KEY_FILE = <absolute path to the blob on disk at runtime>
+//	SMOO_CONFIG_KEY      = <returned KeyB64>
+//
+// At cold start, NewRuntimeConfigManager reads both and decrypts once into
+// an in-memory cache. No runtime fetch for public + secret values.
+//
+// Feature flags are intentionally NOT baked — they're designed to flip
+// without a redeploy, so they stay live-fetched via ConfigClient. Pass a
+// Classify function (or use ClassifyFromSchema) so the baker knows which
+// keys to drop.
+//
+// Blob layout (wire-compatible with the TS + Python bakers):
+//
+//	nonce (12 random bytes) || ciphertext || authTag (16 bytes)
+
+// ClassifyResult is the output of a Classifier. One of "public", "secret",
+// or "skip" — "skip" omits the key from the blob (e.g., for feature flags).
+type ClassifyResult string
+
+const (
+	ClassifyPublic ClassifyResult = "public"
+	ClassifySecret ClassifyResult = "secret"
+	ClassifySkip   ClassifyResult = "skip"
+)
+
+// Classifier assigns each key to "public", "secret", or "skip".
+type Classifier func(key string, value any) ClassifyResult
+
+func defaultClassify(_ string, _ any) ClassifyResult {
+	return ClassifyPublic
+}
+
+// BuildBundleOptions configures BuildBundle.
+//
+// The ConfigClient fields (BaseURL, APIKey, OrgID) are required for the
+// remote fetch. Environment picks which slice of config to bake. If no
+// Classify is provided, every key is bucketed into "public" — almost never
+// what you want; use ClassifyFromSchema instead.
+type BuildBundleOptions struct {
+	// BaseURL is the config API base URL (e.g. https://api.smoo.ai).
+	BaseURL string
+	// APIKey is the bearer token used to authenticate to the config API.
+	APIKey string
+	// OrgID identifies the organization whose values will be fetched.
+	OrgID string
+	// Environment selects which environment's values to bake
+	// (e.g. "production"). Empty uses the client default.
+	Environment string
+	// Classify decides which section each key lands in. Return
+	// ClassifySkip to drop a key (feature flags).
+	Classify Classifier
+}
+
+// BuildBundleResult is the output of BuildBundle.
+type BuildBundleResult struct {
+	// KeyB64 is the base64-encoded 32-byte AES-256 key. Set as SMOO_CONFIG_KEY.
+	KeyB64 string
+	// Blob is the encrypted blob: nonce || ciphertext || authTag.
+	// Write this to disk and bundle with the function artifact.
+	Blob []byte
+	// Size is the length of Blob in bytes.
+	Size int64
+	// KeyCount is the number of keys baked (public + secret).
+	KeyCount int
+	// SkippedCount is the number of keys skipped (e.g., feature flags).
+	SkippedCount int
+}
+
+// ClassifyFromSchema builds a Classifier driven by explicit key sets.
+//
+// Feature-flag keys return ClassifySkip — they stay live-fetched at runtime.
+// Unknown keys default to ClassifyPublic to match the TS/Python behaviour.
+func ClassifyFromSchema(publicKeys, secretKeys, featureFlagKeys map[string]bool) Classifier {
+	return func(key string, _ any) ClassifyResult {
+		if secretKeys[key] {
+			return ClassifySecret
+		}
+		if publicKeys[key] {
+			return ClassifyPublic
+		}
+		if featureFlagKeys[key] {
+			return ClassifySkip
+		}
+		return ClassifyPublic
+	}
+}
+
+// partitionedBundle is the JSON shape baked into the blob. Matches the
+// TS/Python layout exactly so blobs are cross-language compatible.
+type partitionedBundle struct {
+	Public map[string]any `json:"public"`
+	Secret map[string]any `json:"secret"`
+}
+
+// BuildBundle fetches every config value for an environment, partitions
+// them via the classifier, encrypts the JSON with AES-256-GCM, and returns
+// the ciphertext blob + base64-encoded key.
+//
+// The caller is responsible for persisting the result: write Blob to disk
+// alongside the function bundle, and surface KeyB64 via the deploy pipeline
+// (typically as a secret env var).
+//
+// Returns an error if the remote fetch, JSON encoding, or AES-GCM sealing
+// fails. ctx is threaded through the underlying fetch where available.
+func BuildBundle(ctx context.Context, opts BuildBundleOptions) (*BuildBundleResult, error) {
+	classify := opts.Classify
+	if classify == nil {
+		classify = defaultClassify
+	}
+
+	client := NewConfigClient(opts.BaseURL, opts.APIKey, opts.OrgID)
+	defer client.Close()
+
+	// Respect ctx cancellation before network work starts. The existing
+	// ConfigClient predates context.Context; cancelling before the fetch
+	// is the cleanest win we can offer without reshaping the client.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("config build bundle: %w", err)
+	}
+
+	values, err := client.GetAllValues(opts.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("config build bundle fetch: %w", err)
+	}
+
+	partitioned := partitionedBundle{
+		Public: make(map[string]any),
+		Secret: make(map[string]any),
+	}
+	skipped := 0
+	for k, v := range values {
+		switch classify(k, v) {
+		case ClassifySkip:
+			skipped++
+		case ClassifySecret:
+			partitioned.Secret[k] = v
+		case ClassifyPublic:
+			partitioned.Public[k] = v
+		default:
+			// Unknown classifier output — treat as public to stay
+			// consistent with TS/Python defaults.
+			partitioned.Public[k] = v
+		}
+	}
+
+	plaintext, err := json.Marshal(partitioned)
+	if err != nil {
+		return nil, fmt.Errorf("config build bundle marshal: %w", err)
+	}
+
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("config build bundle rand key: %w", err)
+	}
+	nonce := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("config build bundle rand nonce: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("config build bundle aes: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("config build bundle gcm: %w", err)
+	}
+
+	// gcm.Seal returns ciphertext||authTag appended to the prefix arg —
+	// reuse that allocation by seeding it with the nonce so the final
+	// slice is nonce || ciphertext || authTag in one go.
+	blob := gcm.Seal(append([]byte(nil), nonce...), nonce, plaintext, nil)
+
+	return &BuildBundleResult{
+		KeyB64:       base64.StdEncoding.EncodeToString(key),
+		Blob:         blob,
+		Size:         int64(len(blob)),
+		KeyCount:     len(partitioned.Public) + len(partitioned.Secret),
+		SkippedCount: skipped,
+	}, nil
+}

--- a/go/config/build_test.go
+++ b/go/config/build_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBuildServer serves a fixed map of values from GetAllValues so
+// BuildBundle can exercise its fetch + encrypt path without touching a
+// real config API.
+func mockBuildServer(t *testing.T, apiKey string, values map[string]any) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/organizations/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+apiKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"values": values}))
+	})
+	return httptest.NewServer(mux)
+}
+
+// decryptBundleForTest inverts the AES-256-GCM seal in BuildBundle so
+// tests can inspect the plaintext without invoking the runtime loader.
+func decryptBundleForTest(t *testing.T, blob []byte, keyB64 string) partitionedBundle {
+	t.Helper()
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	require.NoError(t, err)
+	require.Len(t, key, 32)
+	require.GreaterOrEqual(t, len(blob), 28)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+
+	plaintext, err := gcm.Open(nil, blob[:12], blob[12:], nil)
+	require.NoError(t, err)
+
+	var parsed partitionedBundle
+	require.NoError(t, json.Unmarshal(plaintext, &parsed))
+	return parsed
+}
+
+func TestBuildBundle_DefaultClassifyAllPublic(t *testing.T) {
+	srv := mockBuildServer(t, "test-key", map[string]any{
+		"apiUrl":       "https://api.example.com",
+		"tavilyApiKey": "tvly-abc",
+	})
+	defer srv.Close()
+
+	result, err := BuildBundle(context.Background(), BuildBundleOptions{
+		BaseURL:     srv.URL,
+		APIKey:      "test-key",
+		OrgID:       "org-1",
+		Environment: "production",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// 32-byte key → 44 chars base64.
+	require.Len(t, result.KeyB64, 44)
+	// Round-trip decrypt → both values land in "public" with the default classifier.
+	parsed := decryptBundleForTest(t, result.Blob, result.KeyB64)
+	assert.Equal(t, "https://api.example.com", parsed.Public["apiUrl"])
+	assert.Equal(t, "tvly-abc", parsed.Public["tavilyApiKey"])
+	assert.Empty(t, parsed.Secret)
+	assert.Equal(t, 2, result.KeyCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, int64(len(result.Blob)), result.Size)
+}
+
+func TestBuildBundle_Classifier_PartitionsAndSkips(t *testing.T) {
+	srv := mockBuildServer(t, "test-key", map[string]any{
+		"apiUrl":       "https://api.example.com",
+		"tavilyApiKey": "tvly-abc",
+		"newFlow":      true, // feature flag — should skip
+	})
+	defer srv.Close()
+
+	classify := ClassifyFromSchema(
+		map[string]bool{"apiUrl": true},
+		map[string]bool{"tavilyApiKey": true},
+		map[string]bool{"newFlow": true},
+	)
+
+	result, err := BuildBundle(context.Background(), BuildBundleOptions{
+		BaseURL:  srv.URL,
+		APIKey:   "test-key",
+		OrgID:    "org-1",
+		Classify: classify,
+	})
+	require.NoError(t, err)
+
+	parsed := decryptBundleForTest(t, result.Blob, result.KeyB64)
+	assert.Equal(t, "https://api.example.com", parsed.Public["apiUrl"])
+	assert.NotContains(t, parsed.Public, "tavilyApiKey")
+	assert.Equal(t, "tvly-abc", parsed.Secret["tavilyApiKey"])
+	// Flag dropped.
+	assert.NotContains(t, parsed.Public, "newFlow")
+	assert.NotContains(t, parsed.Secret, "newFlow")
+	assert.Equal(t, 2, result.KeyCount)
+	assert.Equal(t, 1, result.SkippedCount)
+}
+
+func TestBuildBundle_BlobLayoutMatchesTsPython(t *testing.T) {
+	// Minimal sanity check on blob layout: nonce(12) || ct || tag(16).
+	srv := mockBuildServer(t, "test-key", map[string]any{"k": "v"})
+	defer srv.Close()
+
+	result, err := BuildBundle(context.Background(), BuildBundleOptions{
+		BaseURL: srv.URL,
+		APIKey:  "test-key",
+		OrgID:   "org-1",
+	})
+	require.NoError(t, err)
+
+	// Length is nonce(12) + ciphertext(len of plaintext) + tag(16).
+	// Plaintext is JSON of {"public":{"k":"v"},"secret":{}} → 30 bytes.
+	require.Greater(t, len(result.Blob), 28)
+	// The first 12 bytes are the random nonce — just assert they're not
+	// the trailing tag region.
+	assert.NotEqual(t, result.Blob[:12], result.Blob[len(result.Blob)-16:])
+}
+
+func TestBuildBundle_RemoteFetchError(t *testing.T) {
+	// Unauthorized — mock server returns 401.
+	srv := mockBuildServer(t, "wrong-key", map[string]any{"k": "v"})
+	defer srv.Close()
+
+	_, err := BuildBundle(context.Background(), BuildBundleOptions{
+		BaseURL: srv.URL,
+		APIKey:  "test-key",
+		OrgID:   "org-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config build bundle fetch")
+}
+
+func TestBuildBundle_CancelledContext(t *testing.T) {
+	srv := mockBuildServer(t, "test-key", map[string]any{"k": "v"})
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	_, err := BuildBundle(ctx, BuildBundleOptions{
+		BaseURL: srv.URL,
+		APIKey:  "test-key",
+		OrgID:   "org-1",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClassifyFromSchema_SecretWinsOverPublic(t *testing.T) {
+	// When a key is in both maps, secret takes precedence — matches TS.
+	classify := ClassifyFromSchema(
+		map[string]bool{"token": true},
+		map[string]bool{"token": true},
+		nil,
+	)
+	assert.Equal(t, ClassifySecret, classify("token", nil))
+}
+
+func TestClassifyFromSchema_UnknownKeyDefaultsPublic(t *testing.T) {
+	classify := ClassifyFromSchema(nil, nil, nil)
+	assert.Equal(t, ClassifyPublic, classify("anything", nil))
+}

--- a/go/config/config_manager.go
+++ b/go/config/config_manager.go
@@ -41,6 +41,13 @@ type ConfigManager struct {
 
 	// Deferred config values
 	deferred map[string]DeferredValue
+
+	// bakedConfig is an optional pre-decrypted map of remote values,
+	// seeded by NewRuntimeConfigManager from an AES-256-GCM blob. When
+	// set, initialize() uses it in place of the live remote fetch —
+	// env-var overrides still apply on top, file config still layers
+	// underneath, and deferred resolution still runs.
+	bakedConfig map[string]any
 }
 
 // ConfigManagerOption is a functional option for ConfigManager.
@@ -151,42 +158,48 @@ func (m *ConfigManager) initialize() error {
 	}
 	envConfig := findAndProcessEnvConfigWithEnv(schemaKeys, m.envPrefix, m.schemaTypes, env)
 
-	// 3. Try remote fetch if API creds are available
+	// 3. Resolve the "remote" tier — either from a baked blob (when
+	// NewRuntimeConfigManager pre-seeded m.bakedConfig) or via a live
+	// HTTP fetch. Env-var overrides still win on top of this.
 	remoteConfig := make(map[string]any)
 
-	apiKey := m.apiKey
-	baseURL := m.baseURL
-	orgID := m.orgID
+	if m.bakedConfig != nil {
+		remoteConfig = m.bakedConfig
+	} else {
+		apiKey := m.apiKey
+		baseURL := m.baseURL
+		orgID := m.orgID
 
-	// Check env vars as fallback for API credentials
-	if apiKey == "" {
-		apiKey = m.getEnvVal("SMOOAI_CONFIG_API_KEY")
-	}
-	if baseURL == "" {
-		baseURL = m.getEnvVal("SMOOAI_CONFIG_API_URL")
-	}
-	if orgID == "" {
-		orgID = m.getEnvVal("SMOOAI_CONFIG_ORG_ID")
-	}
-
-	if apiKey != "" && baseURL != "" && orgID != "" {
-		// Resolve environment
-		configEnv := m.environment
-		if configEnv == "" {
-			configEnv = m.getEnvVal("SMOOAI_CONFIG_ENV")
+		// Check env vars as fallback for API credentials
+		if apiKey == "" {
+			apiKey = m.getEnvVal("SMOOAI_CONFIG_API_KEY")
 		}
-		if configEnv == "" {
-			configEnv = "development"
+		if baseURL == "" {
+			baseURL = m.getEnvVal("SMOOAI_CONFIG_API_URL")
+		}
+		if orgID == "" {
+			orgID = m.getEnvVal("SMOOAI_CONFIG_ORG_ID")
 		}
 
-		client := NewConfigClient(baseURL, apiKey, orgID)
-		defer client.Close()
+		if apiKey != "" && baseURL != "" && orgID != "" {
+			// Resolve environment
+			configEnv := m.environment
+			if configEnv == "" {
+				configEnv = m.getEnvVal("SMOOAI_CONFIG_ENV")
+			}
+			if configEnv == "" {
+				configEnv = "development"
+			}
 
-		values, err := client.GetAllValues(configEnv)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "[Smooai Config] Warning: Failed to fetch remote config: %v\n", err)
-		} else {
-			remoteConfig = values
+			client := NewConfigClient(baseURL, apiKey, orgID)
+			defer client.Close()
+
+			values, err := client.GetAllValues(configEnv)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[Smooai Config] Warning: Failed to fetch remote config: %v\n", err)
+			} else {
+				remoteConfig = values
+			}
 		}
 	}
 

--- a/go/config/runtime.go
+++ b/go/config/runtime.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Bake-aware runtime hydrator — parity with TS buildConfigRuntime and
+// Python build_config_runtime.
+//
+// Reads a pre-encrypted JSON blob produced by BuildBundle and exposes a
+// fully-hydrated *ConfigManager. The same GetPublicConfig / GetSecretConfig
+// calls then resolve public + secret keys from the in-memory cache — no
+// HTTP round-trip. Feature flags are never baked — the baker skips them,
+// so GetFeatureFlag reads whatever value (if any) lands in the merged
+// config from the env / file tiers.
+//
+// Environment variables (set by the deploy pipeline):
+//
+//	SMOO_CONFIG_KEY_FILE  — absolute path to the encrypted blob on disk
+//	SMOO_CONFIG_KEY       — base64-encoded 32-byte AES-256 key
+//
+//	SMOOAI_CONFIG_API_URL  — for fallback live lookups when no blob is present
+//	SMOOAI_CONFIG_API_KEY
+//	SMOOAI_CONFIG_ORG_ID
+//	SMOOAI_CONFIG_ENV
+//
+// Blob layout (matches TS + Python): nonce (12 bytes) || ciphertext || authTag (16 bytes)
+
+// RuntimeOptions configures NewRuntimeConfigManager. Any of these may be
+// empty — empty strings fall back to SMOOAI_CONFIG_* env vars via the
+// normal ConfigManager defaulting path.
+type RuntimeOptions struct {
+	// KeyFile overrides the SMOO_CONFIG_KEY_FILE env var.
+	KeyFile string
+	// KeyB64 overrides the SMOO_CONFIG_KEY env var.
+	KeyB64 string
+
+	// APIKey, BaseURL, OrgID, Environment configure the fallback live
+	// client used when no blob is present.
+	APIKey      string
+	BaseURL     string
+	OrgID       string
+	Environment string
+
+	// CacheTTL is the cache TTL for per-key lookups. Zero uses the
+	// ConfigManager default (24h).
+	CacheTTL time.Duration
+
+	// EnvOverride replaces os.Getenv lookups (primarily for tests).
+	EnvOverride map[string]string
+
+	// Extra ConfigManager options to layer on. Applied last, so callers
+	// can override any of the defaults derived from RuntimeOptions.
+	Extra []ConfigManagerOption
+}
+
+type decryptedBundle struct {
+	public map[string]any
+	secret map[string]any
+}
+
+// decryptBlobFromEnv reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY (or their
+// explicit overrides) and returns the decrypted {public, secret} map.
+// Returns (nil, nil) when either env var is missing — callers fall back to
+// a plain live-fetching ConfigManager.
+func decryptBlobFromEnv(keyFile, keyB64 string, envOverride map[string]string) (*decryptedBundle, error) {
+	getEnv := func(key string) string {
+		if envOverride != nil {
+			return envOverride[key]
+		}
+		return os.Getenv(key)
+	}
+
+	if keyFile == "" {
+		keyFile = getEnv("SMOO_CONFIG_KEY_FILE")
+	}
+	if keyB64 == "" {
+		keyB64 = getEnv("SMOO_CONFIG_KEY")
+	}
+	if keyFile == "" || keyB64 == "" {
+		return nil, nil
+	}
+
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return nil, fmt.Errorf("smoo-config decode key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("SMOO_CONFIG_KEY must decode to 32 bytes (got %d)", len(key))
+	}
+
+	blob, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("smoo-config read blob: %w", err)
+	}
+	// nonce(12) + minimum ciphertext(0) + tag(16) = 28.
+	if len(blob) < 28 {
+		return nil, fmt.Errorf("smoo-config blob too short (%d bytes)", len(blob))
+	}
+
+	nonce := blob[:12]
+	ciphertextAndTag := blob[12:]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("smoo-config aes: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("smoo-config gcm: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertextAndTag, nil)
+	if err != nil {
+		return nil, fmt.Errorf("smoo-config decrypt: %w", err)
+	}
+
+	var parsed partitionedBundle
+	if err := json.Unmarshal(plaintext, &parsed); err != nil {
+		return nil, fmt.Errorf("smoo-config unmarshal: %w", err)
+	}
+	pub := parsed.Public
+	if pub == nil {
+		pub = map[string]any{}
+	}
+	sec := parsed.Secret
+	if sec == nil {
+		sec = map[string]any{}
+	}
+	return &decryptedBundle{public: pub, secret: sec}, nil
+}
+
+// NewRuntimeConfigManager constructs a ConfigManager seeded from a
+// pre-decrypted baked blob — the bake-aware analogue of NewConfigManager.
+//
+// Behaviour:
+//   - When SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY (or explicit overrides)
+//     resolve to a valid blob, the decrypted {public, secret} map is
+//     installed as the manager's "remote" tier. GetPublicConfig /
+//     GetSecretConfig then resolve from in-memory state with no HTTP
+//     round-trip. Env-var overrides still win, file config still layers
+//     underneath, deferred values still resolve.
+//   - Feature flags are never baked — GetFeatureFlag reads whatever lands
+//     in the merged config from env / file tiers (or undefined).
+//   - When the blob env vars are absent, returns a regular ConfigManager
+//     configured from RuntimeOptions so callers get uniform API semantics
+//     even on dev machines without a baked blob.
+//   - A decryption failure (bad key, truncated blob, tampered bytes) is
+//     returned as an error — the caller chooses whether to fall back or
+//     fail loud. There's no silent-fallback path for tampering.
+func NewRuntimeConfigManager(opts RuntimeOptions) (*ConfigManager, error) {
+	bundle, err := decryptBlobFromEnv(opts.KeyFile, opts.KeyB64, opts.EnvOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	base := []ConfigManagerOption{}
+	if opts.APIKey != "" {
+		base = append(base, WithAPIKey(opts.APIKey))
+	}
+	if opts.BaseURL != "" {
+		base = append(base, WithBaseURL(opts.BaseURL))
+	}
+	if opts.OrgID != "" {
+		base = append(base, WithOrgID(opts.OrgID))
+	}
+	if opts.Environment != "" {
+		base = append(base, WithConfigEnvironment(opts.Environment))
+	}
+	if opts.CacheTTL > 0 {
+		base = append(base, WithCMCacheTTL(opts.CacheTTL))
+	}
+	if opts.EnvOverride != nil {
+		base = append(base, WithCMEnvOverride(opts.EnvOverride))
+	}
+	if bundle != nil {
+		base = append(base, withBakedConfig(bundle))
+	}
+	base = append(base, opts.Extra...)
+
+	return NewConfigManager(base...), nil
+}
+
+// withBakedConfig installs a pre-decrypted public+secret map as the
+// manager's "remote" tier. Package-private: only NewRuntimeConfigManager
+// should call it — the BuildBundle → NewRuntimeConfigManager flow is the
+// only sanctioned path for pre-seeding.
+func withBakedConfig(bundle *decryptedBundle) ConfigManagerOption {
+	merged := make(map[string]any, len(bundle.public)+len(bundle.secret))
+	for k, v := range bundle.public {
+		merged[k] = v
+	}
+	for k, v := range bundle.secret {
+		merged[k] = v
+	}
+	return func(m *ConfigManager) {
+		m.bakedConfig = merged
+	}
+}

--- a/go/config/runtime_test.go
+++ b/go/config/runtime_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encryptSample writes an AES-256-GCM blob matching the BuildBundle layout
+// (nonce || ciphertext || authTag) so tests can exercise the decrypt +
+// hydrate path without standing up a network fetch first.
+func encryptSample(t *testing.T, dir string, partitioned partitionedBundle) (string, string) {
+	t.Helper()
+	plaintext, err := json.Marshal(partitioned)
+	require.NoError(t, err)
+
+	key := make([]byte, 32)
+	_, err = io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+	nonce := make([]byte, 12)
+	_, err = io.ReadFull(rand.Reader, nonce)
+	require.NoError(t, err)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+
+	blob := gcm.Seal(append([]byte(nil), nonce...), nonce, plaintext, nil)
+
+	path := filepath.Join(dir, "smoo-config.enc")
+	require.NoError(t, os.WriteFile(path, blob, 0o600))
+	return path, base64.StdEncoding.EncodeToString(key)
+}
+
+func TestNewRuntimeConfigManager_RoundTripHydratesCache(t *testing.T) {
+	path, keyB64 := encryptSample(t, t.TempDir(), partitionedBundle{
+		Public: map[string]any{"apiUrl": "https://api.example.com"},
+		Secret: map[string]any{"tavilyApiKey": "tvly-abc"},
+	})
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+		// Deliberately no APIKey/BaseURL/OrgID — a baked manager must
+		// never need the network for public/secret reads.
+		EnvOverride: map[string]string{
+			"SMOOAI_CONFIG_ENV": "production",
+		},
+	})
+	require.NoError(t, err)
+
+	pub, err := mgr.GetPublicConfig("apiUrl")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", pub)
+
+	sec, err := mgr.GetSecretConfig("tavilyApiKey")
+	require.NoError(t, err)
+	assert.Equal(t, "tvly-abc", sec)
+}
+
+func TestNewRuntimeConfigManager_WrongKeyRejects(t *testing.T) {
+	path, _ := encryptSample(t, t.TempDir(), partitionedBundle{
+		Public: map[string]any{"k": "v"},
+		Secret: map[string]any{},
+	})
+
+	// Generate an unrelated 32-byte key.
+	wrongKey := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, wrongKey)
+	require.NoError(t, err)
+
+	_, err = NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  base64.StdEncoding.EncodeToString(wrongKey),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt")
+}
+
+func TestNewRuntimeConfigManager_TamperedBlobRejects(t *testing.T) {
+	dir := t.TempDir()
+	path, keyB64 := encryptSample(t, dir, partitionedBundle{
+		Public: map[string]any{"k": "v"},
+		Secret: map[string]any{},
+	})
+
+	// Flip one byte inside the ciphertext (past the 12-byte nonce prefix).
+	blob, err := os.ReadFile(path)
+	require.NoError(t, err)
+	blob[20] ^= 0xff
+	require.NoError(t, os.WriteFile(path, blob, 0o600))
+
+	_, err = NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt")
+}
+
+func TestNewRuntimeConfigManager_ShortBlobRejects(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tiny.enc")
+	require.NoError(t, os.WriteFile(path, []byte("too-short"), 0o600))
+
+	key := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+
+	_, err = NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  base64.StdEncoding.EncodeToString(key),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestNewRuntimeConfigManager_BadKeyLengthRejects(t *testing.T) {
+	path, _ := encryptSample(t, t.TempDir(), partitionedBundle{
+		Public: map[string]any{"k": "v"},
+		Secret: map[string]any{},
+	})
+
+	_, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  base64.StdEncoding.EncodeToString([]byte("short")),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+func TestNewRuntimeConfigManager_NoEnvFallsBackToLiveClient(t *testing.T) {
+	// Without the blob env vars set, the runtime manager should behave
+	// identically to a regular ConfigManager — proving GetPublicConfig
+	// still resolves through the live fetch path.
+	var hits atomic.Int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/organizations/", func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"values": map[string]any{"liveKey": "live-value"},
+		}))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		// No KeyFile/KeyB64 and no SMOO_CONFIG_* env — should fall back
+		// cleanly to a live-fetching ConfigManager.
+		APIKey:      "test-key",
+		BaseURL:     srv.URL,
+		OrgID:       "org-1",
+		Environment: "production",
+		EnvOverride: map[string]string{
+			// Ensure no stray blob env vars leak in from the test runner.
+			"SMOO_CONFIG_KEY_FILE": "",
+			"SMOO_CONFIG_KEY":      "",
+		},
+	})
+	require.NoError(t, err)
+
+	v, err := mgr.GetPublicConfig("liveKey")
+	require.NoError(t, err)
+	assert.Equal(t, "live-value", v)
+	assert.GreaterOrEqual(t, hits.Load(), int64(1))
+}
+
+func TestNewRuntimeConfigManager_EnvVarsOverrideBakedValues(t *testing.T) {
+	// Baked values must still be overridable by env vars — matches the
+	// TS priority chain (env > remote/baked > file).
+	path, keyB64 := encryptSample(t, t.TempDir(), partitionedBundle{
+		Public: map[string]any{"API_URL": "https://baked.example.com"},
+		Secret: map[string]any{},
+	})
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+		EnvOverride: map[string]string{
+			"API_URL": "https://env-wins.example.com",
+		},
+		Extra: []ConfigManagerOption{
+			WithCMSchemaKeys(map[string]bool{"API_URL": true}),
+		},
+	})
+	require.NoError(t, err)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://env-wins.example.com", v)
+}
+
+func TestNewRuntimeConfigManager_FeatureFlagsNotInBlob(t *testing.T) {
+	// Feature flags are never baked into the blob — GetFeatureFlag for a
+	// flag key that was skipped during BuildBundle returns nil from the
+	// merged config.
+	path, keyB64 := encryptSample(t, t.TempDir(), partitionedBundle{
+		Public: map[string]any{"apiUrl": "https://api.example.com"},
+		Secret: map[string]any{},
+	})
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+	})
+	require.NoError(t, err)
+
+	flag, err := mgr.GetFeatureFlag("newFlow")
+	require.NoError(t, err)
+	assert.Nil(t, flag)
+}

--- a/rust/config/Cargo.lock
+++ b/rust/config/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +143,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "deadpool"
@@ -296,6 +370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +401,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -610,6 +704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +939,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +992,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1190,12 +1320,15 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "smooai-config"
 version = "4.2.2"
 dependencies = [
+ "aes-gcm",
+ "base64",
  "percent-encoding",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
  "wiremock",
 ]
@@ -1285,6 +1418,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1429,6 +1582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1598,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1469,6 +1638,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/rust/config/Cargo.toml
+++ b/rust/config/Cargo.toml
@@ -17,6 +17,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 tokio = { version = "1", features = ["full"] }
+aes-gcm = "0.10"
+base64 = "0.22"
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }

--- a/rust/config/src/build.rs
+++ b/rust/config/src/build.rs
@@ -1,0 +1,264 @@
+//! Deploy-time baker for `smooai-config` (Rust parity with TypeScript/Python).
+//!
+//! Fetches every config value for an environment via [`ConfigClient`], partitions
+//! them into `public` and `secret` sections (feature flags are skipped),
+//! JSON-encodes the partition, and encrypts with AES-256-GCM. The caller writes
+//! the resulting blob to disk, ships it with the function bundle, and sets two
+//! environment variables on the runtime:
+//!
+//! ```text
+//! SMOO_CONFIG_KEY_FILE = <absolute path to the blob at runtime>
+//! SMOO_CONFIG_KEY      = <returned key_b64>
+//! ```
+//!
+//! At cold start, [`crate::runtime::build_config_runtime`] reads both and
+//! decrypts once into an in-memory cache.
+//!
+//! Blob layout (wire-compatible with the TypeScript + Python bakers):
+//! `nonce (12 random bytes) || ciphertext || authTag (16 bytes)`.
+
+use std::collections::HashMap;
+
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
+use aes_gcm::{AeadCore, Aes256Gcm, Key, Nonce};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::client::ConfigClient;
+
+/// Classification returned by a [`Classifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Classification {
+    /// Bake into the `public` partition of the blob.
+    Public,
+    /// Bake into the `secret` partition of the blob.
+    Secret,
+    /// Drop — not included in the blob (typically feature flags).
+    Skip,
+}
+
+/// Classifier type: given a key + value, decides which partition the key lands in.
+pub type Classifier = Box<dyn Fn(&str, &Value) -> Classification + Send + Sync>;
+
+/// Inputs for [`build_bundle`]. Mirrors the TypeScript `BuildBundleOptions` shape —
+/// bundles the [`ConfigClient`] connection params plus an optional classifier.
+pub struct BuildBundleOptions {
+    /// Base URL of the config API, e.g. `https://config.smoo.ai`.
+    pub base_url: String,
+    /// Bearer token used to authenticate with the config API.
+    pub api_key: String,
+    /// Organization ID that owns the config values.
+    pub org_id: String,
+    /// Environment to fetch (e.g. `production`, `staging`). Defaults to the
+    /// client's own default environment when `None`.
+    pub environment: Option<String>,
+    /// Per-key classifier. If `None`, every key lands in `public`. Use a
+    /// schema-driven classifier for the typical case — the default is rarely
+    /// what production code wants.
+    pub classify: Option<Classifier>,
+}
+
+/// Output of [`build_bundle`].
+#[derive(Debug)]
+pub struct BuildBundleResult {
+    /// Base64-encoded 32-byte AES-256 key. Set as `SMOO_CONFIG_KEY`.
+    pub key_b64: String,
+    /// Encrypted blob: `nonce || ciphertext || authTag`. Write to disk and
+    /// bundle with the function. Point `SMOO_CONFIG_KEY_FILE` at the path.
+    pub blob: Vec<u8>,
+    /// Size of the blob in bytes.
+    pub size: u64,
+    /// Number of keys baked into the blob (public + secret).
+    pub key_count: usize,
+    /// Number of keys skipped (e.g. feature flags).
+    pub skipped_count: usize,
+}
+
+/// Errors produced by [`build_bundle`].
+#[derive(Debug, Error)]
+pub enum BuildError {
+    /// The live config fetch via [`ConfigClient`] failed.
+    #[error("failed to fetch config values: {0}")]
+    Fetch(#[from] reqwest::Error),
+    /// Serializing the partitioned config to JSON failed.
+    #[error("failed to serialize config values to JSON: {0}")]
+    Serialize(#[from] serde_json::Error),
+    /// AES-GCM encryption failed. In practice this only happens if the AEAD
+    /// implementation itself rejects the inputs — effectively unreachable.
+    #[error("aes-gcm encryption failed: {0}")]
+    Encrypt(String),
+}
+
+/// Fetch + encrypt config values for an environment.
+///
+/// Pulls all values via [`ConfigClient::get_all_values`], runs each through
+/// `options.classify` (default: everything goes into `public`), JSON-encodes
+/// the `{public, secret}` partition, and encrypts with a fresh random 32-byte
+/// AES-256 key + 12-byte nonce. Returns the ciphertext blob and the base64
+/// key so the caller can ship both.
+pub async fn build_bundle(options: BuildBundleOptions) -> Result<BuildBundleResult, BuildError> {
+    let BuildBundleOptions {
+        base_url,
+        api_key,
+        org_id,
+        environment,
+        classify,
+    } = options;
+
+    let mut client = match &environment {
+        Some(env) => ConfigClient::with_environment(&base_url, &api_key, &org_id, env),
+        None => ConfigClient::new(&base_url, &api_key, &org_id),
+    };
+
+    let all = client.get_all_values(environment.as_deref()).await?;
+
+    let mut public_map: HashMap<String, Value> = HashMap::new();
+    let mut secret_map: HashMap<String, Value> = HashMap::new();
+    let mut skipped_count: usize = 0;
+
+    for (key, value) in all {
+        let section = match classify {
+            Some(ref f) => f(&key, &value),
+            None => Classification::Public,
+        };
+        match section {
+            Classification::Public => {
+                public_map.insert(key, value);
+            }
+            Classification::Secret => {
+                secret_map.insert(key, value);
+            }
+            Classification::Skip => {
+                skipped_count += 1;
+            }
+        }
+    }
+
+    let key_count = public_map.len() + secret_map.len();
+
+    // Serialize the partition with a stable shape that the hydrator can parse.
+    let partitioned = serde_json::json!({
+        "public": public_map,
+        "secret": secret_map,
+    });
+    let plaintext = serde_json::to_vec(&partitioned)?;
+
+    // Generate key and nonce.
+    let key_bytes: [u8; 32] = {
+        let k = Aes256Gcm::generate_key(&mut OsRng);
+        k.into()
+    };
+    let nonce_bytes: [u8; 12] = {
+        let n = Aes256Gcm::generate_nonce(&mut OsRng);
+        n.into()
+    };
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext_and_tag = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: &plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(|e| BuildError::Encrypt(e.to_string()))?;
+
+    // Blob layout: nonce || ciphertext || authTag. aes-gcm returns ciphertext
+    // with the 16-byte tag already appended, matching the TS and Python wire
+    // format.
+    let mut blob = Vec::with_capacity(nonce_bytes.len() + ciphertext_and_tag.len());
+    blob.extend_from_slice(&nonce_bytes);
+    blob.extend_from_slice(&ciphertext_and_tag);
+
+    let size = blob.len() as u64;
+    let key_b64 = B64.encode(key_bytes);
+
+    Ok(BuildBundleResult {
+        key_b64,
+        blob,
+        size,
+        key_count,
+        skipped_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path_regex, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn build_bundle_encrypts_and_reports_counts() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/organizations/.+/config/values"))
+            .and(query_param("environment", "production"))
+            .and(header("Authorization", "Bearer test-api-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": {
+                    "apiUrl": "https://api.example.com",
+                    "tavilyApiKey": "tvly-abc",
+                    "newFlow": true,
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let classify: Classifier = Box::new(|key, _v| match key {
+            "tavilyApiKey" => Classification::Secret,
+            "newFlow" => Classification::Skip,
+            _ => Classification::Public,
+        });
+
+        let result = build_bundle(BuildBundleOptions {
+            base_url: mock_server.uri(),
+            api_key: "test-api-key".to_string(),
+            org_id: "test-org".to_string(),
+            environment: Some("production".to_string()),
+            classify: Some(classify),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result.key_count, 2); // apiUrl + tavilyApiKey
+        assert_eq!(result.skipped_count, 1); // newFlow
+        assert!(result.blob.len() > 12 + 16); // nonce + tag at minimum
+        assert_eq!(result.size, result.blob.len() as u64);
+        // key_b64 decodes to exactly 32 bytes
+        let key = B64.decode(&result.key_b64).unwrap();
+        assert_eq!(key.len(), 32);
+    }
+
+    #[tokio::test]
+    async fn build_bundle_default_classifier_makes_everything_public() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/organizations/.+/config/values"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": {"FOO": "bar", "BAZ": 42}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = build_bundle(BuildBundleOptions {
+            base_url: mock_server.uri(),
+            api_key: "k".to_string(),
+            org_id: "o".to_string(),
+            environment: Some("test".to_string()),
+            classify: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result.key_count, 2);
+        assert_eq!(result.skipped_count, 0);
+    }
+}

--- a/rust/config/src/config_manager.rs
+++ b/rust/config/src/config_manager.rs
@@ -323,6 +323,27 @@ impl ConfigManager {
             inner.feature_flag_cache.clear();
         }
     }
+
+    /// Seed the manager's merged config map directly and mark it initialized.
+    ///
+    /// Used by the bake-aware runtime ([`crate::runtime::build_config_runtime`])
+    /// to hydrate public + secret values from a pre-decrypted blob, bypassing
+    /// the normal file/env/remote merge pipeline. After seeding, public and
+    /// secret lookups hit the in-memory map synchronously. Feature flags are
+    /// intentionally omitted from the blob and still fall through to whatever
+    /// live-fetch path the consumer has configured.
+    pub fn seed_from_baked(&self, values: HashMap<String, Value>) -> Result<(), SmooaiConfigError> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| SmooaiConfigError::new("Failed to acquire write lock"))?;
+        inner.config = values;
+        inner.public_cache.clear();
+        inner.secret_cache.clear();
+        inner.feature_flag_cache.clear();
+        inner.initialized = true;
+        Ok(())
+    }
 }
 
 impl Default for ConfigManager {

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides schema definition, JSON Schema generation, runtime config client,
 //! and local file/env-based configuration with caching.
 
+pub mod build;
 pub mod client;
 pub mod cloud_region;
 pub mod config_manager;
@@ -11,10 +12,12 @@ pub mod env_config;
 pub mod file_config;
 pub mod local;
 pub mod merge;
+pub mod runtime;
 pub mod schema;
 pub mod schema_validator;
 pub mod utils;
 
+pub use build::{build_bundle, BuildBundleOptions, BuildBundleResult, BuildError, Classification, Classifier};
 pub use client::ConfigClient;
 pub use cloud_region::{get_cloud_region, get_cloud_region_from_env, CloudRegionResult};
 pub use config_manager::ConfigManager;
@@ -22,4 +25,5 @@ pub use env_config::find_and_process_env_config;
 pub use file_config::{find_and_process_file_config, find_config_directory};
 pub use local::LocalConfigManager;
 pub use merge::merge_replace_arrays;
+pub use runtime::{build_config_runtime, read_baked_config, BakedConfig, RuntimeError, RuntimeOptions};
 pub use utils::{camel_to_upper_snake, coerce_boolean, SmooaiConfigError};

--- a/rust/config/src/runtime.rs
+++ b/rust/config/src/runtime.rs
@@ -1,0 +1,507 @@
+//! Bake-aware runtime hydrator for `smooai-config` (Rust parity with TypeScript/Python).
+//!
+//! Reads a pre-encrypted blob produced by [`crate::build::build_bundle`] and
+//! exposes sync accessors by seeding a [`ConfigManager`]'s merged-config map.
+//! The library API stays uniform — consumers always call
+//! `manager.get_public_config(key)` / `manager.get_secret_config(key)`
+//! regardless of whether the data came from the baked blob or a live fetch.
+//!
+//! - Public + secret values hydrate from the blob (sync, no network)
+//! - Feature flags are never baked — they stay live-fetched through the
+//!   normal [`ConfigManager`] merge pipeline when env vars are absent.
+//!
+//! Environment variables (set by the deploy pipeline):
+//!
+//! ```text
+//! SMOO_CONFIG_KEY_FILE  — absolute path to the encrypted blob on disk
+//! SMOO_CONFIG_KEY       — base64-encoded 32-byte AES-256 key
+//! ```
+//!
+//! Blob layout (matches TypeScript + Python):
+//! `nonce (12 bytes) || ciphertext || authTag (16 bytes)`.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::config_manager::ConfigManager;
+
+/// Options for [`build_config_runtime`]. All fields optional — the function
+/// falls back to environment variables / defaults for anything left unset.
+#[derive(Default)]
+pub struct RuntimeOptions {
+    /// Override `SMOO_CONFIG_KEY_FILE` (blob path on disk).
+    pub key_file: Option<PathBuf>,
+    /// Override `SMOO_CONFIG_KEY` (base64 AES-256 key).
+    pub key_b64: Option<String>,
+    /// Override the `ConfigManager`'s environment name (e.g. `production`).
+    pub environment: Option<String>,
+}
+
+/// Errors produced by [`build_config_runtime`] and related helpers.
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    /// The key file pointed to by `SMOO_CONFIG_KEY_FILE` could not be read.
+    #[error("failed to read config key file {path}: {source}")]
+    KeyFileRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// `SMOO_CONFIG_KEY` was not valid base64.
+    #[error("SMOO_CONFIG_KEY is not valid base64: {0}")]
+    InvalidKeyBase64(#[from] base64::DecodeError),
+    /// `SMOO_CONFIG_KEY` decoded to something other than 32 bytes.
+    #[error("SMOO_CONFIG_KEY must decode to 32 bytes (got {0})")]
+    InvalidKeyLength(usize),
+    /// The blob is shorter than the minimum possible layout.
+    #[error("smoo-config blob too short ({0} bytes)")]
+    BlobTooShort(usize),
+    /// AES-GCM authentication / decryption failed. Either the key is wrong or
+    /// the blob has been tampered with.
+    #[error("aes-gcm decryption failed (wrong key or tampered blob)")]
+    Decrypt,
+    /// The decrypted plaintext was not valid JSON with the expected shape.
+    #[error("failed to parse decrypted config JSON: {0}")]
+    ParseJson(#[from] serde_json::Error),
+    /// Seeding the [`ConfigManager`] failed (lock poisoning).
+    #[error("failed to seed ConfigManager: {0}")]
+    Seed(String),
+}
+
+/// Decrypt a baked blob if the required env vars / overrides are present.
+///
+/// Returns `Ok(None)` when no blob is configured — the caller should fall back
+/// to a live-fetch [`ConfigManager`]. Returns `Ok(Some({public, secret}))` on
+/// success, where each inner map is the decrypted JSON section.
+pub fn read_baked_config(opts: &RuntimeOptions) -> Result<Option<BakedConfig>, RuntimeError> {
+    let key_file = opts
+        .key_file
+        .clone()
+        .or_else(|| env::var_os("SMOO_CONFIG_KEY_FILE").map(PathBuf::from));
+    let key_b64 = opts.key_b64.clone().or_else(|| env::var("SMOO_CONFIG_KEY").ok());
+
+    let (Some(key_file), Some(key_b64)) = (key_file, key_b64) else {
+        return Ok(None);
+    };
+
+    let key = B64.decode(key_b64.as_bytes())?;
+    if key.len() != 32 {
+        return Err(RuntimeError::InvalidKeyLength(key.len()));
+    }
+
+    let blob = fs::read(&key_file).map_err(|source| RuntimeError::KeyFileRead {
+        path: key_file.clone(),
+        source,
+    })?;
+
+    decrypt_blob(&key, &blob).map(Some)
+}
+
+/// Decrypted `{public, secret}` partition from a baked blob.
+#[derive(Debug, Default, Clone)]
+pub struct BakedConfig {
+    pub public: HashMap<String, Value>,
+    pub secret: HashMap<String, Value>,
+}
+
+impl BakedConfig {
+    /// Total number of baked entries (public + secret).
+    pub fn len(&self) -> usize {
+        self.public.len() + self.secret.len()
+    }
+
+    /// Whether the baked config contains zero entries.
+    pub fn is_empty(&self) -> bool {
+        self.public.is_empty() && self.secret.is_empty()
+    }
+
+    /// Merge public + secret into a single flat map. Secret keys win on
+    /// collisions, matching the TS/Python hydrator semantics.
+    pub fn into_merged(self) -> HashMap<String, Value> {
+        let mut merged = self.public;
+        for (k, v) in self.secret {
+            merged.insert(k, v);
+        }
+        merged
+    }
+}
+
+fn decrypt_blob(key: &[u8], blob: &[u8]) -> Result<BakedConfig, RuntimeError> {
+    // Minimum layout: 12-byte nonce + 16-byte tag = 28 bytes before any ciphertext.
+    if blob.len() < 12 + 16 {
+        return Err(RuntimeError::BlobTooShort(blob.len()));
+    }
+    let (nonce_bytes, ciphertext_and_tag) = blob.split_at(12);
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let plaintext = cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: ciphertext_and_tag,
+                aad: &[],
+            },
+        )
+        .map_err(|_| RuntimeError::Decrypt)?;
+
+    #[derive(serde::Deserialize, Default)]
+    struct Partitioned {
+        #[serde(default)]
+        public: HashMap<String, Value>,
+        #[serde(default)]
+        secret: HashMap<String, Value>,
+    }
+    let parsed: Partitioned = serde_json::from_slice(&plaintext)?;
+    Ok(BakedConfig {
+        public: parsed.public,
+        secret: parsed.secret,
+    })
+}
+
+/// Build a bake-aware [`ConfigManager`].
+///
+/// Reads `SMOO_CONFIG_KEY_FILE` + `SMOO_CONFIG_KEY` at cold start and seeds a
+/// fresh [`ConfigManager`] with the decrypted public + secret values. If
+/// either env var is missing, returns a plain [`ConfigManager`] that lazily
+/// loads from file/env/remote on first access — preserving a graceful fallback
+/// path for local development.
+///
+/// Feature flags are never baked; the [`ConfigManager`] falls through to the
+/// live-fetch pipeline for `get_feature_flag` calls when no seeded entry
+/// exists.
+pub async fn build_config_runtime(opts: RuntimeOptions) -> Result<ConfigManager, RuntimeError> {
+    let mut manager = ConfigManager::new();
+    if let Some(env) = opts.environment.as_deref() {
+        manager = manager.with_environment(env);
+    }
+
+    match read_baked_config(&opts)? {
+        Some(baked) => {
+            let merged = baked.into_merged();
+            manager
+                .seed_from_baked(merged)
+                .map_err(|e| RuntimeError::Seed(e.to_string()))?;
+        }
+        None => {
+            // No blob configured — caller gets a live-fetch manager. Nothing
+            // else to do here; lazy init will pull from file/env/remote on
+            // first access.
+        }
+    }
+
+    Ok(manager)
+}
+
+/// Convenience: decrypt a blob from an explicit path + key, bypassing env vars.
+///
+/// Mostly useful for tests and one-off scripts. Prefer
+/// [`build_config_runtime`] in production code.
+pub fn read_baked_config_from(path: &Path, key_b64: &str) -> Result<BakedConfig, RuntimeError> {
+    let key = B64.decode(key_b64.as_bytes())?;
+    if key.len() != 32 {
+        return Err(RuntimeError::InvalidKeyLength(key.len()));
+    }
+    let blob = fs::read(path).map_err(|source| RuntimeError::KeyFileRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    decrypt_blob(&key, &blob)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build::{build_bundle, BuildBundleOptions, Classification, Classifier};
+    use std::io::Write;
+    use wiremock::matchers::{header, method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // --- Helpers ---
+
+    async fn bake_fixture(values: serde_json::Value, classify: Option<Classifier>) -> (String, Vec<u8>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/organizations/.+/config/values"))
+            .and(header("Authorization", "Bearer test-api-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": values
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = build_bundle(BuildBundleOptions {
+            base_url: mock_server.uri(),
+            api_key: "test-api-key".to_string(),
+            org_id: "test-org".to_string(),
+            environment: Some("test".to_string()),
+            classify,
+        })
+        .await
+        .unwrap();
+
+        (result.key_b64, result.blob)
+    }
+
+    fn write_blob(dir: &tempfile::TempDir, blob: &[u8]) -> PathBuf {
+        let path = dir.path().join("smoo-config.enc");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(blob).unwrap();
+        path
+    }
+
+    // --- Test: round-trip bake → hydrate → retrieve ---
+    #[tokio::test]
+    async fn round_trip_bake_hydrate() {
+        let classify: Classifier = Box::new(|key, _v| match key {
+            "tavilyApiKey" => Classification::Secret,
+            _ => Classification::Public,
+        });
+
+        let (key_b64, blob) = bake_fixture(
+            serde_json::json!({
+                "apiUrl": "https://api.example.com",
+                "tavilyApiKey": "tvly-abc",
+            }),
+            Some(classify),
+        )
+        .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob_path = write_blob(&dir, &blob);
+
+        let manager = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            key_b64: Some(key_b64),
+            environment: Some("test".to_string()),
+        })
+        .await
+        .unwrap();
+
+        // Public + secret both retrievable via sync accessors (no network).
+        assert_eq!(
+            manager.get_public_config("apiUrl").unwrap(),
+            Some(serde_json::json!("https://api.example.com"))
+        );
+        assert_eq!(
+            manager.get_secret_config("tavilyApiKey").unwrap(),
+            Some(serde_json::json!("tvly-abc"))
+        );
+    }
+
+    // --- Test: wrong key rejects via AES-GCM tag verification ---
+    #[tokio::test]
+    async fn wrong_key_rejects() {
+        let (_key_b64, blob) = bake_fixture(serde_json::json!({"apiUrl": "https://api.example.com"}), None).await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob_path = write_blob(&dir, &blob);
+
+        // Random wrong key of the correct length (32 bytes).
+        let wrong_key = B64.encode([0xFFu8; 32]);
+
+        let result = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            key_b64: Some(wrong_key),
+            environment: None,
+        })
+        .await;
+
+        match result {
+            Err(RuntimeError::Decrypt) => {}
+            other => panic!("expected Decrypt error, got: {:?}", other.err()),
+        }
+    }
+
+    // --- Test: tampered blob rejects ---
+    #[tokio::test]
+    async fn tampered_blob_rejects() {
+        let (key_b64, mut blob) = bake_fixture(serde_json::json!({"apiUrl": "https://api.example.com"}), None).await;
+
+        // Flip a byte in the ciphertext region (past the 12-byte nonce).
+        blob[20] ^= 0x01;
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob_path = write_blob(&dir, &blob);
+
+        let result = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            key_b64: Some(key_b64),
+            environment: None,
+        })
+        .await;
+
+        match result {
+            Err(RuntimeError::Decrypt) => {}
+            other => panic!("expected Decrypt error, got: {:?}", other.err()),
+        }
+    }
+
+    // --- Test: missing key file falls back gracefully (no blob loaded) ---
+    #[tokio::test]
+    async fn missing_env_falls_back_gracefully() {
+        // Both env vars unset — no override either — should succeed and
+        // return a live-fetch ConfigManager with no seeded state.
+        // Guard the real env to avoid interference from the caller's shell.
+        let prev_file = env::var_os("SMOO_CONFIG_KEY_FILE");
+        let prev_key = env::var_os("SMOO_CONFIG_KEY");
+        // SAFETY: tests in this module run single-threaded relative to these
+        // env vars. We restore the prior values at the end.
+        unsafe {
+            env::remove_var("SMOO_CONFIG_KEY_FILE");
+            env::remove_var("SMOO_CONFIG_KEY");
+        }
+
+        let result = build_config_runtime(RuntimeOptions::default()).await;
+
+        // Restore before asserting to keep failure output clean.
+        unsafe {
+            if let Some(v) = prev_file {
+                env::set_var("SMOO_CONFIG_KEY_FILE", v);
+            }
+            if let Some(v) = prev_key {
+                env::set_var("SMOO_CONFIG_KEY", v);
+            }
+        }
+
+        let _manager = result.expect("should return a live-fetch manager with no error");
+    }
+
+    // --- Test: missing key file (path does not exist) is a hard error ---
+    #[tokio::test]
+    async fn missing_key_file_path_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let nonexistent = dir.path().join("does-not-exist.enc");
+
+        let result = build_config_runtime(RuntimeOptions {
+            key_file: Some(nonexistent),
+            key_b64: Some(B64.encode([0u8; 32])),
+            environment: None,
+        })
+        .await;
+
+        match result {
+            Err(RuntimeError::KeyFileRead { .. }) => {}
+            other => panic!("expected KeyFileRead error, got: {:?}", other.err()),
+        }
+    }
+
+    // --- Test: invalid key length ---
+    #[tokio::test]
+    async fn invalid_key_length_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_path = write_blob(&dir, &[0u8; 64]);
+
+        let result = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            // 16-byte key, not 32.
+            key_b64: Some(B64.encode([0u8; 16])),
+            environment: None,
+        })
+        .await;
+
+        match result {
+            Err(RuntimeError::InvalidKeyLength(16)) => {}
+            other => panic!("expected InvalidKeyLength(16), got: {:?}", other.err()),
+        }
+    }
+
+    // --- Test: classifier skip logic — feature flags dropped from blob ---
+    #[tokio::test]
+    async fn classifier_skip_drops_feature_flags() {
+        let classify: Classifier = Box::new(|key, _v| match key {
+            "apiUrl" => Classification::Public,
+            "dbPassword" => Classification::Secret,
+            "newFlow" => Classification::Skip,
+            _ => Classification::Public,
+        });
+
+        let (key_b64, blob) = bake_fixture(
+            serde_json::json!({
+                "apiUrl": "https://api.example.com",
+                "dbPassword": "super-secret",
+                "newFlow": true,
+            }),
+            Some(classify),
+        )
+        .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob_path = write_blob(&dir, &blob);
+
+        let manager = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            key_b64: Some(key_b64),
+            environment: Some("test".to_string()),
+        })
+        .await
+        .unwrap();
+
+        // Public + secret are in the seeded map.
+        assert_eq!(
+            manager.get_public_config("apiUrl").unwrap(),
+            Some(serde_json::json!("https://api.example.com"))
+        );
+        assert_eq!(
+            manager.get_secret_config("dbPassword").unwrap(),
+            Some(serde_json::json!("super-secret"))
+        );
+        // Feature flag was dropped — not in the seeded config.
+        assert_eq!(manager.get_feature_flag("newFlow").unwrap(), None);
+    }
+
+    // --- Test: blob too short ---
+    #[tokio::test]
+    async fn blob_too_short_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        // Only 10 bytes — below the 28-byte minimum (12 nonce + 16 tag).
+        let blob_path = write_blob(&dir, &[0u8; 10]);
+
+        let result = build_config_runtime(RuntimeOptions {
+            key_file: Some(blob_path),
+            key_b64: Some(B64.encode([0u8; 32])),
+            environment: None,
+        })
+        .await;
+
+        match result {
+            Err(RuntimeError::BlobTooShort(10)) => {}
+            other => panic!("expected BlobTooShort(10), got: {:?}", other.err()),
+        }
+    }
+
+    // --- Test: read_baked_config returns None when opts/env both absent ---
+    #[tokio::test]
+    async fn read_baked_config_returns_none_without_env() {
+        // Guard real env to keep the test hermetic.
+        let prev_file = env::var_os("SMOO_CONFIG_KEY_FILE");
+        let prev_key = env::var_os("SMOO_CONFIG_KEY");
+        unsafe {
+            env::remove_var("SMOO_CONFIG_KEY_FILE");
+            env::remove_var("SMOO_CONFIG_KEY");
+        }
+
+        let result = read_baked_config(&RuntimeOptions::default());
+
+        unsafe {
+            if let Some(v) = prev_file {
+                env::set_var("SMOO_CONFIG_KEY_FILE", v);
+            }
+            if let Some(v) = prev_key {
+                env::set_var("SMOO_CONFIG_KEY", v);
+            }
+        }
+
+        assert!(result.unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Brings Rust and Go @smooai/config clients up to parity with TypeScript + Python on the **bake-aware runtime**: deploy-time `buildBundle` baker + cold-start `buildConfigRuntime` hydrator. Public + secret config values now hydrate from a pre-encrypted blob (sync, no network) in both languages. Feature flags intentionally stay live (never baked).

Closes two of the three sub-tickets under SMOODEV-615:
- **SMOODEV-625** — Go (`go/config/build.go`, `go/config/runtime.go`)
- **SMOODEV-626** — Rust (`rust/config/src/build.rs`, `rust/config/src/runtime.rs`)

Third sub-ticket **SMOODEV-624** (cohort-context arg on `get_feature_flag`) remains open — tracked separately.

## Blob layout (matches TS + Python exactly)

```
nonce (12 bytes) || ciphertext || authTag (16 bytes)
```

AES-256-GCM, 32-byte random key (base64 for transport). Wrong key or tampered blob rejects via GCM auth-tag verification.

## Env-var contract

- `SMOO_CONFIG_KEY_FILE` — path to encrypted blob on disk
- `SMOO_CONFIG_KEY` — base64-encoded 32-byte AES-256 key

Both langs fall back to a regular live-fetching client when env vars are missing.

## Implementation notes

- **Go:** Uses stdlib `crypto/cipher.NewGCM` — no new deps. `Classifier` func type for partition (`ClassifyPublic | ClassifySecret | ClassifySkip`). Pre-seeded map installed as the manager's "remote" tier so env overrides + file tiers still win.
- **Rust:** Adds `aes-gcm = "0.10"`, `base64 = "0.22"`, `thiserror = "1"` deps. `Classifier` as `Option<Box<dyn Fn + Send + Sync>>`. New `ConfigManager::seed_from_baked` method hydrates the internal merged-config map directly (matches Rust's sync-accessor architecture).

## Test plan

- [x] Go: 15 new tests — round-trip, wrong-key, tampered, short-blob, bad-key-length, missing-env fallback, env-overrides-baked, flags-not-in-blob
- [x] Rust: 11 new tests — same scenarios + `read_baked_config` helper coverage
- [x] Full suites pass: Go `go test -count=1 ./...` green, Rust `cargo test --release` 184 tests, `cargo clippy -- -D warnings` clean
- [x] Pre-commit hook (`pnpm lint:fix && typecheck && test && build && format`) green on combined state

🤖 Generated with [Claude Code](https://claude.com/claude-code)