### PR TITLE
SMOODEV-643: CLI glowup — OAuth login, tsx loader, schema-name, list errors, Ink UI polish

### DIFF
--- a/.changeset/smoodev-643-cli-glowup.md
+++ b/.changeset/smoodev-643-cli-glowup.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': minor
+---
+
+SMOODEV-643: CLI glowup — `smooai-config` now authenticates via OAuth2 client-credentials (auto-refreshing access tokens), loads TypeScript configs through `jiti` so explicit `ReturnType<typeof defineConfig>` annotations no longer crash `push`, requires an explicit `--schema-name` (or `schemaName` export / `$smooaiName` field) to prevent accidental schema creation from `cwd` basename, surfaces server-side `{ success: false }` envelopes as real errors instead of silent empty lists, and ships a refreshed Ink UI with Smoo AI brand colors, a larger `Smoo AI` banner, boxed summary/success/error panels, secret redaction on `set`/`list`, and actionable `Try: …` hints on failures. Legacy `--api-key` continues to work.

--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
         "ink-big-text": "^2.0.0",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
+        "jiti": "^2.6.1",
         "json-schema-to-zod": "^2.6.1",
         "lru-cache": "^11.1.0",
         "synckit": "^0.11.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       ink-spinner:
         specifier: ^5.0.0
         version: 5.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       json-schema-to-zod:
         specifier: ^2.6.1
         version: 2.6.1
@@ -132,22 +135,22 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.2)(yaml@2.7.0)
+        version: 8.4.0(jiti@2.6.1)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.2)(yaml@2.7.0)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
       vite:
         specifier: ^6.2.4
-        version: 6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+        version: 6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
       vite-node:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+        version: 3.1.1(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0))
+        version: 5.1.4(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0))
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.13.10)(jsdom@28.1.0)(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(tsx@4.19.4)(yaml@2.7.0)
+        version: 3.1.1(@types/node@22.13.10)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(tsx@4.19.4)(yaml@2.7.0)
       zod:
         specifier: ^4.0.0
         version: 4.1.5
@@ -2221,6 +2224,10 @@ packages:
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   joycon@3.1.1:
@@ -4962,14 +4969,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0))':
+  '@vitest/mocker@3.1.1(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.12.10(@types/node@22.13.10)(typescript@5.8.2)
-      vite: 6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -5704,6 +5711,8 @@ snapshots:
       filelist: 1.0.4
       picocolors: 1.1.1
 
+  jiti@2.6.1: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -6025,10 +6034,11 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.6.1
       postcss: 8.5.3
       tsx: 4.19.4
       yaml: 2.7.0
@@ -6461,7 +6471,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.2)(yaml@2.7.0):
+  tsup@8.4.0(jiti@2.6.1)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.2)
       cac: 6.7.14
@@ -6471,7 +6481,7 @@ snapshots:
       esbuild: 0.25.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.35.0
       source-map: 0.8.0-beta.0
@@ -6527,13 +6537,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@3.1.1(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0):
+  vite-node@3.1.1(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6548,18 +6558,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0):
+  vite@6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -6567,13 +6577,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       fsevents: 2.3.3
+      jiti: 2.6.1
       tsx: 4.19.4
       yaml: 2.7.0
 
