### PR TITLE
SMOODEV-624: Cohort-aware feature-flag evaluator — Python, Rust, Go parity

### DIFF
--- a/go/config/client.go
+++ b/go/config/client.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -222,4 +225,176 @@ func (c *ConfigClient) InvalidateCacheForEnvironment(environment string) {
 // Close releases resources held by the client.
 func (c *ConfigClient) Close() {
 	c.client.CloseIdleConnections()
+}
+
+// EvaluateFeatureFlagResponse is the wire contract for the cohort-aware
+// feature-flag evaluator. It mirrors the TS `EvaluateFeatureFlagResponse`
+// and the schema defined in `@smooai/schemas/config/feature-flag`.
+type EvaluateFeatureFlagResponse struct {
+	// Value is the resolved flag value (post rules + rollout).
+	Value any `json:"value"`
+	// MatchedRuleID is the id of the rule that fired, if any.
+	MatchedRuleID *string `json:"matchedRuleId,omitempty"`
+	// RolloutBucket is the 0-99 bucket the context was assigned to, if a rollout ran.
+	RolloutBucket *int `json:"rolloutBucket,omitempty"`
+	// Source is which branch the evaluator returned from: "raw" | "rule" | "rollout" | "default".
+	Source string `json:"source"`
+}
+
+// FeatureFlagErrorKind categorizes errors from EvaluateFeatureFlag so callers
+// can branch on 404 / 400 / 5xx without parsing messages.
+type FeatureFlagErrorKind int
+
+const (
+	// FeatureFlagKindServer covers 5xx responses and any non-404 / non-400 HTTP errors.
+	FeatureFlagKindServer FeatureFlagErrorKind = iota
+	// FeatureFlagKindNotFound is a 404 — the flag key is not defined in the org's schema.
+	FeatureFlagKindNotFound
+	// FeatureFlagKindContext is a 400 — invalid context or missing environment.
+	FeatureFlagKindContext
+)
+
+// String returns the lowercase name of the kind. Handy for logs.
+func (k FeatureFlagErrorKind) String() string {
+	switch k {
+	case FeatureFlagKindNotFound:
+		return "not_found"
+	case FeatureFlagKindContext:
+		return "context"
+	default:
+		return "server"
+	}
+}
+
+// Sentinel errors so callers can use `errors.Is` to match an error category
+// without taking a dependency on the concrete `FeatureFlagEvaluationError`.
+var (
+	// ErrFeatureFlagNotFound matches any FeatureFlagEvaluationError with Kind == FeatureFlagKindNotFound.
+	ErrFeatureFlagNotFound = errors.New("feature flag not found")
+	// ErrFeatureFlagContext matches any FeatureFlagEvaluationError with Kind == FeatureFlagKindContext.
+	ErrFeatureFlagContext = errors.New("feature flag context invalid")
+	// ErrFeatureFlagServer matches any FeatureFlagEvaluationError with Kind == FeatureFlagKindServer.
+	ErrFeatureFlagServer = errors.New("feature flag server error")
+)
+
+// FeatureFlagEvaluationError is returned from EvaluateFeatureFlag when the
+// server rejects the request or returns a non-2xx status. Use the Kind field
+// (or errors.Is with the sentinel vars) to branch on 404 / 400 / 5xx.
+type FeatureFlagEvaluationError struct {
+	// Key is the feature-flag key the caller asked to evaluate.
+	Key string
+	// StatusCode is the HTTP status returned by the server.
+	StatusCode int
+	// Kind categorizes the error (not found / context / server).
+	Kind FeatureFlagErrorKind
+	// ServerMessage is the raw response body text, if any.
+	ServerMessage string
+}
+
+// Error implements the error interface.
+func (e *FeatureFlagEvaluationError) Error() string {
+	if e.ServerMessage != "" {
+		return fmt.Sprintf("feature flag %q evaluation failed: HTTP %d — %s", e.Key, e.StatusCode, e.ServerMessage)
+	}
+	return fmt.Sprintf("feature flag %q evaluation failed: HTTP %d", e.Key, e.StatusCode)
+}
+
+// Is supports errors.Is matching against the sentinel errors above.
+func (e *FeatureFlagEvaluationError) Is(target error) bool {
+	switch target {
+	case ErrFeatureFlagNotFound:
+		return e.Kind == FeatureFlagKindNotFound
+	case ErrFeatureFlagContext:
+		return e.Kind == FeatureFlagKindContext
+	case ErrFeatureFlagServer:
+		return e.Kind == FeatureFlagKindServer
+	}
+	return false
+}
+
+// EvaluateFeatureFlag evaluates a cohort-aware feature flag against the server.
+//
+// Unlike GetValue, this is always a network call: cohort rules (percentage
+// rollout, attribute matching, bucketing) live server-side and the response
+// depends on the `evalContext` you pass. Callers that don't need cohort
+// evaluation should keep using GetValue for the static flag value.
+//
+// Parameters:
+//   - ctx: standard context for cancellation / deadline.
+//   - key: feature-flag key.
+//   - evalContext: attributes the server's cohort rules may reference
+//     (e.g. {userId, tenantId, plan, country}). Unreferenced keys are ignored
+//     by the server. Keep values JSON-serializable — the server hashes
+//     `bucketBy` values by their string representation, so numbers and
+//     booleans bucket stably across client rebuilds. A nil map is sent as {}.
+//   - environment: environment name. Pass an empty string to use the client's
+//     default environment.
+//
+// Errors:
+//   - *FeatureFlagEvaluationError with Kind == FeatureFlagKindNotFound on 404.
+//   - *FeatureFlagEvaluationError with Kind == FeatureFlagKindContext on 400.
+//   - *FeatureFlagEvaluationError with Kind == FeatureFlagKindServer for 5xx
+//     and other non-2xx responses.
+//   - Wrapped network / decode errors from the underlying HTTP client.
+func (c *ConfigClient) EvaluateFeatureFlag(
+	ctx context.Context,
+	key string,
+	evalContext map[string]any,
+	environment string,
+) (*EvaluateFeatureFlagResponse, error) {
+	env := c.resolveEnv(environment)
+
+	if evalContext == nil {
+		evalContext = map[string]any{}
+	}
+
+	body, err := json.Marshal(struct {
+		Environment string         `json:"environment"`
+		Context     map[string]any `json:"context"`
+	}{
+		Environment: env,
+		Context:     evalContext,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag %q: marshal body: %w", key, err)
+	}
+
+	u := fmt.Sprintf("%s/organizations/%s/config/feature-flags/%s/evaluate",
+		c.baseURL, c.orgID, url.PathEscape(key))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag %q: build request: %w", key, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag %q: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		kind := FeatureFlagKindServer
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			kind = FeatureFlagKindNotFound
+		case http.StatusBadRequest:
+			kind = FeatureFlagKindContext
+		}
+		return nil, &FeatureFlagEvaluationError{
+			Key:           key,
+			StatusCode:    resp.StatusCode,
+			Kind:          kind,
+			ServerMessage: strings.TrimSpace(string(msg)),
+		}
+	}
+
+	var result EvaluateFeatureFlagResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("config evaluate feature flag %q: decode response: %w", key, err)
+	}
+
+	return &result, nil
 }

