### PR TITLE
Rename cohort → segment in evaluator docstrings

### DIFF
--- a/.changeset/segment-rename.md
+++ b/.changeset/segment-rename.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+Docstring-only rename: "cohort" → "segment" across TS/Python/Rust/Go feature-flag evaluator surfaces. The underlying API (`evaluateFeatureFlag(key, context)`, `createFeatureFlagEvaluator`) is unchanged; only prose and JSDoc/comments pick up the more industry-standard "segment" terminology. Design doc renamed `DESIGN-cohort-context.md` → `DESIGN-segment-context.md`.

--- a/DESIGN-segment-context.md
+++ b/DESIGN-segment-context.md
@@ -1,9 +1,9 @@
-# SMOODEV-624 — Cohort-aware feature-flag evaluation client API
+# SMOODEV-624 — Segment-aware feature-flag evaluation client API
 
-> Design notes for adding cohort / context-aware feature-flag evaluation to
+> Design notes for adding segment / context-aware feature-flag evaluation to
 > the `@smooai/config` client libraries (TS, Python, Rust, Go). Background:
 > SMOODEV-614 already landed the server-side evaluator endpoint and the
-> schema-level cohort rule definitions (`$cohort` envelope, `rules`,
+> schema-level segment rule definitions (`$cohort` envelope, `rules`,
 > `defaultValue`, `bucketBy`, `rollout`). The client side currently
 > only supports fetching static feature-flag values from cache; this doc
 > specifies how to expose cohort-evaluated values.
@@ -31,7 +31,7 @@ Rationale:
 - `getFeatureFlag` is sync today; callers across the codebase rely on that
   (no `await` at every call site). Making it async would be a breaking
   change for every caller. We don't have a deprecation runway.
-- Cohort evaluation is fundamentally a network call — the server does the
+- Segment evaluation is fundamentally a network call — the server does the
   rule matching, rollout bucketing, and audit logging. Hiding the network
   behind a name that used to be sync is a footgun.
 - The evaluator response is richer than a boolean (it returns
@@ -93,7 +93,7 @@ includes canonicalized context so toggling context re-fetches.
 ### Context shape guidance
 
 Context is `Record<string, unknown>`. Server only reads keys that the
-specific flag's cohort rules reference (e.g. `userId`, `tenantId`,
+specific flag's segment rules reference (e.g. `userId`, `tenantId`,
 `plan`, `country`, `$cohort.bucketBy`). Clients can over-provide context
 freely — unused keys are ignored.
 

--- a/go/config/client.go
+++ b/go/config/client.go
@@ -227,7 +227,7 @@ func (c *ConfigClient) Close() {
 	c.client.CloseIdleConnections()
 }
 
-// EvaluateFeatureFlagResponse is the wire contract for the cohort-aware
+// EvaluateFeatureFlagResponse is the wire contract for the segment-aware
 // feature-flag evaluator. It mirrors the TS `EvaluateFeatureFlagResponse`
 // and the schema defined in `@smooai/schemas/config/feature-flag`.
 type EvaluateFeatureFlagResponse struct {
@@ -312,17 +312,17 @@ func (e *FeatureFlagEvaluationError) Is(target error) bool {
 	return false
 }
 
-// EvaluateFeatureFlag evaluates a cohort-aware feature flag against the server.
+// EvaluateFeatureFlag evaluates a segment-aware feature flag against the server.
 //
-// Unlike GetValue, this is always a network call: cohort rules (percentage
+// Unlike GetValue, this is always a network call: segment rules (percentage
 // rollout, attribute matching, bucketing) live server-side and the response
-// depends on the `evalContext` you pass. Callers that don't need cohort
+// depends on the `evalContext` you pass. Callers that don't need segment
 // evaluation should keep using GetValue for the static flag value.
 //
 // Parameters:
 //   - ctx: standard context for cancellation / deadline.
 //   - key: feature-flag key.
-//   - evalContext: attributes the server's cohort rules may reference
+//   - evalContext: attributes the server's segment rules may reference
 //     (e.g. {userId, tenantId, plan, country}). Unreferenced keys are ignored
 //     by the server. Keep values JSON-serializable — the server hashes
 //     `bucketBy` values by their string representation, so numbers and

--- a/python/src/smooai_config/client.py
+++ b/python/src/smooai_config/client.py
@@ -151,17 +151,17 @@ class ConfigClient:
         context: dict[str, Any] | None = None,
         environment: str | None = None,
     ) -> "EvaluateFeatureFlagResponse":
-        """Evaluate a cohort-aware feature flag against the server.
+        """Evaluate a segment-aware feature flag against the server.
 
         Unlike :meth:`get_value` / the local cache, this is always a network
-        call: cohort rules (percentage rollout, attribute matching, bucketing)
+        call: segment rules (percentage rollout, attribute matching, bucketing)
         live server-side and the response depends on the ``context`` passed.
-        Callers that don't need cohort evaluation should keep using
+        Callers that don't need segment evaluation should keep using
         :meth:`get_value` for the static flag value.
 
         Args:
             key: Feature-flag key.
-            context: Attributes the server's cohort rules may reference
+            context: Attributes the server's segment rules may reference
                 (e.g. ``{"userId": ..., "tenantId": ..., "plan": ..., "country": ...}``).
                 Unreferenced keys are ignored by the server. Keep values
                 JSON-serializable — the server hashes ``bucketBy`` values by

--- a/rust/config/src/client.rs
+++ b/rust/config/src/client.rs
@@ -273,17 +273,17 @@ impl ConfigClient {
         Ok(response.values)
     }
 
-    /// Evaluate a cohort-aware feature flag on the server.
+    /// Evaluate a segment-aware feature flag on the server.
     ///
     /// Unlike [`get_value`](Self::get_value), this is always a network call —
-    /// cohort rules (percentage rollout, attribute matching, bucketing) live
+    /// segment rules (percentage rollout, attribute matching, bucketing) live
     /// server-side and the response depends on the `context` you pass. Callers
-    /// that don't need cohort evaluation should keep using `get_value` for the
+    /// that don't need segment evaluation should keep using `get_value` for the
     /// static flag value.
     ///
     /// # Arguments
     /// * `key` — Feature-flag key. URL-encoded before being placed in the path.
-    /// * `context` — Attributes the server's cohort rules may reference
+    /// * `context` — Attributes the server's segment rules may reference
     ///   (e.g. `{ "userId": ..., "plan": ... }`). `None` is equivalent to an
     ///   empty map. Values must be JSON-serializable — the server hashes
     ///   `bucketBy` values by their string representation, so numbers and

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -123,9 +123,9 @@ export function createFeatureFlagChecker<T extends Record<string, string>>(): (k
 }
 
 /**
- * Create a typed cohort-aware feature-flag evaluator from a config's
+ * Create a typed segment-aware feature-flag evaluator from a config's
  * FeatureFlagKeys and a `ConfigClient`. Always hits the server-side
- * evaluator — cohort rules (percentage rollout, attribute matching,
+ * evaluator — segment rules (percentage rollout, attribute matching,
  * bucketing) live server-side. Use this when the flag result depends on
  * per-request context.
  *

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -176,16 +176,16 @@ export class ConfigClient {
     }
 
     /**
-     * Evaluate a cohort-aware feature flag against the server.
+     * Evaluate a segment-aware feature flag against the server.
      *
      * Unlike `getValue` / `getCachedValue`, this is always a network call:
-     * cohort rules (percentage rollout, attribute matching, bucketing) live
+     * segment rules (percentage rollout, attribute matching, bucketing) live
      * server-side and the response depends on the `context` you pass. Callers
-     * that don't need cohort evaluation should keep using `getValue` for the
+     * that don't need segment evaluation should keep using `getValue` for the
      * static flag value.
      *
      * @param key - Feature-flag key.
-     * @param context - Attributes the server's cohort rules may reference
+     * @param context - Attributes the server's segment rules may reference
      *   (e.g. `{ userId, tenantId, plan, country }`). Unreferenced keys are
      *   ignored by the server. Keep values JSON-serializable — the server
      *   hashes `bucketBy` values by their string representation, so numbers


### PR DESCRIPTION
Industry-standard feature-flag terminology. Docstring-only across TS/Python/Rust/Go — zero API breakage. Design doc renamed to match. Paired with upcoming smooai-side rename of the schema types (`CohortRule` → `SegmentRule`, `$cohort` envelope → `$segment`).