-  vitest@3.1.1(@types/node@22.13.10)(jsdom@28.1.0)(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(tsx@4.19.4)(yaml@2.7.0):
+  vitest@3.1.1(@types/node@22.13.10)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.1(msw@2.12.10(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -6589,8 +6600,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.4(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
-      vite-node: 3.1.1(@types/node@22.13.10)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.2.4(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
+      vite-node: 3.1.1(@types/node@22.13.10)(jiti@2.6.1)(tsx@4.19.4)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.10

--- a/src/cli/commands/get.tsx
+++ b/src/cli/commands/get.tsx
@@ -1,6 +1,8 @@
 import { render, Box, Text } from 'ink';
 import React, { useEffect, useState } from 'react';
 import { Banner } from '../components/Banner';
+import { BRAND } from '../components/brand';
+import { ErrorPanel } from '../components/Panels';
 import { TaskList, type TaskItem } from '../components/TaskList';
 import { CliApiClient } from '../utils/api-client';
 import { getCredentialsOrExit } from '../utils/credentials';
@@ -22,41 +24,43 @@ export async function getLogic(key: string, options: GetOptions): Promise<{ succ
 }
 
 function GetUI({ configKey, options }: { configKey: string; options: GetOptions }) {
+    const environment = options.environment ?? 'development';
     const [tasks, setTasks] = useState<TaskItem[]>([{ label: `Fetching ${configKey}`, status: 'pending' }]);
     const [result, setResult] = useState<{ key: string; value: unknown; environment: string } | null>(null);
+    const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
 
     useEffect(() => {
         (async () => {
-            setTasks([{ label: `Fetching ${configKey}`, status: 'running' }]);
-
+            setTasks([{ label: `Fetching ${configKey}`, status: 'running', startedAt: Date.now() }]);
             try {
                 const res = await getLogic(configKey, options);
-
                 setTasks([{ label: `Fetching ${configKey}`, status: 'done' }]);
                 setResult(res);
             } catch (err) {
-                setTasks([
-                    {
-                        label: `Fetching ${configKey}`,
-                        status: 'error',
-                        error: err instanceof Error ? err.message : String(err),
-                    },
-                ]);
+                const message = err instanceof Error ? err.message : String(err);
+                setTasks([{ label: `Fetching ${configKey}`, status: 'error', error: message }]);
+                setError({
+                    message,
+                    hint: /not found|404/i.test(message) ? `Use \`smooai-config list --environment ${environment}\` to see available keys.` : undefined,
+                });
             }
         })();
     }, []);
 
     return (
         <Box flexDirection="column">
-            <Banner title="Get Config Value" />
+            <Banner title={`Get ${configKey}`} subtitle={environment} />
             <TaskList tasks={tasks} />
             {result && (
-                <Box marginTop={1} flexDirection="column">
-                    <Text bold>{result.key}</Text>
+                <Box flexDirection="column" borderStyle="round" borderColor={BRAND.teal} paddingX={1} marginY={1}>
+                    <Text color={BRAND.orange} bold>
+                        {result.key}
+                    </Text>
                     <Text>{typeof result.value === 'object' ? JSON.stringify(result.value, null, 2) : String(result.value)}</Text>
-                    <Text color="gray">Environment: {result.environment}</Text>
+                    <Text color={BRAND.gray}>environment: {result.environment}</Text>
                 </Box>
             )}
+            {error && <ErrorPanel title="Get failed" message={error.message} hint={error.hint} />}
         </Box>
     );
 }

--- a/src/cli/commands/list.tsx
+++ b/src/cli/commands/list.tsx
@@ -1,14 +1,17 @@
 import { render, Box, Text } from 'ink';
 import React, { useEffect, useState } from 'react';
 import { Banner } from '../components/Banner';
+import { BRAND } from '../components/brand';
+import { ErrorPanel } from '../components/Panels';
 import { TaskList, type TaskItem } from '../components/TaskList';
 import { CliApiClient } from '../utils/api-client';
-import { getCredentialsOrExit } from '../utils/credentials';
+import { getCredentialsOrExit, maskSecret } from '../utils/credentials';
 import { isInteractive, jsonOutput } from '../utils/output';
 
 interface ListOptions {
     json?: boolean;
     environment?: string;
+    showSecrets?: boolean;
 }
 
 export async function listLogic(options: ListOptions): Promise<{ success: boolean; environment: string; values: Record<string, unknown> }> {
@@ -21,57 +24,82 @@ export async function listLogic(options: ListOptions): Promise<{ success: boolea
     return { success: true, environment, values };
 }
 
+function formatValue(value: unknown): string {
+    if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+    if (typeof value === 'string') return value;
+    return String(value);
+}
+
 function ListUI({ options }: { options: ListOptions }) {
-    const [tasks, setTasks] = useState<TaskItem[]>([{ label: `Fetching values for ${options.environment ?? 'development'}`, status: 'pending' }]);
-    const [result, setResult] = useState<{
-        environment: string;
-        values: Record<string, unknown>;
-    } | null>(null);
+    const environment = options.environment ?? 'development';
+    const [tasks, setTasks] = useState<TaskItem[]>([{ label: `Fetching values for ${environment}`, status: 'pending' }]);
+    const [result, setResult] = useState<{ environment: string; values: Record<string, unknown> } | null>(null);
+    const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
 
     useEffect(() => {
         (async () => {
-            setTasks([{ label: `Fetching values for ${options.environment ?? 'development'}`, status: 'running' }]);
-
+            setTasks([{ label: `Fetching values for ${environment}`, status: 'running', startedAt: Date.now() }]);
             try {
                 const res = await listLogic(options);
-
-                setTasks([{ label: `Fetching values for ${res.environment}`, status: 'done' }]);
+                setTasks([{ label: `Fetching values for ${res.environment}`, status: 'done', hint: `${Object.keys(res.values).length} value(s)` }]);
                 setResult(res);
             } catch (err) {
-                setTasks([
-                    {
-                        label: `Fetching values for ${options.environment ?? 'development'}`,
-                        status: 'error',
-                        error: err instanceof Error ? err.message : String(err),
-                    },
-                ]);
+                const message = err instanceof Error ? err.message : String(err);
+                setTasks([{ label: `Fetching values for ${environment}`, status: 'error', error: message }]);
+                setError({
+                    message,
+                    hint: /401|403|HTTP 4/i.test(message)
+                        ? 'Run `smooai-config login` again — your credentials may have expired.'
+                        : /not found|404/i.test(message)
+                          ? `Environment "${environment}" may not exist. Run \`smooai-config list --environment production\` to try another.`
+                          : undefined,
+                });
             }
         })();
     }, []);
 
+    const entries = result ? Object.entries(result.values) : [];
+
     return (
         <Box flexDirection="column">
-            <Banner title="List Config Values" />
+            <Banner title="List values" subtitle={environment} />
             <TaskList tasks={tasks} />
-            {result && (
-                <Box marginTop={1} flexDirection="column">
-                    <Text bold>
-                        Environment: {result.environment} ({Object.keys(result.values).length} values)
+            {result && entries.length > 0 && (
+                <Box flexDirection="column" borderStyle="round" borderColor={BRAND.teal} paddingX={1} marginY={1}>
+                    <Text color={BRAND.teal} bold>
+                        {result.environment} · {entries.length} value(s)
                     </Text>
-                    <Box marginTop={1} flexDirection="column">
-                        {Object.entries(result.values).map(([key, value]) => (
+                    {entries.map(([key, value]) => {
+                        const raw = formatValue(value);
+                        const looksSecret = /secret|token|key|password|credential/i.test(key);
+                        const display = looksSecret && !options.showSecrets ? maskSecret(raw) : raw;
+                        return (
                             <Box key={key}>
-                                <Text bold color="cyan">
+                                <Text color={BRAND.orange} bold>
                                     {key}
                                 </Text>
-                                <Text> = </Text>
-                                <Text>{typeof value === 'object' ? JSON.stringify(value) : String(value)}</Text>
+                                <Text color={BRAND.gray}> = </Text>
+                                <Text color={looksSecret && !options.showSecrets ? BRAND.mutedOrange : undefined}>{display}</Text>
+                                {looksSecret && !options.showSecrets ? <Text color={BRAND.gray}> (masked — pass --show-secrets to reveal)</Text> : null}
                             </Box>
-                        ))}
-                    </Box>
-                    {Object.keys(result.values).length === 0 && <Text color="gray">No values found for this environment.</Text>}
+                        );
+                    })}
                 </Box>
             )}
+            {result && entries.length === 0 && (
+                <Box marginTop={1}>
+                    <Text color={BRAND.gray}>No values set for environment </Text>
+                    <Text color={BRAND.darkBlue} bold>
+                        {result.environment}
+                    </Text>
+                    <Text color={BRAND.gray}>. Use </Text>
+                    <Text color={BRAND.orange} bold>
+                        smooai-config set
+                    </Text>
+                    <Text color={BRAND.gray}> to add one.</Text>
+                </Box>
+            )}
+            {error && <ErrorPanel title="List failed" message={error.message} hint={error.hint} />}
         </Box>
     );
 }

--- a/src/cli/commands/login.tsx
+++ b/src/cli/commands/login.tsx
@@ -1,76 +1,204 @@
 import { render, Box, Text } from 'ink';
 import React, { useEffect, useState } from 'react';
 import { Banner } from '../components/Banner';
+import { BRAND } from '../components/brand';
+import { ErrorPanel, SuccessPanel, SummaryPanel } from '../components/Panels';
 import { TaskList, type TaskItem } from '../components/TaskList';
 import { CliApiClient } from '../utils/api-client';
-import { saveCredentials } from '../utils/credentials';
+import { deriveAuthUrlFromBaseUrl, maskSecret, saveCredentials, type ApiKeyCredentials, type OAuthCredentials } from '../utils/credentials';
+import { exchangeClientCredentials } from '../utils/oauth';
 import { isInteractive, jsonOutput } from '../utils/output';
 
 interface LoginOptions {
     json?: boolean;
     apiKey?: string;
+    clientId?: string;
+    clientSecret?: string;
     orgId?: string;
     baseUrl?: string;
+    authUrl?: string;
 }
 
 const DEFAULT_BASE_URL = 'https://api.smoo.ai';
 
-export async function loginLogic(options: LoginOptions): Promise<{ success: boolean; orgId: string }> {
-    const apiKey = options.apiKey;
-    const orgId = options.orgId;
-    const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+export interface LoginResult {
+    success: true;
+    orgId: string;
+    mode: 'oauth' | 'api-key';
+    authUrl?: string;
+    expiresIn?: number;
+}
 
-    if (!apiKey) throw new Error('API key is required. Use --api-key flag.');
+export async function loginLogic(options: LoginOptions): Promise<LoginResult> {
+    const orgId = options.orgId;
+    const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+
     if (!orgId) throw new Error('Organization ID is required. Use --org-id flag.');
 
-    // Validate credentials by calling the API
-    const client = new CliApiClient({ apiKey, orgId, baseUrl });
-    await client.listSchemas(); // Throws on auth failure
+    // OAuth client-credentials (preferred)
+    if (options.clientId && options.clientSecret) {
+        const authUrl = (options.authUrl ?? deriveAuthUrlFromBaseUrl(baseUrl)).replace(/\/+$/, '');
 
-    // Save credentials
-    saveCredentials({ apiKey, orgId, baseUrl });
+        const token = await exchangeClientCredentials({
+            authUrl,
+            clientId: options.clientId,
+            clientSecret: options.clientSecret,
+        });
 
-    return { success: true, orgId };
+        const creds: OAuthCredentials = {
+            clientId: options.clientId,
+            clientSecret: options.clientSecret,
+            orgId,
+            baseUrl,
+            authUrl,
+            accessToken: token.accessToken,
+            accessTokenExpiresAt: token.expiresAt,
+        };
+
+        // Validate by listing schemas with the minted token.
+        const client = new CliApiClient(creds, { onCredentialsChange: () => {} });
+        await client.listSchemas();
+
+        saveCredentials(creds);
+        return { success: true, orgId, mode: 'oauth', authUrl, expiresIn: token.expiresIn };
+    }
+
+    // Legacy API key fallback
+    if (options.apiKey) {
+        const creds: ApiKeyCredentials = { apiKey: options.apiKey, orgId, baseUrl };
+        const client = new CliApiClient(creds, { onCredentialsChange: () => {} });
+        await client.listSchemas();
+        saveCredentials(creds);
+        return { success: true, orgId, mode: 'api-key' };
+    }
+
+    throw new Error('Provide either --client-id + --client-secret (OAuth) or --api-key (legacy).');
+}
+
+function buildInitialTasks(mode: 'oauth' | 'api-key'): TaskItem[] {
+    if (mode === 'oauth') {
+        return [
+            { label: 'Exchanging client credentials for access token', status: 'pending' },
+            { label: 'Validating token against api.smoo.ai', status: 'pending' },
+            { label: 'Saving to ~/.smooai/credentials.json', status: 'pending' },
+        ];
+    }
+    return [
+        { label: 'Validating API key against api.smoo.ai', status: 'pending' },
+        { label: 'Saving to ~/.smooai/credentials.json', status: 'pending' },
+    ];
 }
 
 function LoginUI({ options }: { options: LoginOptions }) {
-    const [tasks, setTasks] = useState<TaskItem[]>([
-        { label: 'Validating credentials', status: 'pending' },
-        { label: 'Saving to ~/.smooai/credentials.json', status: 'pending' },
-    ]);
-    const [result, setResult] = useState<{ orgId: string } | null>(null);
+    const mode: 'oauth' | 'api-key' = options.clientId && options.clientSecret ? 'oauth' : 'api-key';
+    const [tasks, setTasks] = useState<TaskItem[]>(() => buildInitialTasks(mode));
+    const [result, setResult] = useState<LoginResult | null>(null);
+    const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
+
+    const resolvedBaseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    const resolvedAuthUrl = (options.authUrl ?? deriveAuthUrlFromBaseUrl(resolvedBaseUrl)).replace(/\/+$/, '');
 
     useEffect(() => {
         (async () => {
-            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running' } : task)));
+            const now = Date.now();
+            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running', startedAt: now } : task)));
 
             try {
-                const res = await loginLogic(options);
+                if (mode === 'oauth') {
+                    // Do the exchange + validate explicitly so the UI can show each step.
+                    const token = await exchangeClientCredentials({
+                        authUrl: resolvedAuthUrl,
+                        clientId: options.clientId!,
+                        clientSecret: options.clientSecret!,
+                    });
 
-                setTasks([
-                    { label: 'Validating credentials', status: 'done' },
-                    { label: 'Saving to ~/.smooai/credentials.json', status: 'done' },
-                ]);
-                setResult({ orgId: res.orgId });
+                    setTasks((t) => [
+                        { ...t[0], status: 'done', hint: `expires in ${token.expiresIn}s` },
+                        { ...t[1], status: 'running', startedAt: Date.now() },
+                        t[2],
+                    ]);
+
+                    const creds: OAuthCredentials = {
+                        clientId: options.clientId!,
+                        clientSecret: options.clientSecret!,
+                        orgId: options.orgId!,
+                        baseUrl: resolvedBaseUrl,
+                        authUrl: resolvedAuthUrl,
+                        accessToken: token.accessToken,
+                        accessTokenExpiresAt: token.expiresAt,
+                    };
+                    const client = new CliApiClient(creds, { onCredentialsChange: () => {} });
+                    const schemas = await client.listSchemas();
+
+                    setTasks((t) => [
+                        t[0],
+                        { ...t[1], status: 'done', hint: `${schemas.length} schema(s) visible` },
+                        { ...t[2], status: 'running', startedAt: Date.now() },
+                    ]);
+
+                    saveCredentials(creds);
+
+                    setTasks((t) => [t[0], t[1], { ...t[2], status: 'done' }]);
+                    setResult({ success: true, orgId: options.orgId!, mode, authUrl: resolvedAuthUrl, expiresIn: token.expiresIn });
+                } else {
+                    const res = await loginLogic(options);
+                    setTasks((t) => [
+                        { ...t[0], status: 'done' },
+                        { ...t[1], status: 'done' },
+                    ]);
+                    setResult(res);
+                }
             } catch (err) {
-                setTasks((t) =>
-                    t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: err instanceof Error ? err.message : String(err) } : task)),
-                );
+                const message = err instanceof Error ? err.message : String(err);
+                setTasks((t) => t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: message } : task)));
+                setError({
+                    message,
+                    hint:
+                        mode === 'oauth'
+                            ? 'Verify --client-id, --client-secret, and --auth-url. Run with --base-url https://api.smoo.ai to confirm prod target.'
+                            : 'Verify --api-key is current and matches --org-id.',
+                });
             }
         })();
     }, []);
 
+    const redactedSecret = options.clientSecret ? maskSecret(options.clientSecret) : options.apiKey ? maskSecret(options.apiKey) : undefined;
+
     return (
         <Box flexDirection="column">
-            <Banner title="Login" />
+            <Banner title="Login" subtitle={mode === 'oauth' ? 'oauth2 client-credentials' : 'legacy api-key'} />
+            <SummaryPanel
+                title="Target"
+                rows={[
+                    { label: 'org', value: options.orgId ?? '(missing)', color: options.orgId ? BRAND.teal : BRAND.red },
+                    { label: 'api', value: resolvedBaseUrl, color: BRAND.darkBlue },
+                    ...(mode === 'oauth' ? [{ label: 'auth', value: resolvedAuthUrl, color: BRAND.darkBlue }] : []),
+                    ...(mode === 'oauth' && options.clientId ? [{ label: 'id', value: options.clientId, color: BRAND.gray }] : []),
+                    ...(redactedSecret ? [{ label: 'secret', value: redactedSecret, color: BRAND.gray }] : []),
+                ]}
+            />
             <TaskList tasks={tasks} />
             {result && (
-                <Box marginTop={1}>
-                    <Text color="green" bold>
-                        Logged in successfully! Organization: {result.orgId}
+                <SuccessPanel title="Logged in">
+                    <Text>
+                        <Text color={BRAND.gray}>{'mode   '}</Text>
+                        <Text color={BRAND.orange} bold>
+                            {result.mode}
+                        </Text>
                     </Text>
-                </Box>
+                    <Text>
+                        <Text color={BRAND.gray}>{'org    '}</Text>
+                        <Text color={BRAND.teal}>{result.orgId}</Text>
+                    </Text>
+                    {result.expiresIn ? (
+                        <Text>
+                            <Text color={BRAND.gray}>{'token  '}</Text>
+                            <Text color={BRAND.teal}>{`valid for ${result.expiresIn}s (auto-refreshes)`}</Text>
+                        </Text>
+                    ) : null}
+                </SuccessPanel>
             )}
+            {error && <ErrorPanel title="Login failed" message={error.message} hint={error.hint} />}
         </Box>
     );
 }

--- a/src/cli/commands/push.spec.ts
+++ b/src/cli/commands/push.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSchemaName } from './push';
+
+describe('resolveSchemaName (SMOODEV-643)', () => {
+    it('prefers the --schema-name flag', () => {
+        expect(resolveSchemaName('flag-name', undefined)).toEqual({ schemaName: 'flag-name', source: 'flag' });
+    });
+
+    it('falls back to the config file declaration', () => {
+        expect(resolveSchemaName(undefined, 'file-name')).toEqual({ schemaName: 'file-name', source: 'config' });
+    });
+
+    it('warns when flag and file disagree but prefers the flag (explicit intent)', () => {
+        const result = resolveSchemaName('flag-name', 'file-name');
+        expect(result.schemaName).toBe('flag-name');
+        expect(result.source).toBe('flag');
+        expect(result.warning).toMatch(/overrides/i);
+    });
+
+    it('does not warn when flag and file match', () => {
+        const result = resolveSchemaName('same-name', 'same-name');
+        expect(result.warning).toBeUndefined();
+    });
+
+    it('throws a helpful error when neither is present (no more cwd basename fallback)', () => {
+        expect(() => resolveSchemaName(undefined, undefined)).toThrow(/Schema name is required/);
+    });
+});

--- a/src/cli/commands/push.tsx
+++ b/src/cli/commands/push.tsx
@@ -1,7 +1,8 @@
-import { basename } from 'path';
 import { render, Box, Text } from 'ink';
 import React, { useEffect, useState } from 'react';
 import { Banner } from '../components/Banner';
+import { BRAND } from '../components/brand';
+import { ErrorPanel, SuccessPanel, SummaryPanel } from '../components/Panels';
 import { TaskList, type TaskItem } from '../components/TaskList';
 import { CliApiClient } from '../utils/api-client';
 import { getCredentialsOrExit } from '../utils/credentials';
@@ -36,7 +37,47 @@ function computeSchemaDiff(local: Record<string, unknown>, remote: Record<string
     return { added, removed, changed };
 }
 
-export async function pushLogic(options: PushOptions): Promise<{ success: boolean; schema?: unknown; version?: unknown; diff?: SchemaDiff }> {
+export interface PushResolution {
+    schemaName: string;
+    source: 'flag' | 'config' | 'schema';
+    /** Set when --schema-name disagrees with a name declared inside the config. */
+    warning?: string;
+}
+
+/**
+ * SMOODEV-643: resolve the schema name deterministically. Never fall back to
+ * cwd basename — that silently created bogus schemas server-side. Either the
+ * user passes `--schema-name`, or the config module exports a top-level
+ * `schemaName` / `name`, or the JSON Schema carries `$smooaiName`. If neither
+ * is present, fail with an actionable error.
+ */
+export function resolveSchemaName(flag: string | undefined, schemaNameFromFile: string | undefined): PushResolution {
+    if (flag && schemaNameFromFile && flag !== schemaNameFromFile) {
+        return {
+            schemaName: flag,
+            source: 'flag',
+            warning: `--schema-name=${flag} overrides schemaName=${schemaNameFromFile} declared in the config file`,
+        };
+    }
+    if (flag) return { schemaName: flag, source: 'flag' };
+    if (schemaNameFromFile) return { schemaName: schemaNameFromFile, source: 'config' };
+    throw new Error(
+        'Schema name is required. Pass --schema-name <name> or export `schemaName` (or `$smooaiName` in schema.json) from your .smooai-config file. ' +
+            'We no longer fall back to the directory name — that previously created bogus schemas server-side.',
+    );
+}
+
+export interface PushLogicResult {
+    success: boolean;
+    schema?: unknown;
+    version?: unknown;
+    diff?: SchemaDiff;
+    schemaName: string;
+    created: boolean;
+    warning?: string;
+}
+
+export async function pushLogic(options: PushOptions): Promise<PushLogicResult> {
     const creds = getCredentialsOrExit();
     const client = new CliApiClient(creds);
 
@@ -59,7 +100,8 @@ export async function pushLogic(options: PushOptions): Promise<{ success: boolea
         throw new Error(`Schema uses unsupported JSON Schema features:\n${errorMessages.join('\n')}`);
     }
 
-    const schemaName = options.schemaName ?? basename(process.cwd());
+    const resolution = resolveSchemaName(options.schemaName, loaded.schemaName);
+    const schemaName = resolution.schemaName;
 
     // Check if schema already exists
     const existingSchema = await client.getSchemaByName(schemaName).catch(() => null);
@@ -69,46 +111,53 @@ export async function pushLogic(options: PushOptions): Promise<{ success: boolea
     if (existingSchema) {
         diff = computeSchemaDiff(loaded.jsonSchema, existingSchema.jsonSchema);
 
-        // Push new version
         const result = await client.pushSchemaVersion(existingSchema.id, {
             jsonSchema: loaded.jsonSchema,
             changeDescription: options.description,
         });
 
-        return { success: true, schema: result.schema, version: result.version, diff };
+        return { success: true, schema: result.schema, version: result.version, diff, schemaName, created: false, warning: resolution.warning };
     }
 
-    // Create new schema
     const schema = await client.createSchema({
         name: schemaName,
         jsonSchema: loaded.jsonSchema,
         description: options.description,
     });
 
-    return { success: true, schema };
+    return { success: true, schema, schemaName, created: true, warning: resolution.warning };
 }
 
 function DiffDisplay({ diff }: { diff: SchemaDiff }) {
     if (diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0) {
-        return <Text color="gray">No changes detected.</Text>;
+        return (
+            <Box marginTop={1}>
+                <Text color={BRAND.gray}>No changes detected.</Text>
+            </Box>
+        );
     }
 
     return (
-        <Box flexDirection="column" marginTop={1}>
-            <Text bold>Schema Changes:</Text>
+        <Box flexDirection="column" borderStyle="round" borderColor={BRAND.darkBlue} paddingX={1} marginY={1}>
+            <Text color={BRAND.darkBlue} bold>
+                Schema diff
+            </Text>
             {diff.added.map((k) => (
-                <Text key={k} color="green">
-                    + {k}
+                <Text key={k} color={BRAND.teal}>
+                    {'  + '}
+                    {k}
                 </Text>
             ))}
             {diff.removed.map((k) => (
-                <Text key={k} color="red">
-                    - {k}
+                <Text key={k} color={BRAND.red}>
+                    {'  - '}
+                    {k}
                 </Text>
             ))}
             {diff.changed.map((k) => (
-                <Text key={k} color="yellow">
-                    ~ {k}
+                <Text key={k} color={BRAND.yellow}>
+                    {'  ~ '}
+                    {k}
                 </Text>
             ))}
         </Box>
@@ -121,18 +170,16 @@ function PushUI({ options }: { options: PushOptions }) {
         { label: 'Validating schema', status: 'pending' },
         { label: 'Pushing to platform', status: 'pending' },
     ]);
-    const [result, setResult] = useState<{ schema?: unknown; version?: unknown; diff?: SchemaDiff } | null>(null);
+    const [result, setResult] = useState<PushLogicResult | null>(null);
+    const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
 
     useEffect(() => {
         (async () => {
-            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running' } : task)));
-
+            const now = Date.now();
+            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running', startedAt: now } : task)));
             try {
-                // Simulate step progression
-                setTasks((t) => [{ ...t[0], status: 'done' }, { ...t[1], status: 'running' }, t[2]]);
-
+                setTasks((t) => [{ ...t[0], status: 'done' }, { ...t[1], status: 'running', startedAt: Date.now() }, t[2]]);
                 const res = await pushLogic(options);
-
                 setTasks([
                     { label: 'Loading local schema', status: 'done' },
                     { label: 'Validating schema', status: 'done' },
@@ -140,25 +187,60 @@ function PushUI({ options }: { options: PushOptions }) {
                 ]);
                 setResult(res);
             } catch (err) {
-                setTasks((t) =>
-                    t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: err instanceof Error ? err.message : String(err) } : task)),
-                );
+                const message = err instanceof Error ? err.message : String(err);
+                setTasks((t) => t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: message } : task)));
+                setError({
+                    message,
+                    hint: /schema name/i.test(message)
+                        ? 'Pass --schema-name, or add `export const schemaName = "your-schema"` to .smooai-config/config.ts.'
+                        : /Invalid JSON Schema/i.test(message)
+                          ? 'Check .smooai-config/schema.json is a valid JSON Schema draft-07 document.'
+                          : undefined,
+                });
             }
         })();
     }, []);
 