--- a/go/config/feature_flag_evaluate_test.go
+++ b/go/config/feature_flag_evaluate_test.go
@@ -1,0 +1,320 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper to build a canned evaluator response
+func encodeEvalResponse(t *testing.T, w http.ResponseWriter, resp EvaluateFeatureFlagResponse) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(resp))
+}
+
+func TestEvaluateFeatureFlag_PostsExpectedBodyAndHeaders(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotContentType string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{
+			Value:  true,
+			Source: "rule",
+		})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "secret-key", "org-abc")
+	defer client.Close()
+
+	ctx := context.Background()
+	resp, err := client.EvaluateFeatureFlag(ctx, "new_dashboard", map[string]any{
+		"userId": "u-1",
+		"plan":   "pro",
+	}, "production")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/organizations/org-abc/config/feature-flags/new_dashboard/evaluate", gotPath)
+	assert.Equal(t, "Bearer secret-key", gotAuth)
+	assert.Equal(t, "application/json", gotContentType)
+
+	assert.Equal(t, "production", gotBody["environment"])
+	require.IsType(t, map[string]any{}, gotBody["context"])
+	gotCtx := gotBody["context"].(map[string]any)
+	assert.Equal(t, "u-1", gotCtx["userId"])
+	assert.Equal(t, "pro", gotCtx["plan"])
+
+	assert.Equal(t, true, resp.Value)
+	assert.Equal(t, "rule", resp.Source)
+}
+
+func TestEvaluateFeatureFlag_NilContextSerializesAsEmptyObject(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{Value: false, Source: "default"})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "flag", nil, "production")
+	require.NoError(t, err)
+
+	require.Contains(t, gotBody, "context")
+	ctxField, ok := gotBody["context"].(map[string]any)
+	require.True(t, ok, "context should be a JSON object, got %T", gotBody["context"])
+	assert.Empty(t, ctxField)
+}
+
+func TestEvaluateFeatureFlag_UsesDefaultEnvironmentWhenEmpty(t *testing.T) {
+	t.Setenv("SMOOAI_CONFIG_ENV", "staging")
+
+	var gotEnv string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotEnv, _ = body["environment"].(string)
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{Value: "on", Source: "raw"})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "flag", map[string]any{}, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "staging", gotEnv)
+}
+
+func TestEvaluateFeatureFlag_EnvironmentOverrideWins(t *testing.T) {
+	t.Setenv("SMOOAI_CONFIG_ENV", "staging")
+
+	var gotEnv string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotEnv, _ = body["environment"].(string)
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{Value: "x", Source: "raw"})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "flag", nil, "production")
+	require.NoError(t, err)
+	assert.Equal(t, "production", gotEnv)
+}
+
+func TestEvaluateFeatureFlag_URLEncodesKey(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// r.URL.Path is already percent-decoded; r.URL.RawPath preserves escapes when they differ.
+		if r.URL.RawPath != "" {
+			gotPath = r.URL.RawPath
+		} else {
+			gotPath = r.URL.Path
+		}
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{Value: nil, Source: "default"})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org-abc")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "weird key/with:chars", nil, "production")
+	require.NoError(t, err)
+
+	// The key segment should be percent-encoded.
+	assert.Contains(t, gotPath, "/feature-flags/")
+	segments := strings.Split(gotPath, "/feature-flags/")
+	require.Len(t, segments, 2)
+	encodedKeyPlusSuffix := segments[1]
+	assert.True(t, strings.HasSuffix(encodedKeyPlusSuffix, "/evaluate"))
+	encodedKey := strings.TrimSuffix(encodedKeyPlusSuffix, "/evaluate")
+	assert.NotContains(t, encodedKey, " ", "space must be encoded")
+	assert.Contains(t, encodedKey, "%20", "space should be %20")
+}
+
+func TestEvaluateFeatureFlag_DecodesFullResponseShape(t *testing.T) {
+	ruleID := "rule-42"
+	bucket := 37
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{
+			Value:         map[string]any{"variant": "B"},
+			MatchedRuleID: &ruleID,
+			RolloutBucket: &bucket,
+			Source:        "rollout",
+		})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	resp, err := client.EvaluateFeatureFlag(context.Background(), "flag", map[string]any{"userId": "u"}, "production")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "rollout", resp.Source)
+	require.NotNil(t, resp.MatchedRuleID)
+	assert.Equal(t, "rule-42", *resp.MatchedRuleID)
+	require.NotNil(t, resp.RolloutBucket)
+	assert.Equal(t, 37, *resp.RolloutBucket)
+	valMap, ok := resp.Value.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "B", valMap["variant"])
+}
+
+func TestEvaluateFeatureFlag_404ReturnsNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("flag not defined"))
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "missing", nil, "production")
+	require.Error(t, err)
+
+	var ffErr *FeatureFlagEvaluationError
+	require.True(t, errors.As(err, &ffErr), "expected *FeatureFlagEvaluationError, got %T", err)
+	assert.Equal(t, FeatureFlagKindNotFound, ffErr.Kind)
+	assert.Equal(t, 404, ffErr.StatusCode)
+	assert.Equal(t, "missing", ffErr.Key)
+	assert.True(t, errors.Is(err, ErrFeatureFlagNotFound))
+	assert.False(t, errors.Is(err, ErrFeatureFlagContext))
+}
+
+func TestEvaluateFeatureFlag_400ReturnsContextError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid context"}`))
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "flag", map[string]any{}, "production")
+	require.Error(t, err)
+
+	var ffErr *FeatureFlagEvaluationError
+	require.True(t, errors.As(err, &ffErr))
+	assert.Equal(t, FeatureFlagKindContext, ffErr.Kind)
+	assert.Equal(t, 400, ffErr.StatusCode)
+	assert.Contains(t, ffErr.ServerMessage, "invalid context")
+	assert.True(t, errors.Is(err, ErrFeatureFlagContext))
+	assert.False(t, errors.Is(err, ErrFeatureFlagNotFound))
+}
+
+func TestEvaluateFeatureFlag_500ReturnsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	_, err := client.EvaluateFeatureFlag(context.Background(), "flag", nil, "production")
+	require.Error(t, err)
+
+	var ffErr *FeatureFlagEvaluationError
+	require.True(t, errors.As(err, &ffErr))
+	assert.Equal(t, FeatureFlagKindServer, ffErr.Kind)
+	assert.Equal(t, 500, ffErr.StatusCode)
+	assert.True(t, errors.Is(err, ErrFeatureFlagServer))
+	assert.False(t, errors.Is(err, ErrFeatureFlagNotFound))
+	assert.False(t, errors.Is(err, ErrFeatureFlagContext))
+}
+
+func TestEvaluateFeatureFlag_CanceledContextReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		encodeEvalResponse(t, w, EvaluateFeatureFlagResponse{Value: true, Source: "raw"})
+	}))
+	defer server.Close()
+
+	client := NewConfigClient(server.URL, "key", "org")
+	defer client.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	_, err := client.EvaluateFeatureFlag(ctx, "flag", nil, "production")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestFeatureFlagErrorKind_String(t *testing.T) {
+	assert.Equal(t, "not_found", FeatureFlagKindNotFound.String())
+	assert.Equal(t, "context", FeatureFlagKindContext.String())
+	assert.Equal(t, "server", FeatureFlagKindServer.String())
+}
+
+func TestFeatureFlagEvaluationError_ErrorMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     *FeatureFlagEvaluationError
+		wantSub []string
+	}{
+		{
+			name: "with server message",
+			err: &FeatureFlagEvaluationError{
+				Key:           "k",
+				StatusCode:    400,
+				Kind:          FeatureFlagKindContext,
+				ServerMessage: "bad input",
+			},
+			wantSub: []string{`"k"`, "400", "bad input"},
+		},
+		{
+			name: "without server message",
+			err: &FeatureFlagEvaluationError{
+				Key:        "k2",
+				StatusCode: 404,
+				Kind:       FeatureFlagKindNotFound,
+			},
+			wantSub: []string{`"k2"`, "404"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			msg := tc.err.Error()
+			for _, s := range tc.wantSub {
+				assert.Contains(t, msg, s)
+			}
+		})
+	}
+}