+    const keyCount = (() => {
+        const schema = result?.schema as { jsonSchema?: { properties?: Record<string, unknown> } } | undefined;
+        return Object.keys(schema?.jsonSchema?.properties ?? {}).length;
+    })();
+
     return (
         <Box flexDirection="column">
-            <Banner title="Push Schema" />
+            <Banner title="Push schema" subtitle={options.schemaName ?? '(auto-detected name)'} />
+            <SummaryPanel
+                title="Target"
+                rows={[
+                    { label: 'name', value: options.schemaName ?? '(from config.ts)', color: BRAND.teal },
+                    ...(options.description ? [{ label: 'desc', value: options.description, color: BRAND.darkBlue }] : []),
+                ]}
+            />
             <TaskList tasks={tasks} />
-            {result?.diff && <DiffDisplay diff={result.diff} />}
-            {result && (
+            {result?.warning && (
                 <Box marginTop={1}>
-                    <Text color="green" bold>
-                        Schema pushed successfully!
-                    </Text>
+                    <Text color={BRAND.yellow}>{'⚠ '}</Text>
+                    <Text color={BRAND.yellow}>{result.warning}</Text>
                 </Box>
             )}
+            {result?.diff && <DiffDisplay diff={result.diff} />}
+            {result && (
+                <SuccessPanel title={result.created ? 'Schema created' : 'Schema updated'}>
+                    <Text>
+                        <Text color={BRAND.gray}>{'name   '}</Text>
+                        <Text color={BRAND.teal} bold>
+                            {result.schemaName}
+                        </Text>
+                    </Text>
+                    {keyCount > 0 && (
+                        <Text>
+                            <Text color={BRAND.gray}>{'keys   '}</Text>
+                            <Text color={BRAND.orange}>{keyCount}</Text>
+                        </Text>
+                    )}
+                </SuccessPanel>
+            )}
+            {error && <ErrorPanel title="Push failed" message={error.message} hint={error.hint} />}
         </Box>
     );
 }

--- a/src/cli/commands/set.tsx
+++ b/src/cli/commands/set.tsx
@@ -1,9 +1,11 @@
 import { render, Box, Text } from 'ink';
 import React, { useEffect, useState } from 'react';
 import { Banner } from '../components/Banner';
+import { BRAND } from '../components/brand';
+import { ErrorPanel, SuccessPanel } from '../components/Panels';
 import { TaskList, type TaskItem } from '../components/TaskList';
 import { CliApiClient } from '../utils/api-client';
-import { getCredentialsOrExit } from '../utils/credentials';
+import { getCredentialsOrExit, maskSecret } from '../utils/credentials';
 import { isInteractive, jsonOutput } from '../utils/output';
 import { validateValue } from '../utils/schema-validator';
 
@@ -23,6 +25,12 @@ function parseValue(raw: string): unknown {
     }
 }
 
+function displayValue(value: unknown, tier: string): string {
+    const raw = typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value);
+    if (tier === 'secret') return maskSecret(raw);
+    return raw;
+}
+
 export async function setLogic(
     key: string,
     rawValue: string,
@@ -35,81 +43,99 @@ export async function setLogic(
     const tier = options.tier ?? 'public';
     const value = parseValue(rawValue);
 
-    // Find the environment
     const env = await client.getEnvironmentByName(environment);
     if (!env) {
         throw new Error(`Environment "${environment}" not found. Create it first.`);
     }
 
-    // Find the schema (optional validation)
     const schemas = await client.listSchemas();
-    if (schemas.length > 0) {
-        const schema = options.schemaName ? schemas.find((s) => s.name === options.schemaName) : schemas[0];
+    if (schemas.length === 0) {
+        throw new Error('No schemas found. Push a schema first with `smooai-config push`.');
+    }
 
-        if (schema?.jsonSchema) {
-            const validation = validateValue(schema.jsonSchema, key, value);
-            if (!validation.valid) {
-                throw new Error(`Validation failed for "${key}": ${validation.errors?.join(', ')}`);
-            }
-        }
+    const schema = options.schemaName ? schemas.find((s) => s.name === options.schemaName) : schemas[0];
+    if (!schema) {
+        throw new Error(`Schema "${options.schemaName}" not found. Available: ${schemas.map((s) => s.name).join(', ')}`);
+    }
 
-        if (schema) {
-            await client.setValue({
-                schemaId: schema.id,
-                environmentId: env.id,
-                key,
-                value,
-                tier,
-            });
-
-            return { success: true, key, value, tier, environment };
+    if (schema.jsonSchema) {
+        const validation = validateValue(schema.jsonSchema, key, value);
+        if (!validation.valid) {
+            throw new Error(`Validation failed for "${key}": ${validation.errors?.join(', ')}`);
         }
     }
 
-    throw new Error('No schemas found. Push a schema first with `smooai-config push`.');
+    await client.setValue({ schemaId: schema.id, environmentId: env.id, key, value, tier });
+    return { success: true, key, value, tier, environment };
 }
 
 function SetUI({ configKey, value, options }: { configKey: string; value: string; options: SetOptions }) {
+    const tier = options.tier ?? 'public';
     const [tasks, setTasks] = useState<TaskItem[]>([
-        { label: 'Validating value', status: 'pending' },
-        { label: `Setting ${configKey}`, status: 'pending' },
+        { label: 'Resolving environment + schema', status: 'pending' },
+        { label: `Validating value for ${configKey}`, status: 'pending' },
+        { label: `Writing ${configKey}`, status: 'pending' },
     ]);
     const [result, setResult] = useState<{ key: string; value: unknown; tier: string; environment: string } | null>(null);
+    const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
 
     useEffect(() => {
         (async () => {
-            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running' } : task)));
-
+            setTasks((t) => t.map((task, i) => (i === 0 ? { ...task, status: 'running', startedAt: Date.now() } : task)));
             try {
+                setTasks((t) => [{ ...t[0], status: 'done' }, { ...t[1], status: 'running', startedAt: Date.now() }, t[2]]);
+                await new Promise((r) => setTimeout(r, 0));
+                setTasks((t) => [t[0], { ...t[1], status: 'done' }, { ...t[2], status: 'running', startedAt: Date.now() }]);
                 const res = await setLogic(configKey, value, options);
-
                 setTasks([
-                    { label: 'Validating value', status: 'done' },
-                    { label: `Setting ${configKey}`, status: 'done' },
+                    { label: 'Resolving environment + schema', status: 'done' },
+                    { label: `Validating value for ${configKey}`, status: 'done' },
+                    { label: `Writing ${configKey}`, status: 'done' },
                 ]);
                 setResult(res);
             } catch (err) {
-                setTasks((t) =>
-                    t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: err instanceof Error ? err.message : String(err) } : task)),
-                );
+                const message = err instanceof Error ? err.message : String(err);
+                setTasks((t) => t.map((task) => (task.status === 'running' ? { ...task, status: 'error', error: message } : task)));
+                setError({
+                    message,
+                    hint: /Validation failed/i.test(message)
+                        ? 'Use `smooai-config diff` to check the remote schema matches your local one.'
+                        : /not found/i.test(message)
+                          ? 'Run `smooai-config push` to publish your schema, then retry.'
+                          : undefined,
+                });
             }
         })();
     }, []);
 
     return (
         <Box flexDirection="column">
-            <Banner title="Set Config Value" />
+            <Banner title={`Set ${configKey}`} subtitle={options.environment ?? 'development'} />
             <TaskList tasks={tasks} />
             {result && (
-                <Box marginTop={1} flexDirection="column">
-                    <Text color="green" bold>
-                        Value set successfully!
+                <SuccessPanel title="Value written">
+                    <Text>
+                        <Text color={BRAND.gray}>{'key    '}</Text>
+                        <Text color={BRAND.orange} bold>
+                            {result.key}
+                        </Text>
                     </Text>
                     <Text>
-                        {result.key} = {JSON.stringify(result.value)} [{result.tier}] ({result.environment})
+                        <Text color={BRAND.gray}>{'value  '}</Text>
+                        <Text color={tier === 'secret' ? BRAND.mutedOrange : undefined}>{displayValue(result.value, tier)}</Text>
+                        {tier === 'secret' ? <Text color={BRAND.gray}> (masked)</Text> : null}
                     </Text>
-                </Box>
+                    <Text>
+                        <Text color={BRAND.gray}>{'tier   '}</Text>
+                        <Text color={tier === 'secret' ? BRAND.red : BRAND.teal}>{tier}</Text>
+                    </Text>
+                    <Text>
+                        <Text color={BRAND.gray}>{'env    '}</Text>
+                        <Text color={BRAND.teal}>{result.environment}</Text>
+                    </Text>
+                </SuccessPanel>
             )}
+            {error && <ErrorPanel title="Set failed" message={error.message} hint={error.hint} />}
         </Box>
     );
 }

--- a/src/cli/components/Banner.tsx
+++ b/src/cli/components/Banner.tsx
@@ -2,14 +2,42 @@ import { Box, Text } from 'ink';
 import BigText from 'ink-big-text';
 import Gradient from 'ink-gradient';
 import React from 'react';
+import { BRAND } from './brand';
 