--- a/python/src/smooai_config/__init__.py
+++ b/python/src/smooai_config/__init__.py
@@ -1,7 +1,13 @@
 """Smoo AI Configuration Management Library - Python SDK."""
 
 from smooai_config.build import BuildBundleResult, build_bundle, classify_from_schema
-from smooai_config.client import ConfigClient
+from smooai_config.client import (
+    ConfigClient,
+    EvaluateFeatureFlagResponse,
+    FeatureFlagContextError,
+    FeatureFlagEvaluationError,
+    FeatureFlagNotFoundError,
+)
 from smooai_config.cloud_region import CloudRegionResult, get_cloud_region
 from smooai_config.config_manager import ConfigManager
 from smooai_config.env_config import find_and_process_env_config
@@ -18,6 +24,10 @@ __all__ = [
     "ConfigClient",
     "ConfigManager",
     "ConfigTier",
+    "EvaluateFeatureFlagResponse",
+    "FeatureFlagContextError",
+    "FeatureFlagEvaluationError",
+    "FeatureFlagNotFoundError",
     "LocalConfigManager",
     "SmooaiConfigError",
     "build_bundle",

--- a/python/src/smooai_config/client.py
+++ b/python/src/smooai_config/client.py
@@ -10,9 +10,13 @@ Environment variables (used as defaults when constructor args are omitted):
 import os
 import threading
 import time
-from typing import Any
+from typing import Any, Literal
+from urllib.parse import quote
 
 import httpx
+from pydantic import BaseModel, Field
+
+from smooai_config.utils import SmooaiConfigError
 
 
 class ConfigClient:
@@ -141,6 +145,58 @@ class ConfigClient:
             for k in keys_to_remove:
                 del self._cache[k]
 
+    def evaluate_feature_flag(
+        self,
+        key: str,
+        context: dict[str, Any] | None = None,
+        environment: str | None = None,
+    ) -> "EvaluateFeatureFlagResponse":
+        """Evaluate a cohort-aware feature flag against the server.
+
+        Unlike :meth:`get_value` / the local cache, this is always a network
+        call: cohort rules (percentage rollout, attribute matching, bucketing)
+        live server-side and the response depends on the ``context`` passed.
+        Callers that don't need cohort evaluation should keep using
+        :meth:`get_value` for the static flag value.
+
+        Args:
+            key: Feature-flag key.
+            context: Attributes the server's cohort rules may reference
+                (e.g. ``{"userId": ..., "tenantId": ..., "plan": ..., "country": ...}``).
+                Unreferenced keys are ignored by the server. Keep values
+                JSON-serializable — the server hashes ``bucketBy`` values by
+                their string representation, so numbers and booleans bucket
+                stably across client rebuilds. Defaults to an empty dict.
+            environment: Environment name (defaults to the client's default).
+
+        Raises:
+            FeatureFlagNotFoundError: Server returned 404 — flag not defined
+                in the org's schema.
+            FeatureFlagContextError: Server returned 400 — invalid context or
+                missing environment.
+            FeatureFlagEvaluationError: Server returned any other non-2xx
+                status code.
+        """
+        env = environment or self._default_environment
+        ctx = context if context is not None else {}
+
+        # Match the TS client's `encodeURIComponent` behavior so flag keys
+        # containing slashes, spaces, or reserved characters are escaped.
+        encoded_key = quote(key, safe="")
+        response = self._client.post(
+            f"/organizations/{self._org_id}/config/feature-flags/{encoded_key}/evaluate",
+            json={"environment": env, "context": ctx},
+        )
+
+        if response.status_code == 404:
+            raise FeatureFlagNotFoundError(key)
+        if response.status_code == 400:
+            raise FeatureFlagContextError(key, _safe_text(response))
+        if not response.is_success:
+            raise FeatureFlagEvaluationError(key, response.status_code, _safe_text(response))
+
+        return EvaluateFeatureFlagResponse.model_validate(response.json())
+
     def close(self) -> None:
         """Close the HTTP client."""
         self._client.close()
@@ -150,3 +206,60 @@ class ConfigClient:
 
     def __exit__(self, *args: object) -> None:
         self.close()
+
+
+def _safe_text(response: httpx.Response) -> str:
+    """Read response body as text, swallowing decode errors."""
+    try:
+        return response.text
+    except Exception:
+        return ""
+
+
+class EvaluateFeatureFlagResponse(BaseModel):
+    """Response from the server-side feature-flag evaluator.
+
+    Matches the wire contract defined in ``@smooai/schemas/config/feature-flag``.
+    """
+
+    value: Any = None
+    """The resolved flag value (post rules + rollout)."""
+
+    matched_rule_id: str | None = Field(default=None, alias="matchedRuleId")
+    """Id of the rule that fired, if any."""
+
+    rollout_bucket: int | None = Field(default=None, alias="rolloutBucket")
+    """0–99 bucket the context was assigned to, if a rollout ran."""
+
+    source: Literal["raw", "rule", "rollout", "default"]
+    """Which branch the evaluator returned from."""
+
+    model_config = {"populate_by_name": True}
+
+
+class FeatureFlagEvaluationError(SmooaiConfigError):
+    """Base class for errors raised by :meth:`ConfigClient.evaluate_feature_flag`.
+
+    Subclasses let callers branch on 404 / 400 / 5xx without parsing messages.
+    """
+
+    def __init__(self, key: str, status_code: int, server_message: str | None = None) -> None:
+        self.key = key
+        self.status_code = status_code
+        self.server_message = server_message
+        suffix = f" — {server_message}" if server_message else ""
+        super().__init__(f'Feature flag "{key}" evaluation failed: HTTP {status_code}{suffix}')
+
+
+class FeatureFlagNotFoundError(FeatureFlagEvaluationError):
+    """Server returned 404 — the flag key is not defined in the org's schema."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key, 404, "flag not defined in schema")
+
+
+class FeatureFlagContextError(FeatureFlagEvaluationError):
+    """Server returned 400 — invalid context or missing environment."""
+
+    def __init__(self, key: str, server_message: str | None = None) -> None:
+        super().__init__(key, 400, server_message or "invalid context or environment")

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,9 +1,17 @@
 """Tests for ConfigClient."""
 
+import json
+
 import httpx
 import pytest
 
-from smooai_config.client import ConfigClient
+from smooai_config.client import (
+    ConfigClient,
+    EvaluateFeatureFlagResponse,
+    FeatureFlagContextError,
+    FeatureFlagEvaluationError,
+    FeatureFlagNotFoundError,
+)
 
 
 @pytest.fixture
@@ -289,3 +297,165 @@ class TestErrorHandling:
             )
             with pytest.raises(httpx.HTTPStatusError):
                 client.get_value("nonexistent", environment="prod")
+
+
+def _make_client_with_transport(transport: httpx.MockTransport, *, environment: str = "production") -> ConfigClient:
+    """Build a ConfigClient whose internal httpx.Client uses the given mock transport."""
+    client = ConfigClient(
+        base_url="https://config.smooai.dev",
+        api_key="test-api-key",
+        org_id="org-123",
+        environment=environment,
+    )
+    client._client = httpx.Client(
+        base_url="https://config.smooai.dev",
+        headers={"Authorization": "Bearer test-api-key"},
+        transport=transport,
+    )
+    return client
+
+
+class TestEvaluateFeatureFlag:
+    """Tests for ConfigClient.evaluate_feature_flag()."""
+
+    def test_posts_body_with_environment_and_context(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(
+                200,
+                json={"value": True, "source": "rule", "matchedRuleId": "rule-123"},
+            )
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            result = client.evaluate_feature_flag("aboutPage", {"userId": "u-1", "plan": "pro"})
+
+        assert isinstance(result, EvaluateFeatureFlagResponse)
+        assert result.value is True
+        assert result.source == "rule"
+        assert result.matched_rule_id == "rule-123"
+        assert result.rollout_bucket is None
+
+        req = captured["request"]
+        assert req.method == "POST"
+        assert str(req.url) == (
+            "https://config.smooai.dev/organizations/org-123/config/feature-flags/aboutPage/evaluate"
+        )
+        assert req.headers["authorization"] == "Bearer test-api-key"
+        assert json.loads(req.content) == {
+            "environment": "production",
+            "context": {"userId": "u-1", "plan": "pro"},
+        }
+
+    def test_defaults_context_to_empty_dict(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json={"value": False, "source": "default"})
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            result = client.evaluate_feature_flag("aboutPage")
+
+        assert result.value is False
+        assert result.source == "default"
+        assert json.loads(captured["request"].content) == {
+            "environment": "production",
+            "context": {},
+        }
+
+    def test_honors_explicit_environment_override(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json={"value": True, "source": "raw"})
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            client.evaluate_feature_flag("aboutPage", {}, environment="staging")
+
+        assert json.loads(captured["request"].content) == {
+            "environment": "staging",
+            "context": {},
+        }
+
+    def test_url_encodes_flag_key_with_special_characters(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json={"value": None, "source": "default"})
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            client.evaluate_feature_flag("with spaces/and+slashes")
+
+        assert "with%20spaces%2Fand%2Bslashes" in str(captured["request"].url)
+
+    def test_parses_rollout_bucket(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"value": True, "source": "rollout", "rolloutBucket": 42},
+            )
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            result = client.evaluate_feature_flag("aboutPage", {"userId": "u-1"})
+
+        assert result.source == "rollout"
+        assert result.rollout_bucket == 42
+
+    def test_raises_feature_flag_not_found_on_404(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="flag not defined")
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(FeatureFlagNotFoundError) as exc_info:
+                client.evaluate_feature_flag("unknown")
+
+        err = exc_info.value
+        assert isinstance(err, FeatureFlagEvaluationError)
+        assert err.key == "unknown"
+        assert err.status_code == 404
+
+    def test_raises_feature_flag_context_error_on_400(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="context missing required key")
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(FeatureFlagContextError) as exc_info:
+                client.evaluate_feature_flag("aboutPage")
+
+        err = exc_info.value
+        assert isinstance(err, FeatureFlagEvaluationError)
+        assert err.status_code == 400
+        assert err.server_message == "context missing required key"
+
+    def test_raises_feature_flag_evaluation_error_on_5xx(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="evaluator overloaded")
+
+        with _make_client_with_transport(httpx.MockTransport(handler)) as client:
+            with pytest.raises(FeatureFlagEvaluationError) as exc_info:
+                client.evaluate_feature_flag("aboutPage")
+
+        err = exc_info.value
+        assert not isinstance(err, FeatureFlagNotFoundError)
+        assert not isinstance(err, FeatureFlagContextError)
+        assert err.status_code == 503
+        assert err.server_message == "evaluator overloaded"
+
+    def test_uses_default_environment_from_constructor(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json={"value": True, "source": "raw"})
+
+        with _make_client_with_transport(
+            httpx.MockTransport(handler),
+            environment="development",
+        ) as client:
+            client.evaluate_feature_flag("aboutPage")
+
+        assert json.loads(captured["request"].content)["environment"] == "development"

--- a/rust/config/src/client.rs
+++ b/rust/config/src/client.rs
@@ -10,10 +10,11 @@
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, Instant};
+use thiserror::Error;
 
 /// Characters to percent-encode in URL path segments.
 /// Encodes everything except unreserved characters (RFC 3986): A-Z a-z 0-9 - . _ ~
@@ -60,6 +61,73 @@ struct ValueResponse {
 #[derive(Deserialize)]
 struct ValuesResponse {
     values: HashMap<String, serde_json::Value>,
+}
+
+/// Response from the server-side feature-flag evaluator.
+///
+/// Matches the wire contract defined by the TS / Python / Go clients and
+/// the `/organizations/{org_id}/config/feature-flags/{key}/evaluate` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvaluateFeatureFlagResponse {
+    /// The resolved flag value (post rules + rollout).
+    pub value: serde_json::Value,
+    /// Id of the rule that fired, if any.
+    #[serde(rename = "matchedRuleId", skip_serializing_if = "Option::is_none")]
+    pub matched_rule_id: Option<String>,
+    /// 0–99 bucket the context was assigned to, if a rollout ran.
+    #[serde(rename = "rolloutBucket", skip_serializing_if = "Option::is_none")]
+    pub rollout_bucket: Option<u32>,
+    /// Which branch the evaluator returned from: `"raw"`, `"rule"`,
+    /// `"rollout"`, or `"default"`.
+    pub source: String,
+}
+
+/// Errors produced by [`ConfigClient::evaluate_feature_flag`].
+///
+/// Mirrors the TS `FeatureFlagEvaluationError` hierarchy: callers can match
+/// on `NotFound` / `ContextError` / `Evaluation` without parsing messages.
+/// `Request` wraps underlying transport / deserialization failures.
+#[derive(Debug, Error)]
+pub enum FeatureFlagEvaluationError {
+    /// Server returned 404 — the flag key is not defined in the org's schema.
+    #[error("Feature flag \"{key}\" evaluation failed: HTTP 404 — flag not defined in schema")]
+    NotFound { key: String },
+    /// Server returned 400 — invalid context or environment.
+    #[error("Feature flag \"{key}\" evaluation failed: HTTP 400 — {message}")]
+    ContextError { key: String, message: String },
+    /// Server returned a non-success status other than 400 / 404.
+    #[error("Feature flag \"{key}\" evaluation failed: HTTP {status}{}", if .message.is_empty() { String::new() } else { format!(" — {}", .message) })]
+    Evaluation { key: String, status: u16, message: String },
+    /// Underlying HTTP transport or JSON deserialization failure.
+    #[error("Feature flag \"{key}\" evaluation failed: {source}")]
+    Request {
+        key: String,
+        #[source]
+        source: reqwest::Error,
+    },
+}
+
+impl FeatureFlagEvaluationError {
+    /// The flag key the failed evaluation was for.
+    pub fn key(&self) -> &str {
+        match self {
+            Self::NotFound { key } => key,
+            Self::ContextError { key, .. } => key,
+            Self::Evaluation { key, .. } => key,
+            Self::Request { key, .. } => key,
+        }
+    }
+
+    /// The HTTP status code, if the failure came from a server response.
+    /// Returns `None` for transport / parse errors.
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            Self::NotFound { .. } => Some(404),
+            Self::ContextError { .. } => Some(400),
+            Self::Evaluation { status, .. } => Some(*status),
+            Self::Request { .. } => None,
+        }
+    }
 }
 
 impl ConfigClient {
@@ -203,6 +271,87 @@ impl ConfigClient {
         }
 
         Ok(response.values)
+    }
+
+    /// Evaluate a cohort-aware feature flag on the server.
+    ///
+    /// Unlike [`get_value`](Self::get_value), this is always a network call —
+    /// cohort rules (percentage rollout, attribute matching, bucketing) live
+    /// server-side and the response depends on the `context` you pass. Callers
+    /// that don't need cohort evaluation should keep using `get_value` for the
+    /// static flag value.
+    ///
+    /// # Arguments
+    /// * `key` — Feature-flag key. URL-encoded before being placed in the path.
+    /// * `context` — Attributes the server's cohort rules may reference
+    ///   (e.g. `{ "userId": ..., "plan": ... }`). `None` is equivalent to an
+    ///   empty map. Values must be JSON-serializable — the server hashes
+    ///   `bucketBy` values by their string representation, so numbers and
+    ///   booleans bucket stably across client rebuilds.
+    /// * `environment` — Environment name (defaults to the client's default
+    ///   environment when `None`).
+    ///
+    /// # Errors
+    /// * [`FeatureFlagEvaluationError::NotFound`] — 404, flag not defined.
+    /// * [`FeatureFlagEvaluationError::ContextError`] — 400, bad context.
+    /// * [`FeatureFlagEvaluationError::Evaluation`] — other non-2xx status.
+    /// * [`FeatureFlagEvaluationError::Request`] — transport / parse failure.
+    pub async fn evaluate_feature_flag(
+        &self,
+        key: &str,
+        context: Option<HashMap<String, serde_json::Value>>,
+        environment: Option<&str>,
+    ) -> Result<EvaluateFeatureFlagResponse, FeatureFlagEvaluationError> {
+        let env = self.resolve_env(environment).to_string();
+        let encoded_key = utf8_percent_encode(key, PATH_SEGMENT_ENCODE_SET).to_string();
+        let url = format!(
+            "{}/organizations/{}/config/feature-flags/{}/evaluate",
+            self.base_url, self.org_id, encoded_key
+        );
+
+        let body = serde_json::json!({
+            "environment": env,
+            "context": context.unwrap_or_default(),
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|source| FeatureFlagEvaluationError::Request {
+                key: key.to_string(),
+                source,
+            })?;
+
+        let status = response.status();
+        if status.is_success() {
+            return response.json::<EvaluateFeatureFlagResponse>().await.map_err(|source| {
+                FeatureFlagEvaluationError::Request {
+                    key: key.to_string(),
+                    source,
+                }
+            });
+        }
+
+        // Non-2xx — read body as text (best-effort) and map to typed error.
+        let status_code = status.as_u16();
+        let message = response.text().await.unwrap_or_default();
+
+        Err(match status_code {
+            404 => FeatureFlagEvaluationError::NotFound { key: key.to_string() },
+            400 => FeatureFlagEvaluationError::ContextError {
+                key: key.to_string(),
+                message,
+            },
+            _ => FeatureFlagEvaluationError::Evaluation {
+                key: key.to_string(),
+                status: status_code,
+                message,
+            },
+        })
     }
 
     /// Clear the entire local cache.

--- a/rust/config/src/client.rs
+++ b/rust/config/src/client.rs
@@ -746,4 +746,294 @@ mod integration_tests {
         let staging_cached = client.get_value("SHARED_KEY", Some("staging")).await.unwrap();
         assert_eq!(staging_cached, serde_json::json!("staging-value"));
     }
+
+    // -----------------------------------------------------------------------
+    // evaluate_feature_flag
+    // -----------------------------------------------------------------------
+
+    use wiremock::matchers::{body_json, path as path_matcher};
+
+    // --- Evaluate: POST with environment + context, returns parsed response ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_posts_body_and_returns_response() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/aboutPage/evaluate",
+            ))
+            .and(header("Authorization", "Bearer test-api-key"))
+            .and(header("content-type", "application/json"))
+            .and(body_json(serde_json::json!({
+                "environment": "production",
+                "context": { "userId": "u-1", "plan": "pro" }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": true,
+                "source": "rule",
+                "matchedRuleId": "rule-123"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let mut ctx = HashMap::new();
+        ctx.insert("userId".to_string(), serde_json::json!("u-1"));
+        ctx.insert("plan".to_string(), serde_json::json!("pro"));
+
+        let result = client
+            .evaluate_feature_flag("aboutPage", Some(ctx), None)
+            .await
+            .expect("evaluator returns 200");
+
+        assert_eq!(result.value, serde_json::json!(true));
+        assert_eq!(result.source, "rule");
+        assert_eq!(result.matched_rule_id.as_deref(), Some("rule-123"));
+        assert_eq!(result.rollout_bucket, None);
+    }
+
+    // --- Evaluate: None context defaults to empty object ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_defaults_context_to_empty() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/aboutPage/evaluate",
+            ))
+            .and(body_json(serde_json::json!({
+                "environment": "production",
+                "context": {}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": false,
+                "source": "default"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let result = client
+            .evaluate_feature_flag("aboutPage", None, None)
+            .await
+            .expect("evaluator returns 200");
+        assert_eq!(result.value, serde_json::json!(false));
+        assert_eq!(result.source, "default");
+    }
+
+    // --- Evaluate: explicit environment override wins over default ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_honors_environment_override() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/aboutPage/evaluate",
+            ))
+            .and(body_json(serde_json::json!({
+                "environment": "staging",
+                "context": {}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": true,
+                "source": "raw"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let result = client
+            .evaluate_feature_flag("aboutPage", None, Some("staging"))
+            .await
+            .expect("evaluator returns 200");
+        assert_eq!(result.source, "raw");
+    }
+
+    // --- Evaluate: flag keys with special chars are percent-encoded in path ---
+    // Uses the same `PATH_SEGMENT_ENCODE_SET` as `get_value` — RFC 3986 unreserved
+    // chars pass through, reserved chars (space, slash, ? etc.) are percent-encoded.
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_url_encodes_key() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/with%20spaces%2Fand%3Fquestion/evaluate",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": null,
+                "source": "default"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let result = client
+            .evaluate_feature_flag("with spaces/and?question", None, None)
+            .await
+            .expect("evaluator returns 200");
+        assert_eq!(result.value, serde_json::Value::Null);
+    }
+
+    // --- Evaluate: 404 → NotFound ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_404_not_found() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/unknown/evaluate",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_string("flag not defined"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let err = client
+            .evaluate_feature_flag("unknown", None, None)
+            .await
+            .expect_err("expected NotFound");
+
+        match &err {
+            FeatureFlagEvaluationError::NotFound { key } => assert_eq!(key, "unknown"),
+            other => panic!("expected NotFound, got {:?}", other),
+        }
+        assert_eq!(err.status_code(), Some(404));
+        assert_eq!(err.key(), "unknown");
+    }
+
+    // --- Evaluate: 400 → ContextError with server message ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_400_context_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/aboutPage/evaluate",
+            ))
+            .respond_with(ResponseTemplate::new(400).set_body_string("context missing required key"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let err = client
+            .evaluate_feature_flag("aboutPage", None, None)
+            .await
+            .expect_err("expected ContextError");
+
+        match &err {
+            FeatureFlagEvaluationError::ContextError { key, message } => {
+                assert_eq!(key, "aboutPage");
+                assert_eq!(message, "context missing required key");
+            }
+            other => panic!("expected ContextError, got {:?}", other),
+        }
+        assert_eq!(err.status_code(), Some(400));
+    }
+
+    // --- Evaluate: 5xx → Evaluation ---
+    #[tokio::test]
+    async fn test_evaluate_feature_flag_5xx_evaluation_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_matcher(
+                "/organizations/test-org/config/feature-flags/aboutPage/evaluate",
+            ))
+            .respond_with(ResponseTemplate::new(503).set_body_string("evaluator overloaded"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ConfigClient::with_environment(&mock_server.uri(), "test-api-key", "test-org", "production");
+        let err = client
+            .evaluate_feature_flag("aboutPage", None, None)
+            .await
+            .expect_err("expected Evaluation");
+
+        match &err {
+            FeatureFlagEvaluationError::Evaluation { key, status, message } => {
+                assert_eq!(key, "aboutPage");
+                assert_eq!(*status, 503);
+                assert_eq!(message, "evaluator overloaded");
+            }
+            other => panic!("expected Evaluation, got {:?}", other),
+        }
+        assert_eq!(err.status_code(), Some(503));
+    }
+}
+
+#[cfg(test)]
+mod evaluate_response_tests {
+    use super::*;
+
+    #[test]
+    fn test_response_deserializes_full_payload() {
+        let json = r#"{"value": true, "matchedRuleId": "r-1", "rolloutBucket": 42, "source": "rollout"}"#;
+        let resp: EvaluateFeatureFlagResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.value, serde_json::json!(true));
+        assert_eq!(resp.matched_rule_id.as_deref(), Some("r-1"));
+        assert_eq!(resp.rollout_bucket, Some(42));
+        assert_eq!(resp.source, "rollout");
+    }
+
+    #[test]
+    fn test_response_deserializes_minimal_payload() {
+        let json = r#"{"value": "x", "source": "raw"}"#;
+        let resp: EvaluateFeatureFlagResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.matched_rule_id, None);
+        assert_eq!(resp.rollout_bucket, None);
+    }
+
+    #[test]
+    fn test_response_serializes_with_camel_case_fields() {
+        let resp = EvaluateFeatureFlagResponse {
+            value: serde_json::json!(true),
+            matched_rule_id: Some("r-1".to_string()),
+            rollout_bucket: Some(7),
+            source: "rule".to_string(),
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"matchedRuleId\":\"r-1\""));
+        assert!(s.contains("\"rolloutBucket\":7"));
+    }
+
+    #[test]
+    fn test_response_skips_none_optional_fields_on_serialize() {
+        let resp = EvaluateFeatureFlagResponse {
+            value: serde_json::json!(false),
+            matched_rule_id: None,
+            rollout_bucket: None,
+            source: "default".to_string(),
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(!s.contains("matchedRuleId"));
+        assert!(!s.contains("rolloutBucket"));
+    }
+
+    #[test]
+    fn test_error_helpers() {
+        let err = FeatureFlagEvaluationError::NotFound { key: "k".into() };
+        assert_eq!(err.key(), "k");
+        assert_eq!(err.status_code(), Some(404));
+
+        let err = FeatureFlagEvaluationError::ContextError {
+            key: "k".into(),
+            message: "bad".into(),
+        };
+        assert_eq!(err.status_code(), Some(400));
+
+        let err = FeatureFlagEvaluationError::Evaluation {
+            key: "k".into(),
+            status: 502,
+            message: "bg".into(),
+        };
+        assert_eq!(err.status_code(), Some(502));
+    }
 }

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -18,7 +18,7 @@ pub mod schema_validator;
 pub mod utils;
 
 pub use build::{build_bundle, BuildBundleOptions, BuildBundleResult, BuildError, Classification, Classifier};
-pub use client::ConfigClient;
+pub use client::{ConfigClient, EvaluateFeatureFlagResponse, FeatureFlagEvaluationError};
 pub use cloud_region::{get_cloud_region, get_cloud_region_from_env, CloudRegionResult};
 pub use config_manager::ConfigManager;
 pub use env_config::find_and_process_env_config;


### PR DESCRIPTION
## Summary

Closes out SMOODEV-624 by porting the TypeScript cohort-aware feature-flag evaluator to Python, Rust, and Go. The TS surface landed in #47; this PR brings the other three language clients to parity so cohort rules (percentage rollout, attribute matching, bucketing) fire uniformly from every client.

## Language deltas

| Language | Surface |
|---|---|
| Python | `ConfigClient.evaluate_feature_flag(key, context=None, environment=None)` + Pydantic `EvaluateFeatureFlagResponse` + typed errors (`FeatureFlagNotFoundError` / `ContextError` / `EvaluationError`) inheriting from `SmooaiConfigError` |
| Rust | `ConfigClient::evaluate_feature_flag(key, context, environment)` → `Result<EvaluateFeatureFlagResponse, FeatureFlagEvaluationError>` — `thiserror` enum with `NotFound` / `ContextError` / `Evaluation` / `Request` variants |
| Go | `(*ConfigClient).EvaluateFeatureFlag(ctx, key, context, environment)` → `*EvaluateFeatureFlagResponse, error` — single `FeatureFlagEvaluationError` struct with `Kind` enum (`KindNotFound` / `KindContext` / `KindServer`) + sentinel errors for `errors.Is` matching |

All three mirror the TS wire contract: POST `{ environment, context }` to `/organizations/{org_id}/config/feature-flags/{key}/evaluate`, 404 → NotFound, 400 → Context, 5xx → Evaluation/Server.

## Tests

- Python: 9 new tests (277 total passing, up from 268) covering body shape, default-empty context, env override, URL encoding, 404/400/5xx paths
- Rust: 12 new tests (7 async wiremock integration + 5 unit) — full lib + integration suites green; `cargo clippy -- -D warnings` clean
- Go: 12 new test funcs / 14 sub-tests covering body + headers, nil-context-as-empty, default-env fallback, URL encoding, error kind mapping with `errors.Is`, context cancellation

## Known quirk

Rust URL encoding uses the existing crate-wide `PATH_SEGMENT_ENCODE_SET` which is narrower than TS `encodeURIComponent` — `+` round-trips unchanged in flag keys. Cross-client inconsistency, separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)