-export function Banner({ title }: { title: string }) {
+/**
+ * Choose a cfonts font that fits the current terminal width. `block` renders
+ * the brand at full impact but needs ~50 columns. Fall back to `chrome` at
+ * mid widths and `tiny` for narrow terminals / pipes.
+ */
+function pickFont(): 'block' | 'chrome' | 'tiny' {
+    const cols = typeof process.stdout.columns === 'number' ? process.stdout.columns : 80;
+    if (cols >= 66) return 'block';
+    if (cols >= 44) return 'chrome';
+    return 'tiny';
+}
+
+export function Banner({ title, subtitle }: { title: string; subtitle?: string }) {
+    const font = pickFont();
     return (
         <Box marginBottom={1} flexDirection="column">
-            <Gradient colors={['#f49f0a', '#ff6b6c']}>
-                <BigText text="Smoo AI" font="tiny" />
+            <Gradient colors={[BRAND.orange, BRAND.teal]}>
+                <BigText text="Smoo AI" font={font} space={false} />
             </Gradient>
-            <Text bold>{title}</Text>
+            <Box flexDirection="row" marginTop={font === 'tiny' ? 0 : -1}>
+                <Text color={BRAND.teal} bold>
+                    {'smooai-config'}
+                </Text>
+                <Text color={BRAND.mutedOrange}> · </Text>
+                <Text color={BRAND.darkBlue} bold>
+                    {title}
+                </Text>
+                {subtitle ? (
+                    <>
+                        <Text color={BRAND.mutedOrange}> · </Text>
+                        <Text color={BRAND.mutedOrange}>{subtitle}</Text>
+                    </>
+                ) : null}
+            </Box>
         </Box>
     );
 }

--- a/src/cli/components/Panels.tsx
+++ b/src/cli/components/Panels.tsx
@@ -1,0 +1,58 @@
+import { Box, Text } from 'ink';
+import React from 'react';
+import { BRAND } from './brand';
+
+export interface PanelRow {
+    label: string;
+    value: string;
+    color?: string;
+}
+
+export function SummaryPanel({ title, rows, accent = BRAND.teal }: { title: string; rows: PanelRow[]; accent?: string }) {
+    const labelWidth = Math.max(...rows.map((r) => r.label.length), 4) + 1;
+    return (
+        <Box flexDirection="column" borderStyle="round" borderColor={accent} paddingX={1} marginY={1}>
+            <Text color={accent} bold>
+                {title}
+            </Text>
+            {rows.map((r, i) => (
+                <Box key={i}>
+                    <Box width={labelWidth}>
+                        <Text color={BRAND.gray}>{r.label}</Text>
+                    </Box>
+                    <Text color={r.color ?? undefined}>{r.value}</Text>
+                </Box>
+            ))}
+        </Box>
+    );
+}
+
+export function SuccessPanel({ title, children }: { title: string; children?: React.ReactNode }) {
+    return (
+        <Box flexDirection="column" borderStyle="round" borderColor={BRAND.teal} paddingX={1} marginY={1}>
+            <Text color={BRAND.teal} bold>
+                {'✔ '}
+                {title}
+            </Text>
+            {children}
+        </Box>
+    );
+}
+
+export function ErrorPanel({ title, message, hint }: { title: string; message: string; hint?: string }) {
+    return (
+        <Box flexDirection="column" borderStyle="round" borderColor={BRAND.red} paddingX={1} marginY={1}>
+            <Text color={BRAND.red} bold>
+                {'✖ '}
+                {title}
+            </Text>
+            <Text color={BRAND.red}>{message}</Text>
+            {hint ? (
+                <Box marginTop={1}>
+                    <Text color={BRAND.yellow}>{'Try: '}</Text>
+                    <Text color={BRAND.gray}>{hint}</Text>
+                </Box>
+            ) : null}
+        </Box>
+    );
+}

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -1,30 +1,60 @@
 import { Box, Text } from 'ink';
 import Spinner from 'ink-spinner';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { BRAND } from './brand';
 
 export interface TaskItem {
     label: string;
     status: 'pending' | 'running' | 'done' | 'error';
     error?: string;
+    /** Optional epoch-ms timestamp — when present, rendered as an elapsed counter. */
+    startedAt?: number;
+    /** Short hint shown dim below the task. */
+    hint?: string;
+}
+
+function Elapsed({ startedAt }: { startedAt: number }) {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 250);
+        return () => clearInterval(id);
+    }, []);
+    const secs = Math.max(0, (now - startedAt) / 1000);
+    if (secs < 1) return null;
+    return <Text color={BRAND.gray}> ({secs.toFixed(1)}s)</Text>;
 }
 
 export function TaskList({ tasks }: { tasks: TaskItem[] }) {
     return (
         <Box flexDirection="column" marginTop={1}>
             {tasks.map((task, i) => (
-                <Box key={i}>
-                    <Box width={3}>
-                        {task.status === 'running' && (
-                            <Text color="yellow">
-                                <Spinner type="dots" />
-                            </Text>
-                        )}
-                        {task.status === 'done' && <Text color="green">✓</Text>}
-                        {task.status === 'error' && <Text color="red">✗</Text>}
-                        {task.status === 'pending' && <Text color="gray">○</Text>}
+                <Box flexDirection="column" key={i}>
+                    <Box>
+                        <Box width={3}>
+                            {task.status === 'running' && (
+                                <Text color={BRAND.orange}>
+                                    <Spinner type="dots3" />
+                                </Text>
+                            )}
+                            {task.status === 'done' && <Text color={BRAND.teal}>✔</Text>}
+                            {task.status === 'error' && <Text color={BRAND.red}>✖</Text>}
+                            {task.status === 'pending' && <Text color={BRAND.gray}>○</Text>}
+                        </Box>
+                        <Text
+                            color={
+                                task.status === 'error' ? BRAND.red : task.status === 'done' ? BRAND.teal : task.status === 'running' ? undefined : BRAND.gray
+                            }
+                        >
+                            {task.label}
+                        </Text>
+                        {task.status === 'running' && task.startedAt ? <Elapsed startedAt={task.startedAt} /> : null}
+                        {task.error && <Text color={BRAND.red}> — {task.error}</Text>}
                     </Box>
-                    <Text color={task.status === 'error' ? 'red' : task.status === 'done' ? 'green' : undefined}>{task.label}</Text>
-                    {task.error && <Text color="red"> — {task.error}</Text>}
+                    {task.hint && task.status !== 'error' && (
+                        <Box marginLeft={3}>
+                            <Text color={BRAND.gray}>{task.hint}</Text>
+                        </Box>
+                    )}
                 </Box>
             ))}
         </Box>

--- a/src/cli/components/brand.tsx
+++ b/src/cli/components/brand.tsx
@@ -1,0 +1,26 @@
+/**
+ * Smoo AI brand tokens for the CLI.
+ *
+ * Colors mirror `packages/ui/globals.css` in the smooai monorepo:
+ *   - orange        → smooai-orange-600 (#f49f0a) — primary accent
+ *   - teal          → smooai-green-800  (#00a6a6) — secondary/tech
+ *   - darkBlue      → smooai-dark-blue  (#25405d) — neutral text
+ *   - mutedOrange   → smooai-orange-900 (#523603) — chrome / separators
+ */
+export const BRAND = {
+    orange: '#f49f0a',
+    coral: '#ff6b6c',
+    teal: '#00a6a6',
+    darkBlue: '#25405d',
+    mutedOrange: '#523603',
+    green: '#10b981',
+    red: '#ef4444',
+    yellow: '#f59e0b',
+    gray: '#6b7280',
+} as const;
+
+export const GRADIENTS = {
+    heroOrangeTeal: [BRAND.orange, BRAND.teal] as [string, string],
+    heroOrangeCoral: [BRAND.orange, BRAND.coral] as [string, string],
+    successTeal: [BRAND.teal, '#22d3ee'] as [string, string],
+} as const;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,10 +18,13 @@ program
 
 program
     .command('login')
-    .description('Store credentials for CLI access')
-    .option('--api-key <key>', 'API key for authentication')
+    .description('Store credentials for CLI access (OAuth client-credentials or legacy API key)')
+    .option('--client-id <id>', 'OAuth2 client_id (uuid) — use with --client-secret')
+    .option('--client-secret <secret>', 'OAuth2 client_secret (sk_...) — use with --client-id')
+    .option('--api-key <key>', 'Legacy API key (fallback mode)')
     .option('--org-id <id>', 'Organization ID')
     .option('--base-url <url>', 'API base URL', 'https://api.smoo.ai')
+    .option('--auth-url <url>', 'OAuth token endpoint base URL (auto-derived from --base-url when omitted)')
     .action(async (opts) => {
         const { runLogin } = await import('./commands/login');
         runLogin({ ...opts, json: program.opts().json ?? opts.json });
@@ -71,6 +74,7 @@ program
     .command('list')
     .description('List all config values for an environment')
     .option('--environment <env>', 'Environment name', 'development')
+    .option('--show-secrets', 'Show secret-looking values in plaintext (off by default)')
     .action(async (opts) => {
         const { runList } = await import('./commands/list');
         runList({ ...opts, json: program.opts().json ?? opts.json });

--- a/src/cli/utils/api-client-oauth.integration.test.ts
+++ b/src/cli/utils/api-client-oauth.integration.test.ts
@@ -1,0 +1,133 @@
+import { CliApiClient } from '@/cli/utils/api-client';
+import type { Credentials, OAuthCredentials } from '@/cli/utils/credentials';
+/**
+ * SMOODEV-643: end-to-end OAuth flow test.
+ *
+ * Verifies that `CliApiClient` transparently exchanges client credentials for
+ * an access token, uses it on API calls, refreshes it when it's about to
+ * expire, and persists refreshed tokens through the `onCredentialsChange`
+ * callback so disk storage stays up to date.
+ */
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const API_URL = 'https://api.smooai.test';
+const AUTH_URL = 'https://auth.smooai.test';
+const ORG_ID = '550e8400-e29b-41d4-a716-446655440000';
+const CLIENT_ID = 'cid-uuid';
+const CLIENT_SECRET = 'sk_super_secret';
+
+let tokenCounter = 0;
+let tokenExchangeCount = 0;
+let lastUsedBearer: string | null = null;
+
+const handlers = [
+    http.post(`${AUTH_URL}/token`, async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        if (body.get('client_id') !== CLIENT_ID || body.get('client_secret') !== CLIENT_SECRET) {
+            return HttpResponse.json({ error: 'invalid_client' }, { status: 401 });
+        }
+        if (body.get('provider') !== 'client_credentials') {
+            return HttpResponse.json({ error: 'missing provider' }, { status: 400 });
+        }
+        tokenExchangeCount += 1;
+        tokenCounter += 1;
+        return HttpResponse.json({
+            access_token: `token-${tokenCounter}`,
+            token_type: 'Bearer',
+            expires_in: 3600,
+        });
+    }),
+    http.get(`${API_URL}/organizations/:orgId/config/schemas`, ({ request }) => {
+        lastUsedBearer = request.headers.get('Authorization');
+        if (!lastUsedBearer?.startsWith('Bearer ')) {
+            return HttpResponse.json({ error: 'unauth' }, { status: 401 });
+        }
+        return HttpResponse.json([]);
+    }),
+    http.get(`${API_URL}/organizations/:orgId/config/values`, ({ request }) => {
+        lastUsedBearer = request.headers.get('Authorization');
+        if (!lastUsedBearer?.startsWith('Bearer ')) {
+            return HttpResponse.json({ error: 'unauth' }, { status: 401 });
+        }
+        return HttpResponse.json({ values: { FOO: 'bar' } });
+    }),
+    http.get(`${API_URL}/organizations/:orgId/config/error-values`, () => HttpResponse.json({ success: false, error: 'schema-not-found' })),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterAll(() => server.close());
+beforeEach(() => {
+    tokenCounter = 0;
+    tokenExchangeCount = 0;
+    lastUsedBearer = null;
+});
+afterEach(() => server.resetHandlers());
+
+function oauthCreds(overrides: Partial<OAuthCredentials> = {}): OAuthCredentials {
+    return {
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        orgId: ORG_ID,
+        baseUrl: API_URL,
+        authUrl: AUTH_URL,
+        ...overrides,
+    };
+}
+
+describe('CliApiClient OAuth flow', () => {
+    it('exchanges client credentials once, then reuses the token', async () => {
+        const persisted: { value: Credentials | null } = { value: null };
+        const client = new CliApiClient(oauthCreds(), { onCredentialsChange: (c) => (persisted.value = c) });
+
+        await client.listSchemas();
+        await client.listSchemas();
+
+        expect(tokenExchangeCount).toBe(1);
+        expect(lastUsedBearer).toBe('Bearer token-1');
+        const saved = persisted.value as OAuthCredentials;
+        expect(saved.accessToken).toBe('token-1');
+        expect(saved.accessTokenExpiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('refreshes when the stored token is within the 60s refresh window', async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const persisted: { value: Credentials | null } = { value: null };
+
+        const client = new CliApiClient(oauthCreds({ accessToken: 'stale', accessTokenExpiresAt: nowSec + 30 }), {
+            onCredentialsChange: (c) => (persisted.value = c),
+        });
+
+        await client.listSchemas();
+        expect(tokenExchangeCount).toBe(1);
+        expect(lastUsedBearer).toBe('Bearer token-1');
+        expect((persisted.value as OAuthCredentials).accessToken).toBe('token-1');
+    });
+
+    it('skips refresh when token is still fresh', async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const client = new CliApiClient(oauthCreds({ accessToken: 'fresh-token', accessTokenExpiresAt: nowSec + 3600 }), { onCredentialsChange: () => {} });
+
+        await client.listSchemas();
+        expect(tokenExchangeCount).toBe(0);
+        expect(lastUsedBearer).toBe('Bearer fresh-token');
+    });
+
+    it('surfaces 401 from the token endpoint as a clear error', async () => {
+        const client = new CliApiClient(oauthCreds({ clientId: 'wrong', clientSecret: 'wrong' }), { onCredentialsChange: () => {} });
+        await expect(client.listSchemas()).rejects.toThrow(/rejected|HTTP 401/i);
+    });
+
+    it('getAllValues throws when the server returns { success: false }', async () => {
+        // Re-route the /values endpoint to the error variant.
+        server.use(http.get(`${API_URL}/organizations/:orgId/config/values`, () => HttpResponse.json({ success: false, error: 'schema not configured' })));
+
+        const nowSec = Math.floor(Date.now() / 1000);
+        const client = new CliApiClient(oauthCreds({ accessToken: 'fresh-token', accessTokenExpiresAt: nowSec + 3600 }), { onCredentialsChange: () => {} });
+
+        await expect(client.getAllValues('production')).rejects.toThrow(/schema not configured/);
+    });
+});

--- a/src/cli/utils/api-client.ts
+++ b/src/cli/utils/api-client.ts
@@ -1,14 +1,18 @@
 /**
  * API client wrapper for CLI commands.
- * Extends ConfigClient with schema and environment management methods.
  *
  * SMOODEV-602: routes HTTP through `@smooai/fetch` so flaky-network retries,
- * 429 back-off, and clearer error surfaces apply to every CLI call — same
- * resilience the SmooAI platform ships for its own HTTP callers.
+ * 429 back-off, and clearer error surfaces apply to every CLI call.
+ *
+ * SMOODEV-643: adds OAuth2 client-credentials exchange. When credentials carry
+ * a `clientId`/`clientSecret`, we mint an access token via auth.smoo.ai and
+ * auto-refresh when it's within 60s of expiry. Legacy `apiKey` credentials are
+ * still supported and used as a raw `Authorization: Bearer` header.
  */
 
 import fetch from '@smooai/fetch';
-import { type Credentials } from './credentials';
+import { isOAuthCredentials, saveCredentials, type Credentials, type OAuthCredentials } from './credentials';
+import { exchangeClientCredentials, shouldRefreshToken } from './oauth';
 
 export interface ConfigSchema {
     id: string;
@@ -45,22 +49,74 @@ export interface PushVersionResponse {
     };
 }
 
+export interface CliApiClientOptions {
+    /**
+     * Called after a successful token refresh so callers can persist the new
+     * `accessToken` + `accessTokenExpiresAt` to disk. Defaults to writing
+     * `~/.smooai/credentials.json` via `saveCredentials`.
+     */
+    onCredentialsChange?: (creds: Credentials) => void;
+}
+
 export class CliApiClient {
     private baseUrl: string;
-    private apiKey: string;
     private orgId: string;
+    private credentials: Credentials;
+    private onCredentialsChange: (creds: Credentials) => void;
 
-    constructor(credentials: Credentials) {
+    constructor(credentials: Credentials, options: CliApiClientOptions = {}) {
         this.baseUrl = credentials.baseUrl.replace(/\/+$/, '');
-        this.apiKey = credentials.apiKey;
         this.orgId = credentials.orgId;
+        this.credentials = { ...credentials } as Credentials;
+        this.onCredentialsChange = options.onCredentialsChange ?? ((c) => saveCredentials(c));
+    }
+
+    /** Return a shallow copy of the current credentials (including any refreshed token). */
+    getCredentials(): Credentials {
+        return { ...this.credentials } as Credentials;
+    }
+
+    private async ensureAccessToken(): Promise<string> {
+        if (!isOAuthCredentials(this.credentials)) {
+            // Legacy: apiKey is used directly.
+            const apiKey = (this.credentials as { apiKey: string }).apiKey;
+            if (!apiKey) throw new Error('Missing API key or OAuth client credentials');
+            return apiKey;
+        }
+
+        const oauth = this.credentials;
+        if (oauth.accessToken && !shouldRefreshToken(oauth.accessTokenExpiresAt)) {
+            return oauth.accessToken;
+        }
+
+        const token = await exchangeClientCredentials({
+            authUrl: oauth.authUrl,
+            clientId: oauth.clientId,
+            clientSecret: oauth.clientSecret,
+        });
+
+        const updated: OAuthCredentials = {
+            ...oauth,
+            accessToken: token.accessToken,
+            accessTokenExpiresAt: token.expiresAt,
+        };
+
+        this.credentials = updated;
+        try {
+            this.onCredentialsChange(updated);
+        } catch {
+            // Non-fatal: we still have the in-memory token.
+        }
+
+        return token.accessToken;
     }
 
     private async fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
+        const token = await this.ensureAccessToken();
         const response = await fetch(`${this.baseUrl}${path}`, {
             ...options,
             headers: {
-                Authorization: `Bearer ${this.apiKey}`,
+                Authorization: `Bearer ${token}`,
                 'Content-Type': 'application/json',
                 ...options?.headers,
             },
@@ -99,10 +155,17 @@ export class CliApiClient {
     }
 
     async getAllValues(environment: string): Promise<Record<string, unknown>> {
-        const result = await this.fetchJson<{ values: Record<string, unknown> }>(
+        // SMOODEV-643: the server may return wrapper envelopes like
+        // `{ success: false, error: ... }` or legacy `{ values: ... }`. Surface
+        // any explicit `success: false` as an error so debugging is loud, not
+        // silent-empty-list.
+        const result = await this.fetchJson<{ values?: Record<string, unknown>; success?: boolean; error?: string }>(
             `/organizations/${this.orgId}/config/values?environment=${encodeURIComponent(environment)}`,
         );
-        return result.values;
+        if (result && typeof result === 'object' && result.success === false) {
+            throw new Error(`API error: ${result.error ?? 'unknown error returned by values endpoint'}`);
+        }
+        return result.values ?? {};
     }
 
     async getValue(key: string, environment: string): Promise<unknown> {

--- a/src/cli/utils/credentials.spec.ts
+++ b/src/cli/utils/credentials.spec.ts
@@ -1,68 +1,69 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { deriveAuthUrlFromBaseUrl, isOAuthCredentials, maskSecret } from './credentials';
 
-// Test with a temp dir inside the real homedir to avoid mock complexity
-const testSmooaiDir = join(homedir(), '.smooai-test-cli');
-const testCredFile = join(testSmooaiDir, 'credentials.json');
-
-// Override the module's constants by providing a wrapper
-// Since we can't easily mock the module's internal constants,
-// we test the core logic patterns directly
-
-describe('credentials logic', () => {
-    beforeAll(() => {
-        mkdirSync(testSmooaiDir, { recursive: true });
+describe('deriveAuthUrlFromBaseUrl', () => {
+    it('swaps api.* for auth.*', () => {
+        expect(deriveAuthUrlFromBaseUrl('https://api.smoo.ai')).toBe('https://auth.smoo.ai');
     });
 
-    afterAll(() => {
-        try {
-            rmSync(testSmooaiDir, { recursive: true });
-        } catch {
-            // ignore
-        }
+    it('preserves path and port', () => {
+        expect(deriveAuthUrlFromBaseUrl('https://api.smoo.ai:8443')).toBe('https://auth.smoo.ai:8443');
     });
 
-    describe('credential file read/write', () => {
-        it('round-trips credentials through JSON', () => {
-            const creds = { apiKey: 'test-key', orgId: 'test-org', baseUrl: 'https://api.test.com' };
-            writeFileSync(testCredFile, JSON.stringify(creds, null, 2), { mode: 0o600 });
-
-            const raw = readFileSync(testCredFile, 'utf-8');
-            const parsed = JSON.parse(raw);
-            expect(parsed).toEqual(creds);
-        });
-
-        it('detects missing required fields', () => {
-            writeFileSync(testCredFile, JSON.stringify({ apiKey: 'only-key' }));
-            const parsed = JSON.parse(readFileSync(testCredFile, 'utf-8'));
-            expect(!parsed.apiKey || !parsed.orgId || !parsed.baseUrl).toBe(true);
-        });
-
-        it('handles missing file gracefully', () => {
-            const nonExistent = join(testSmooaiDir, 'nonexistent.json');
-            expect(existsSync(nonExistent)).toBe(false);
-        });
-
-        it('handles invalid JSON gracefully', () => {
-            writeFileSync(testCredFile, 'not valid json');
-            expect(() => JSON.parse(readFileSync(testCredFile, 'utf-8'))).toThrow();
-        });
+    it('returns localhost unchanged', () => {
+        expect(deriveAuthUrlFromBaseUrl('http://localhost:4000')).toBe('http://localhost:4000');
     });
 
-    describe('loadCredentials integration', () => {
-        it('loads and saves from the real module', async () => {
-            // Import the real module
-            const { loadCredentials, saveCredentials } = await import('./credentials');
+    it('returns 127.0.0.1 unchanged', () => {
+        expect(deriveAuthUrlFromBaseUrl('http://127.0.0.1:4000')).toBe('http://127.0.0.1:4000');
+    });
 
-            // Save real credentials
-            const creds = { apiKey: 'integration-key', orgId: 'integration-org', baseUrl: 'https://api.integration.com' };
-            saveCredentials(creds);
+    it('strips trailing slashes from the derived URL', () => {
+        expect(deriveAuthUrlFromBaseUrl('https://api.smoo.ai/')).toBe('https://auth.smoo.ai');
+    });
 
-            // Load them back
-            const loaded = loadCredentials();
-            expect(loaded).toEqual(creds);
-        });
+    it('returns a normalized url when the host does not start with api.', () => {
+        expect(deriveAuthUrlFromBaseUrl('https://gateway.smoo.ai')).toBe('https://gateway.smoo.ai');
+    });
+
+    it('falls back to original string on malformed URL', () => {
+        expect(deriveAuthUrlFromBaseUrl('not a url')).toBe('not a url');
+    });
+});
+
+describe('isOAuthCredentials', () => {
+    it('returns true when both clientId and clientSecret are present', () => {
+        expect(
+            isOAuthCredentials({
+                clientId: 'cid',
+                clientSecret: 'sk_secret',
+                orgId: 'org',
+                baseUrl: 'https://api.smoo.ai',
+                authUrl: 'https://auth.smoo.ai',
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false for api-key credentials', () => {
+        expect(isOAuthCredentials({ apiKey: 'key', orgId: 'org', baseUrl: 'https://api.smoo.ai' })).toBe(false);
+    });
+});
+
+describe('maskSecret', () => {
+    it('masks after first 4 chars', () => {
+        expect(maskSecret('sk_abcdefghij')).toBe('sk_a' + '•'.repeat(9));
+    });
+
+    it('returns dots for short inputs', () => {
+        expect(maskSecret('abc')).toBe('•'.repeat(8));
+    });
+
+    it('handles empty input', () => {
+        expect(maskSecret('')).toBe('');
+    });
+
+    it('caps the dot run at 16', () => {
+        const masked = maskSecret('sk_' + 'x'.repeat(100));
+        expect(masked).toBe('sk_x' + '•'.repeat(16));
     });
 });

--- a/src/cli/utils/credentials.ts
+++ b/src/cli/utils/credentials.ts
@@ -1,34 +1,102 @@
 /**
  * Manage CLI credentials stored at ~/.smooai/credentials.json.
+ *
+ * Supports two authentication modes:
+ *   - OAuth2 client-credentials (preferred): clientId + clientSecret exchanged at
+ *     auth.smoo.ai for a short-lived access token, auto-refreshed on expiry.
+ *   - Legacy API key (fallback): apiKey used directly as `Authorization: Bearer`.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
-export interface Credentials {
+export interface OAuthCredentials {
+    clientId: string;
+    clientSecret: string;
+    orgId: string;
+    baseUrl: string;
+    authUrl: string;
+    accessToken?: string;
+    accessTokenExpiresAt?: number;
+    /** Optional legacy fallback. */
+    apiKey?: never;
+}
+
+export interface ApiKeyCredentials {
     apiKey: string;
     orgId: string;
     baseUrl: string;
+    clientId?: never;
+    clientSecret?: never;
+    authUrl?: never;
+    accessToken?: never;
+    accessTokenExpiresAt?: never;
 }
+
+export type Credentials = OAuthCredentials | ApiKeyCredentials;
 
 const SMOOAI_DIR = join(homedir(), '.smooai');
 const CREDENTIALS_FILE = join(SMOOAI_DIR, 'credentials.json');
+
+export function isOAuthCredentials(creds: Credentials): creds is OAuthCredentials {
+    return typeof (creds as OAuthCredentials).clientId === 'string' && typeof (creds as OAuthCredentials).clientSecret === 'string';
+}
+
+/**
+ * Substitute the leading hostname segment of `api.*` with `auth.*` to derive an
+ * auth server URL. Falls back to unchanged input when the hostname doesn't
+ * match the expected pattern.
+ */
+export function deriveAuthUrlFromBaseUrl(baseUrl: string): string {
+    try {
+        const url = new URL(baseUrl);
+        if (url.hostname.startsWith('api.')) {
+            url.hostname = `auth.${url.hostname.slice('api.'.length)}`;
+        } else if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
+            // Dev: keep as-is; tests will override explicitly.
+            return baseUrl;
+        }
+        return url.toString().replace(/\/+$/, '');
+    } catch {
+        return baseUrl;
+    }
+}
 
 export function loadCredentials(): Credentials | null {
     try {
         if (!existsSync(CREDENTIALS_FILE)) return null;
         const raw = readFileSync(CREDENTIALS_FILE, 'utf-8');
         const parsed = JSON.parse(raw);
-        if (!parsed.apiKey || !parsed.orgId || !parsed.baseUrl) return null;
-        return parsed as Credentials;
+
+        if (!parsed.orgId || !parsed.baseUrl) return null;
+
+        // OAuth shape
+        if (parsed.clientId && parsed.clientSecret) {
+            return {
+                clientId: parsed.clientId,
+                clientSecret: parsed.clientSecret,
+                orgId: parsed.orgId,
+                baseUrl: parsed.baseUrl,
+                authUrl: parsed.authUrl ?? deriveAuthUrlFromBaseUrl(parsed.baseUrl),
+                accessToken: parsed.accessToken,
+                accessTokenExpiresAt: parsed.accessTokenExpiresAt,
+            };
+        }
+
+        // Legacy API key shape
+        if (parsed.apiKey) {
+            return { apiKey: parsed.apiKey, orgId: parsed.orgId, baseUrl: parsed.baseUrl };
+        }
+
+        return null;
     } catch {
         return null;
     }
 }
 
 export function saveCredentials(credentials: Credentials): void {
-    mkdirSync(SMOOAI_DIR, { recursive: true });
+    mkdirSync(SMOOAI_DIR, { recursive: true, mode: 0o700 });
     writeFileSync(CREDENTIALS_FILE, JSON.stringify(credentials, null, 2), { mode: 0o600 });
 }
 
@@ -39,4 +107,15 @@ export function getCredentialsOrExit(): Credentials {
         process.exit(1);
     }
     return creds;
+}
+
+/**
+ * Mask a secret for display — show first 4 chars then fill with `•`.
+ * Used for terminal output where recording might leak values.
+ */
+export function maskSecret(value: string): string {
+    if (!value) return '';
+    if (value.length <= 4) return '•'.repeat(8);
+    const prefix = value.slice(0, 4);
+    return `${prefix}${'•'.repeat(Math.min(value.length - 4, 16))}`;
 }

--- a/src/cli/utils/oauth.spec.ts
+++ b/src/cli/utils/oauth.spec.ts
@@ -1,0 +1,89 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { exchangeClientCredentials, shouldRefreshToken } from './oauth';
+
+const AUTH_URL = 'https://auth.smoo.test';
+
+describe('shouldRefreshToken', () => {
+    it('returns true when expiresAt is undefined', () => {
+        expect(shouldRefreshToken(undefined)).toBe(true);
+    });
+
+    it('returns true inside the refresh window', () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        expect(shouldRefreshToken(nowSec + 30, 60)).toBe(true);
+    });
+
+    it('returns false outside the refresh window', () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        expect(shouldRefreshToken(nowSec + 600, 60)).toBe(false);
+    });
+});
+
+describe('exchangeClientCredentials', () => {
+    const handlers = [
+        http.post(`${AUTH_URL}/token`, async ({ request }) => {
+            expect(request.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
+            const bodyText = await request.text();
+            const body = new URLSearchParams(bodyText);
+            expect(body.get('grant_type')).toBe('client_credentials');
+            expect(body.get('provider')).toBe('client_credentials');
+
+            const clientId = body.get('client_id');
+            const clientSecret = body.get('client_secret');
+
+            if (clientId === 'happy' && clientSecret === 'sk_happy') {
+                return HttpResponse.json({ access_token: 'eyJ.happy', token_type: 'Bearer', expires_in: 3600 });
+            }
+            if (clientId === 'bad') {
+                return HttpResponse.json({ error: 'invalid_client' }, { status: 401 });
+            }
+            if (clientId === 'servererror') {
+                return HttpResponse.json({ error: 'boom' }, { status: 500 });
+            }
+            if (clientId === 'malformed') {
+                return HttpResponse.json({ foo: 'bar' });
+            }
+            return HttpResponse.json({ error: 'unexpected' }, { status: 400 });
+        }),
+    ];
+    const server = setupServer(...handlers);
+
+    beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+    afterAll(() => server.close());
+    afterEach(() => server.resetHandlers());
+
+    it('returns an access token on 200', async () => {
+        const result = await exchangeClientCredentials({
+            authUrl: AUTH_URL,
+            clientId: 'happy',
+            clientSecret: 'sk_happy',
+        });
+        expect(result.accessToken).toBe('eyJ.happy');
+        expect(result.tokenType).toBe('Bearer');
+        expect(result.expiresIn).toBe(3600);
+        expect(result.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('throws with a helpful hint on 401', async () => {
+        await expect(exchangeClientCredentials({ authUrl: AUTH_URL, clientId: 'bad', clientSecret: 'sk_bad' })).rejects.toThrow(/rejected.*HTTP 401/i);
+    });
+
+    it('throws with raw status on 5xx', async () => {
+        await expect(exchangeClientCredentials({ authUrl: AUTH_URL, clientId: 'servererror', clientSecret: 'sk_x' })).rejects.toThrow(/HTTP 500/i);
+    });
+
+    it('throws when the response is missing access_token', async () => {
+        await expect(exchangeClientCredentials({ authUrl: AUTH_URL, clientId: 'malformed', clientSecret: 'sk_x' })).rejects.toThrow(/malformed/i);
+    });
+
+    it('strips trailing slashes on authUrl', async () => {
+        const result = await exchangeClientCredentials({
+            authUrl: `${AUTH_URL}/`,
+            clientId: 'happy',
+            clientSecret: 'sk_happy',
+        });
+        expect(result.accessToken).toBe('eyJ.happy');
+    });
+});

--- a/src/cli/utils/oauth.ts
+++ b/src/cli/utils/oauth.ts
@@ -1,0 +1,99 @@
+/**
+ * OAuth2 client-credentials exchange against auth.smoo.ai.
+ *
+ * Server contract (SMOODEV-643):
+ *   POST {authUrl}/token
+ *   Content-Type: application/x-www-form-urlencoded
+ *   Body: grant_type=client_credentials
+ *         provider=client_credentials  (non-standard but required)
+ *         client_id=<uuid>
+ *         client_secret=sk_...
+ *   Response: { access_token, token_type, expires_in }
+ *
+ * Uses native `fetch` rather than `@smooai/fetch` — the latter wraps non-2xx
+ * responses in retry-happy error types which makes status handling noisy, and
+ * auth failures shouldn't silently retry.
+ */
+
+export interface TokenExchangeResult {
+    accessToken: string;
+    /** Absolute epoch seconds when the token expires. */
+    expiresAt: number;
+    expiresIn: number;
+    tokenType: string;
+}
+
+export interface TokenExchangeInput {
+    authUrl: string;
+    clientId: string;
+    clientSecret: string;
+}
+
+/**
+ * Exchange client credentials for an access token.
+ * Throws with a descriptive message on network failure or non-2xx response.
+ */
+export async function exchangeClientCredentials({ authUrl, clientId, clientSecret }: TokenExchangeInput): Promise<TokenExchangeResult> {
+    const body = new URLSearchParams({
+        grant_type: 'client_credentials',
+        provider: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+    });
+
+    const tokenEndpoint = `${authUrl.replace(/\/+$/, '')}/token`;
+
+    let response: Response;
+    try {
+        response = await fetch(tokenEndpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Token exchange failed: could not reach ${tokenEndpoint} (${msg}). Try: check your internet connection or --auth-url flag.`);
+    }
+
+    if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        if (response.status === 401 || response.status === 403) {
+            throw new Error(
+                `Token exchange rejected (HTTP ${response.status}): check --client-id and --client-secret are correct and belong to this organization.${
+                    text ? ` Server said: ${text}` : ''
+                }`,
+            );
+        }
+        throw new Error(`Token exchange failed: HTTP ${response.status} ${response.statusText}${text ? ` — ${text}` : ''}`);
+    }
+
+    const json = (await response.json().catch(() => null)) as {
+        access_token?: string;
+        token_type?: string;
+        expires_in?: number;
+    } | null;
+
+    if (!json?.access_token) {
+        throw new Error(`Token exchange returned malformed response — missing access_token`);
+    }
+
+    const expiresIn = typeof json.expires_in === 'number' ? json.expires_in : 3600;
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    return {
+        accessToken: json.access_token,
+        tokenType: json.token_type ?? 'Bearer',
+        expiresIn,
+        expiresAt: nowSec + expiresIn,
+    };
+}
+
+/**
+ * Returns true when a stored access token needs to be refreshed — either
+ * missing entirely or within the refresh window of expiry.
+ */
+export function shouldRefreshToken(expiresAt: number | undefined, refreshWindowSec = 60): boolean {
+    if (!expiresAt) return true;
+    const nowSec = Math.floor(Date.now() / 1000);
+    return nowSec >= expiresAt - refreshWindowSec;
+}

--- a/src/cli/utils/schema-loader.spec.ts
+++ b/src/cli/utils/schema-loader.spec.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, rmSync, realpathSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { findLocalConfigDir } from './schema-loader';
+import { findLocalConfigDir, loadLocalSchema } from './schema-loader';
 
 describe('schema-loader', () => {
     describe('findLocalConfigDir', () => {
@@ -12,7 +12,6 @@ describe('schema-loader', () => {
 
         beforeAll(() => {
             mkdirSync(rawTestDir, { recursive: true });
-            // Resolve macOS /var -> /private/var symlink
             testDir = realpathSync(rawTestDir);
         });
 
@@ -59,6 +58,33 @@ describe('schema-loader', () => {
             mkdirSync(plainDir);
             process.chdir(subDir);
             expect(findLocalConfigDir()).toBe(dotDir);
+        });
+    });
+
+    describe('loadLocalSchema (TypeScript via jiti)', () => {
+        const FIXTURES = resolve(__dirname, '../../../test-fixtures/cli-schema-loader');
+
+        it('loads a TS config with explicit ReturnType<typeof defineConfig> annotation', async () => {
+            // SMOODEV-643: this annotation previously crashed tsx's stripper.
+            const loaded = await loadLocalSchema(join(FIXTURES, 'annotated/.smooai-config'));
+            expect(loaded).not.toBeNull();
+            expect(loaded!.format).toBe('typescript');
+            expect(loaded!.jsonSchema).toMatchObject({ type: 'object', properties: { API_URL: { type: 'string' } } });
+            expect(loaded!.schemaName).toBe('fixture-annotated');
+        });
+
+        it('reads schemaName from the default-export object when present', async () => {
+            const loaded = await loadLocalSchema(join(FIXTURES, 'named/.smooai-config'));
+            expect(loaded).not.toBeNull();
+            expect(loaded!.schemaName).toBe('fixture-via-default');
+            expect(loaded!.jsonSchema).toMatchObject({ properties: { DEBUG: { type: 'boolean' } } });
+        });
+
+        it('reads $smooaiName from schema.json', async () => {
+            const loaded = await loadLocalSchema(join(FIXTURES, 'json-named/.smooai-config'));
+            expect(loaded).not.toBeNull();
+            expect(loaded!.format).toBe('json-schema');
+            expect(loaded!.schemaName).toBe('fixture-json');
         });
     });
 });

--- a/src/cli/utils/schema-loader.ts
+++ b/src/cli/utils/schema-loader.ts
@@ -7,11 +7,18 @@
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 
 export interface LoadedSchema {
     format: 'typescript' | 'json-schema' | 'python-generator' | 'go-generator' | 'rust-generator';
     jsonSchema: Record<string, unknown>;
     filePath: string;
+    /**
+     * Optional canonical schema name declared by the config module itself
+     * (e.g. `export const schemaName = 'smooai'`). When present, the `push`
+     * command uses this instead of a cwd-basename fallback.
+     */
+    schemaName?: string;
 }
 
 /**
@@ -55,6 +62,35 @@ function runGenerator(command: string, filePath: string, format: LoadedSchema['f
 }
 
 /**
+ * SMOODEV-643: load a TypeScript config module through `jiti`.
+ *
+ * Why jiti and not tsx's `tsImport`: the explicit type annotation
+ *   `const config: ReturnType<typeof defineConfig> = defineConfig({...})`
+ * — added in the smooai monorepo to work around a tsgo issue — trips tsx's
+ * lightweight stripper with `SyntaxError: Missing initializer in const
+ * declaration`. jiti uses a full TypeScript compiler path that handles
+ * arbitrary TS, including complex type annotations and re-exports.
+ */
+async function loadTsConfigModule(tsPath: string): Promise<Record<string, unknown>> {
+    // Dynamic import so the CLI bundle doesn't resolve jiti at import-graph
+    // time (it's only needed when a project has a .ts config). We keep
+    // `interopDefault: false` so named exports like `schemaName` survive — we
+    // manually unwrap the default in `loadLocalSchema`.
+    const { createJiti } = await import('jiti');
+    const jiti = createJiti(pathToFileURL(tsPath).href, { interopDefault: false, moduleCache: false });
+    const mod = (await jiti.import(tsPath)) as Record<string, unknown>;
+    return mod;
+}
+
+function pickSchemaName(mod: Record<string, unknown>, configDef: Record<string, unknown>): string | undefined {
+    const candidates = [configDef.schemaName, configDef.name, mod.schemaName, mod.name];
+    for (const v of candidates) {
+        if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+    return undefined;
+}
+
+/**
  * Load config schema from .smooai-config/.
  *
  * Detection order:
@@ -72,10 +108,13 @@ export async function loadLocalSchema(configDir?: string): Promise<LoadedSchema 
     const jsonSchemaPath = join(dir, 'schema.json');
     if (existsSync(jsonSchemaPath)) {
         const raw = readFileSync(jsonSchemaPath, 'utf-8');
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const schemaName = typeof parsed.$smooaiName === 'string' ? parsed.$smooaiName : undefined;
         return {
             format: 'json-schema',
-            jsonSchema: JSON.parse(raw),
+            jsonSchema: parsed,
             filePath: jsonSchemaPath,
+            schemaName,
         };
     }
 
@@ -86,24 +125,20 @@ export async function loadLocalSchema(configDir?: string): Promise<LoadedSchema 
 
     if (tsPath) {
         try {
-            // SMOODEV-602: use tsx's `tsImport` to load `.ts` at runtime. A bare
-            // `await import(tsPath)` hits ERR_UNKNOWN_FILE_EXTENSION under Node
-            // because .ts has no built-in loader. `tsx` is already a dependency
-            // of this package — routing the dynamic import through it lets
-            // `smooai-config diff/push/pull` work out of the box in any project
-            // whose `.smooai-config/config.ts` is actual TypeScript.
-            const { tsImport } = await import('tsx/esm/api');
-            const mod = await tsImport(tsPath, import.meta.url);
-            const configDef = mod.default ?? mod;
+            const mod = await loadTsConfigModule(tsPath);
+            const configDef = ((mod as { default?: Record<string, unknown> }).default ?? mod) as Record<string, unknown>;
+
             if (configDef.serializedAllConfigSchema) {
                 return {
                     format: 'typescript',
-                    jsonSchema: configDef.serializedAllConfigSchema,
+                    jsonSchema: configDef.serializedAllConfigSchema as Record<string, unknown>,
                     filePath: tsPath,
+                    schemaName: pickSchemaName(mod, configDef),
                 };
             }
         } catch (err) {
-            throw new Error(`Failed to load TypeScript config from ${tsPath}: ${err}`);
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new Error(`Failed to load TypeScript config from ${tsPath}: ${msg}`);
         }
     }
 

--- a/test-fixtures/cli-schema-loader/annotated/.smooai-config/config.ts
+++ b/test-fixtures/cli-schema-loader/annotated/.smooai-config/config.ts
@@ -1,0 +1,28 @@
+// SMOODEV-643 reproducer: explicit `ReturnType<typeof ...>` annotation
+// crashes tsx's lightweight TS stripper (`Missing initializer in const
+// declaration`). jiti handles it fine, which is exactly why we switched.
+//
+// We stub out defineConfig locally so the fixture has no dep on the parent
+// package graph — the loader only reads `serializedAllConfigSchema` + optional
+// `schemaName`, and this minimal shape is enough.
+
+type Fake = {
+    serializedAllConfigSchema: Record<string, unknown>;
+};
+
+function defineConfig(input: { serializedAllConfigSchema: Record<string, unknown> }): Fake {
+    return input;
+}
+
+const config: ReturnType<typeof defineConfig> = defineConfig({
+    serializedAllConfigSchema: {
+        type: 'object',
+        properties: {
+            API_URL: { type: 'string' },
+        },
+    },
+});
+
+export const schemaName = 'fixture-annotated';
+
+export default config;

--- a/test-fixtures/cli-schema-loader/json-named/.smooai-config/schema.json
+++ b/test-fixtures/cli-schema-loader/json-named/.smooai-config/schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$smooaiName": "fixture-json",
+    "type": "object",
+    "properties": {
+        "MAX_RETRIES": { "type": "number" }
+    }
+}

--- a/test-fixtures/cli-schema-loader/named/.smooai-config/config.ts
+++ b/test-fixtures/cli-schema-loader/named/.smooai-config/config.ts
@@ -1,0 +1,13 @@
+function defineConfig<T extends { serializedAllConfigSchema: Record<string, unknown> }>(input: T): T {
+    return input;
+}
+
+export default defineConfig({
+    serializedAllConfigSchema: {
+        type: 'object',
+        properties: {
+            DEBUG: { type: 'boolean' },
+        },
+    },
+    schemaName: 'fixture-via-default',
+});


### PR DESCRIPTION
## Summary

Four bugs and a polished Ink UI for `smooai-config`. [Jira SMOODEV-643](https://smooai.atlassian.net/browse/SMOODEV-643).

### Bug fixes

- **OAuth2 client-credentials login (Bug 1).** New `--client-id` / `--client-secret` flags on `smooai-config login`. Exchange runs against `auth.smoo.ai/token` with the non-standard `provider=client_credentials` field; token is stored at `~/.smooai/credentials.json` (mode `0600`) and auto-refreshed by `CliApiClient` when within 60s of expiry (writes the refreshed token back via `onCredentialsChange`). Auth URL derives from `--base-url` (`api.*` → `auth.*`) and can be overridden with `--auth-url`. Legacy `--api-key` is still supported and continues to send a direct `Authorization: Bearer` header.
- **tsx TS parse failure (Bug 2).** Swapped `tsx/esm/api`'s `tsImport` for **`jiti`**. tsx's lightweight stripper crashed on the explicit `const config: ReturnType<typeof defineConfig> = defineConfig({...})` annotation; jiti uses the full TypeScript compiler path and handles it. Fixture at `test-fixtures/cli-schema-loader/annotated/` reproduces the crashing annotation so we don't regress.
- **`push` cwd-basename foot-gun (Bug 3).** No more silent garbage schemas from running `push` in the wrong directory. `push` now requires either `--schema-name`, or a top-level `schemaName` / `name` export from `.smooai-config/config.ts`, or `$smooaiName` in `schema.json`. Fails with an actionable error when none are present. Warns when flag and in-file name disagree.
- **`list` silent-empty-on-error (Bug 4).** `CliApiClient.getAllValues` now surfaces server-side `{ success: false, error: ... }` envelopes as real errors, and the `list` command renders them in a dedicated `ErrorPanel` with a `Try: ...` hint.

### UI glowup

- **Brand tokens** sourced from `packages/ui/globals.css`: orange `#f49f0a`, teal `#00a6a6`, dark blue `#25405d`, muted orange `#523603`. Centralised in `src/cli/components/brand.tsx`.
- **Banner** — `cfonts` `block` font for wide terminals, auto-degrading to `chrome` / `tiny` on narrow ones; orange→teal gradient.
- **TaskList** — brand-coloured ✔ / ✖ marks, `dots3` spinner, elapsed-seconds counter for long-running tasks, optional `hint` line under each task.
- **Panels** — reusable `SummaryPanel` / `SuccessPanel` / `ErrorPanel` with rounded borders; every command surfaces actionable `Try: ...` hints on failure.
- **Secret redaction** — `set --tier secret` and any key matching `/secret|token|key|password|credential/i` in `list` mask after the first 4 chars with `•`. New `--show-secrets` opt-in on `list`.
- **No new Ink deps** — still just `ink`, `ink-big-text`, `ink-gradient`, `ink-spinner`.

### Login flag signature

```
smooai-config login
  --client-id <uuid>          OAuth2 client_id (use with --client-secret)
  --client-secret <sk_...>    OAuth2 client_secret
  --api-key <key>             Legacy API key (fallback mode)
  --org-id <id>               Organization ID          [required]
  --base-url <url>            default: https://api.smoo.ai
  --auth-url <url>            auto-derived from --base-url when omitted
```

### Ink UI snapshot (login)

```
 ███████╗ ███╗   ███╗  ██████╗   ██████╗       █████╗  ██╗
 ██╔════╝ ████╗ ████║ ██╔═══██╗ ██╔═══██╗     ██╔══██╗ ██║
 ███████╗ ██╔████╔██║ ██║   ██║ ██║   ██║     ███████║ ██║
 ╚════██║ ██║╚██╔╝██║ ██║   ██║ ██║   ██║     ██╔══██║ ██║
 ███████║ ██║ ╚═╝ ██║ ╚██████╔╝ ╚██████╔╝     ██║  ██║ ██║
 ╚══════╝ ╚═╝     ╚═╝  ╚═════╝   ╚═════╝      ╚═╝  ╚═╝ ╚═╝

smooai-config · Login · oauth2 client-credentials

╭─────────────────────────────────────────────╮
│ Target                                      │
│ org    550e8400-org-fake                    │
│ api    https://api.smoo.ai                  │
│ auth   https://auth.smoo.ai                 │
│ id     5c3f4d8a-1                           │
│ secret sk_l•••••••••••••••                  │
╰─────────────────────────────────────────────╯

⠋  Exchanging client credentials for access token (0.3s)
○  Validating token against api.smoo.ai
○  Saving to ~/.smooai/credentials.json
```

## Test plan

- [x] `pnpm vitest run --passWithNoTests` — 169 unit tests pass (including 8 new OAuth tests, 5 new `resolveSchemaName` tests, 3 new schema-loader fixture tests)
- [x] `pnpm exec tsc --noEmit --skipLibCheck` — clean
- [x] `pnpm exec oxlint` — clean on CLI files
- [x] `pnpm exec oxfmt --check .` — clean
- [x] `pnpm build:cli` — CLI bundle builds, `smooai-config --help` + `login --help` render correctly
- [x] Pre-commit hook passes (lint, typecheck, test, build, format, python/rust/go suites)
- [x] MSW integration test covers token exchange → reuse → refresh-on-stale → fresh-skip → 401 surfacing → `{success:false}` envelope
- [ ] Manual happy-path `login` against prod after merge (brent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)