### PR TITLE
SMOODEV-661: SmooAI.Config .NET phase 2 — local runtime + buildBundle + source generator

### DIFF
--- a/.changeset/dotnet-config-phase2.md
+++ b/.changeset/dotnet-config-phase2.md
@@ -1,0 +1,12 @@
+---
+'@smooai/config': minor
+---
+
+SmooAI.Config .NET phase 2: ship full parity with the TypeScript, Python, Rust, and Go clients.
+
+- **Local runtime** (`SmooConfigRuntime`) — AES-256-GCM decrypt of a baked bundle from `SMOO_CONFIG_KEY_FILE` + `SMOO_CONFIG_KEY`. Wire-compatible with every other language client (12-byte nonce || ciphertext || 16-byte tag). Thread-safe lazy singleton with env-var fallback for local dev.
+- **Build pipeline** (`SmooConfigBuilder.BuildAsync`) — fetches all values via the HTTP client, partitions public/secret via a `Classify` delegate (feature flags skipped), emits an encrypted bundle + base64 AES key. `SchemaClassifier.FromSchemaFile` reads a `schema.json` (JSON-Schema shape or serialized `defineConfig` shape).
+- **Roslyn source generator** — reads a `schema.json` from the consumer's `AdditionalFiles` and emits strongly-typed `Public.*`, `Secrets.*`, `FeatureFlags.*` static `ConfigKey<T>` properties under `SmooAI.Config.Generated`. Shipped inside the main `SmooAI.Config` NuGet — one package install, compile-time-safe key access.
+- **Typed key API** (`ConfigKey<T>`) — `.GetAsync(client)`, `.Get(runtime)`, `.ResolveAsync(runtime, client)`. Runtime-baked values resolve synchronously; missing keys fall through to the HTTP client.
+- **Great NuGet README** — rewritten with quickstart, feature overview, and wire-compat notes. Renders on nuget.org.
+- **Version sync** — `scripts/sync-versions.mjs` now bumps the `.csproj` to the npm version on every Changesets release; the Release workflow publishes to NuGet alongside PyPI/crates.io/Go. NuGet version aligns with the npm version (first synced release: 4.4.0).

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,7 +3,13 @@ name: Publish NuGet (SmooAI.Config)
 on:
     push:
         tags:
+            # Primary — matches the npm release tag produced by Changesets.
+            # Version stays in lockstep with every other language client.
+            - 'v*'
+            # Legacy — kept so manually-pushed dotnet-only releases still work.
             - 'dotnet-v*'
+            # Per-package Changesets tag (`@smooai/config@<version>`).
+            - '@smooai/config@*'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,22 @@ jobs:
                   git push origin "${TAG}"
                   echo "Go module tagged and pushed: ${TAG}"
 
+            - name: Publish SmooAI.Config to NuGet
+              if: steps.changesets.outputs.published == 'true'
+              working-directory: dotnet
+              env:
+                  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+              run: |
+                  if [ -z "${NUGET_API_KEY}" ]; then
+                      echo "::error::NUGET_API_KEY secret is not set"
+                      exit 1
+                  fi
+                  dotnet pack src/SmooAI.Config/SmooAI.Config.csproj -c Release --no-build -o dist
+                  dotnet nuget push "dist/*.nupkg" \
+                      --api-key "${NUGET_API_KEY}" \
+                      --source https://api.nuget.org/v3/index.json \
+                      --skip-duplicate
+
             - name: Auto-Merge Changeset PR
               run: |
                   PR_NUMBER=$(gh pr list --state open --head changeset-release/main --json number --jq '.[0].number')

--- a/dotnet/SmooAI.Config.sln
+++ b/dotnet/SmooAI.Config.sln
@@ -11,26 +11,76 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{401A922D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmooAI.Config.Tests", "tests\SmooAI.Config.Tests\SmooAI.Config.Tests.csproj", "{22436F76-8FBD-4F08-902A-E4848F468B20}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmooAI.Config.SourceGenerator", "src\SmooAI.Config.SourceGenerator\SmooAI.Config.SourceGenerator.csproj", "{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmooAI.Config.SourceGenerator.Tests", "tests\SmooAI.Config.SourceGenerator.Tests\SmooAI.Config.SourceGenerator.Tests.csproj", "{F5C45060-93D1-4709-9A06-0632A38AD58D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Debug|x86.Build.0 = Debug|Any CPU
 		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|x64.Build.0 = Release|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C833C24-A785-4C3D-92E5-397A8E642C67}.Release|x86.Build.0 = Release|Any CPU
 		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|x64.Build.0 = Debug|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Debug|x86.Build.0 = Debug|Any CPU
 		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|x64.ActiveCfg = Release|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|x64.Build.0 = Release|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|x86.ActiveCfg = Release|Any CPU
+		{22436F76-8FBD-4F08-902A-E4848F468B20}.Release|x86.Build.0 = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|x64.Build.0 = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Debug|x86.Build.0 = Debug|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|x64.ActiveCfg = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|x64.Build.0 = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|x86.ActiveCfg = Release|Any CPU
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064}.Release|x86.Build.0 = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|x64.Build.0 = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5C45060-93D1-4709-9A06-0632A38AD58D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7C833C24-A785-4C3D-92E5-397A8E642C67} = {F6179CD1-E405-451F-B89D-6331B629A0EE}
 		{22436F76-8FBD-4F08-902A-E4848F468B20} = {401A922D-A198-45BA-9E46-9B94449FC2B6}
+		{949F5E7D-2F8B-4EDC-9AE1-A1707D588064} = {F6179CD1-E405-451F-B89D-6331B629A0EE}
+		{F5C45060-93D1-4709-9A06-0632A38AD58D} = {401A922D-A198-45BA-9E46-9B94449FC2B6}
 	EndGlobalSection
 EndGlobal

--- a/dotnet/src/SmooAI.Config.SourceGenerator/AssemblyInfo.cs
+++ b/dotnet/src/SmooAI.Config.SourceGenerator/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SmooAI.Config.SourceGenerator.Tests")]

--- a/dotnet/src/SmooAI.Config.SourceGenerator/SmooAI.Config.SourceGenerator.csproj
+++ b/dotnet/src/SmooAI.Config.SourceGenerator/SmooAI.Config.SourceGenerator.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+
+    <!-- Roslyn source generators must target netstandard2.0. -->
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <!--
+      System.Text.Json is provided by the Roslyn analyzer host in 4.8+, so we
+      don't ship it alongside the analyzer. A compile-time reference is
+      sufficient — ExcludeAssets=runtime prevents it from being copied into
+      the consumer's output.
+    -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/SmooAI.Config.SourceGenerator/SmooConfigSchemaGenerator.cs
+++ b/dotnet/src/SmooAI.Config.SourceGenerator/SmooConfigSchemaGenerator.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SmooAI.Config.SourceGenerator;
+
+/// <summary>
+/// Incremental source generator that reads a <c>schema.json</c> file from the
+/// consumer project's <c>AdditionalFiles</c> and emits strongly-typed static
+/// <c>ConfigKey&lt;T&gt;</c> properties under <c>SmooAI.Config.Generated</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Consumers opt in by including the schema file in their csproj:
+/// </para>
+/// <code>
+/// &lt;ItemGroup&gt;
+///   &lt;AdditionalFiles Include="schema.json" SmooConfigSchema="true" /&gt;
+/// &lt;/ItemGroup&gt;
+/// </code>
+/// <para>
+/// The generator recognizes two schema shapes (both produced by the
+/// <c>@smooai/config</c> CLI):
+/// </para>
+/// <list type="number">
+///   <item><description>JSON-Schema shape — <c>{ properties: { public, secret, featureFlags } }</c></description></item>
+///   <item><description>Serialized <c>defineConfig</c> shape — <c>{ publicConfigSchema, secretConfigSchema, featureFlagSchema }</c></description></item>
+/// </list>
+/// </remarks>
+[Generator(LanguageNames.CSharp)]
+public sealed class SmooConfigSchemaGenerator : IIncrementalGenerator
+{
+    private const string SchemaMetadataKey = "SmooConfigSchema";
+    private const string DefaultNamespace = "SmooAI.Config.Generated";
+
+    /// <inheritdoc />
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var schemaFiles = context.AdditionalTextsProvider
+            .Combine(context.AnalyzerConfigOptionsProvider)
+            .Where(pair =>
+            {
+                var (file, optionsProvider) = pair;
+                var options = optionsProvider.GetOptions(file);
+                if (options.TryGetValue($"build_metadata.AdditionalFiles.{SchemaMetadataKey}", out var flag)
+                    && !string.IsNullOrEmpty(flag)
+                    && !string.Equals(flag, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                // Convention: a root-level `schema.json` is treated as a schema.
+                var name = System.IO.Path.GetFileName(file.Path);
+                return string.Equals(name, "schema.json", StringComparison.OrdinalIgnoreCase);
+            })
+            .Select((pair, cancellationToken) =>
+            {
+                var (file, optionsProvider) = pair;
+                var text = file.GetText(cancellationToken)?.ToString() ?? string.Empty;
+                var options = optionsProvider.GetOptions(file);
+                options.TryGetValue($"build_metadata.AdditionalFiles.SmooConfigNamespace", out var ns);
+                return new SchemaInput(file.Path, text, string.IsNullOrWhiteSpace(ns) ? DefaultNamespace : ns!);
+            });
+
+        context.RegisterSourceOutput(schemaFiles, Emit);
+    }
+
+    private void Emit(SourceProductionContext context, SchemaInput input)
+    {
+        ParsedSchema parsed;
+        try
+        {
+            parsed = Parse(input.Text);
+        }
+        catch (JsonException ex)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: "SMOOCFG001",
+                    title: "Invalid schema JSON",
+                    messageFormat: "Schema file '{0}' is not valid JSON: {1}",
+                    category: "SmooAI.Config",
+                    defaultSeverity: DiagnosticSeverity.Error,
+                    isEnabledByDefault: true),
+                Location.None,
+                input.FilePath,
+                ex.Message));
+            return;
+        }
+
+        var source = Render(parsed, input.Namespace);
+        context.AddSource("SmooConfigGenerated.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    internal static ParsedSchema Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new ParsedSchema(ImmutableArray<SchemaKey>.Empty, ImmutableArray<SchemaKey>.Empty, ImmutableArray<SchemaKey>.Empty);
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return new ParsedSchema(ImmutableArray<SchemaKey>.Empty, ImmutableArray<SchemaKey>.Empty, ImmutableArray<SchemaKey>.Empty);
+        }
+
+        var pub = new List<SchemaKey>();
+        var sec = new List<SchemaKey>();
+        var flags = new List<SchemaKey>();
+
+        // Shape 1 — JSON-Schema: { properties: { public, secret, featureFlags } }
+        if (root.TryGetProperty("properties", out var properties) && properties.ValueKind == JsonValueKind.Object)
+        {
+            ExtractFromJsonSchemaSection(properties, "public", pub);
+            ExtractFromJsonSchemaSection(properties, "secret", sec);
+            ExtractFromJsonSchemaSection(properties, "featureFlags", flags);
+        }
+
+        // Shape 2 — serialized defineConfig: { publicConfigSchema, secretConfigSchema, featureFlagSchema }
+        ExtractFromSerializedObject(root, "publicConfigSchema", pub);
+        ExtractFromSerializedObject(root, "secretConfigSchema", sec);
+        ExtractFromSerializedObject(root, "featureFlagSchema", flags);
+
+        return new ParsedSchema(pub.ToImmutableArray(), sec.ToImmutableArray(), flags.ToImmutableArray());
+    }
+
+    private static void ExtractFromJsonSchemaSection(JsonElement properties, string sectionName, List<SchemaKey> target)
+    {
+        if (!properties.TryGetProperty(sectionName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        if (!section.TryGetProperty("properties", out var keys) || keys.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in keys.EnumerateObject())
+        {
+            var type = InferTypeFromJsonSchema(prop.Value);
+            target.Add(new SchemaKey(prop.Name, type));
+        }
+    }
+
+    private static void ExtractFromSerializedObject(JsonElement root, string sectionName, List<SchemaKey> target)
+    {
+        if (!root.TryGetProperty(sectionName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in section.EnumerateObject())
+        {
+            var type = InferTypeFromSerializedValue(prop.Value);
+            // Don't double-register if the JSON-Schema shape already populated
+            // the same key above.
+            if (target.Any(k => k.Name == prop.Name)) continue;
+            target.Add(new SchemaKey(prop.Name, type));
+        }
+    }
+
+    private static string InferTypeFromJsonSchema(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return "string";
+        if (!element.TryGetProperty("type", out var typeElement)) return "string";
+        if (typeElement.ValueKind != JsonValueKind.String) return "string";
+        return typeElement.GetString() switch
+        {
+            "string" => "string",
+            "boolean" => "bool",
+            "number" or "integer" => "double",
+            _ => "string",
+        };
+    }
+
+    private static string InferTypeFromSerializedValue(JsonElement element)
+    {
+        // Serialized schema leafs: "stringSchema" | "booleanSchema" | "numberSchema" | { JSON Schema object }
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return element.GetString() switch
+            {
+                "stringSchema" => "string",
+                "booleanSchema" => "bool",
+                "numberSchema" => "double",
+                _ => "string",
+            };
+        }
+        return InferTypeFromJsonSchema(element);
+    }
+
+    internal static string Render(ParsedSchema parsed, string ns)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using SmooAI.Config.Models;");
+        sb.AppendLine("using SmooAI.Config.Typed;");
+        sb.AppendLine();
+        sb.Append("namespace ").Append(ns).AppendLine(";");
+        sb.AppendLine();
+
+        RenderSection(sb, "Public", parsed.PublicKeys, "ConfigTier.Public");
+        sb.AppendLine();
+        RenderSection(sb, "Secrets", parsed.SecretKeys, "ConfigTier.Secret");
+        sb.AppendLine();
+        RenderSection(sb, "FeatureFlags", parsed.FeatureFlagKeys, "ConfigTier.FeatureFlag");
+
+        return sb.ToString();
+    }
+
+    private static void RenderSection(StringBuilder sb, string className, ImmutableArray<SchemaKey> keys, string tierExpression)
+    {
+        sb.Append("/// <summary>Generated typed keys for the <c>").Append(className).AppendLine("</c> tier.</summary>");
+        sb.Append("public static class ").AppendLine(className);
+        sb.AppendLine("{");
+        foreach (var key in keys)
+        {
+            var propertyName = ToPascalCase(key.Name);
+            sb.Append("    /// <summary>Config key <c>").Append(key.Name).AppendLine("</c>.</summary>");
+            sb.Append("    public static global::SmooAI.Config.Typed.ConfigKey<").Append(key.ClrType).Append("> ")
+              .Append(propertyName)
+              .Append(" { get; } = new global::SmooAI.Config.Typed.ConfigKey<").Append(key.ClrType).Append(">(")
+              .Append('"').Append(EscapeString(key.Name)).Append('"').Append(", ")
+              .Append("global::SmooAI.Config.Models.").Append(tierExpression).Append(")")
+              .AppendLine(";");
+        }
+        sb.AppendLine("}");
+    }
+
+    private static string ToPascalCase(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return key;
+        // Split on non-alphanumerics and re-join with each part capitalized.
+        var parts = new List<string>();
+        var buf = new StringBuilder();
+        bool prevUpper = false;
+        foreach (var ch in key)
+        {
+            if (!char.IsLetterOrDigit(ch))
+            {
+                if (buf.Length > 0) { parts.Add(buf.ToString()); buf.Clear(); }
+                prevUpper = false;
+                continue;
+            }
+            // Split camelCase: lowercase->uppercase transition starts a new word.
+            if (char.IsUpper(ch) && buf.Length > 0 && !prevUpper)
+            {
+                parts.Add(buf.ToString());
+                buf.Clear();
+            }
+            buf.Append(ch);
+            prevUpper = char.IsUpper(ch);
+        }
+        if (buf.Length > 0) parts.Add(buf.ToString());
+        var sb = new StringBuilder();
+        foreach (var p in parts)
+        {
+            if (p.Length == 0) continue;
+            sb.Append(char.ToUpperInvariant(p[0]));
+            if (p.Length > 1) sb.Append(p.Substring(1).ToLowerInvariant());
+        }
+        var result = sb.ToString();
+        if (result.Length == 0) return "Value";
+        if (char.IsDigit(result[0])) result = "_" + result;
+        return result;
+    }
+
+    private static string EscapeString(string s) => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    internal sealed class SchemaInput
+    {
+        public string FilePath { get; }
+        public string Text { get; }
+        public string Namespace { get; }
+        public SchemaInput(string filePath, string text, string ns)
+        {
+            FilePath = filePath;
+            Text = text;
+            Namespace = ns;
+        }
+    }
+
+    internal sealed class SchemaKey
+    {
+        public string Name { get; }
+        public string ClrType { get; }
+        public SchemaKey(string name, string clrType)
+        {
+            Name = name;
+            ClrType = clrType;
+        }
+    }
+
+    internal sealed class ParsedSchema
+    {
+        public ImmutableArray<SchemaKey> PublicKeys { get; }
+        public ImmutableArray<SchemaKey> SecretKeys { get; }
+        public ImmutableArray<SchemaKey> FeatureFlagKeys { get; }
+        public ParsedSchema(
+            ImmutableArray<SchemaKey> publicKeys,
+            ImmutableArray<SchemaKey> secretKeys,
+            ImmutableArray<SchemaKey> featureFlagKeys)
+        {
+            PublicKeys = publicKeys;
+            SecretKeys = secretKeys;
+            FeatureFlagKeys = featureFlagKeys;
+        }
+    }
+}

--- a/dotnet/src/SmooAI.Config/Build/SchemaClassifier.cs
+++ b/dotnet/src/SmooAI.Config/Build/SchemaClassifier.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+
+namespace SmooAI.Config.Build;
+
+/// <summary>
+/// Classifier factory that routes each key into <c>public</c>, <c>secret</c>,
+/// or <c>skip</c> based on a schema description.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two schema shapes are recognized — both produced by the first-party
+/// <c>@smooai/config</c> CLI:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <description>
+///       The JSON Schema shape written by <c>smooai-config init</c>:
+///       <c>{ properties: { public: {}, secret: {}, featureFlags: {} } }</c>.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       The serialized <c>defineConfig</c> shape:
+///       <c>{ publicConfigSchema: {}, secretConfigSchema: {}, featureFlagSchema: {} }</c>.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Unknown keys default to <c>public</c>, matching TS/Python behavior.
+/// </para>
+/// </remarks>
+public static class SchemaClassifier
+{
+    /// <summary>
+    /// Parse a <c>schema.json</c> file on disk into a classifier.
+    /// </summary>
+    public static Func<string, JsonElement, ClassifyResult> FromSchemaFile(string schemaPath)
+    {
+        if (string.IsNullOrWhiteSpace(schemaPath)) throw new ArgumentException("Schema path is required.", nameof(schemaPath));
+        var json = File.ReadAllText(schemaPath);
+        return FromSchemaJson(json);
+    }
+
+    /// <summary>
+    /// Parse a schema JSON string (either JSON-Schema shape or serialized
+    /// <c>defineConfig</c> shape) into a classifier.
+    /// </summary>
+    public static Func<string, JsonElement, ClassifyResult> FromSchemaJson(string schemaJson)
+    {
+        if (string.IsNullOrWhiteSpace(schemaJson)) throw new ArgumentException("Schema JSON is required.", nameof(schemaJson));
+        using var doc = JsonDocument.Parse(schemaJson);
+        return FromSchemaElement(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Build a classifier from a parsed <see cref="JsonElement"/>.
+    /// </summary>
+    public static Func<string, JsonElement, ClassifyResult> FromSchemaElement(JsonElement root)
+    {
+        var publicKeys = new HashSet<string>(StringComparer.Ordinal);
+        var secretKeys = new HashSet<string>(StringComparer.Ordinal);
+        var flagKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        // Shape 1: JSON-Schema shape.
+        if (root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("properties", out var properties)
+            && properties.ValueKind == JsonValueKind.Object)
+        {
+            AddKeysFromSection(properties, "public", publicKeys);
+            AddKeysFromSection(properties, "secret", secretKeys);
+            AddKeysFromSection(properties, "featureFlags", flagKeys);
+        }
+
+        // Shape 2: serialized defineConfig shape.
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            AddKeysFromObject(root, "publicConfigSchema", publicKeys);
+            AddKeysFromObject(root, "secretConfigSchema", secretKeys);
+            AddKeysFromObject(root, "featureFlagSchema", flagKeys);
+        }
+
+        return FromKeys(publicKeys, secretKeys, flagKeys);
+    }
+
+    /// <summary>
+    /// Build a classifier from explicit key sets. Useful when callers
+    /// already extracted the keys from some other source.
+    /// </summary>
+    public static Func<string, JsonElement, ClassifyResult> FromKeys(
+        IEnumerable<string>? publicKeys,
+        IEnumerable<string>? secretKeys,
+        IEnumerable<string>? featureFlagKeys)
+    {
+        var pub = new HashSet<string>(publicKeys ?? Enumerable.Empty<string>(), StringComparer.Ordinal);
+        var sec = new HashSet<string>(secretKeys ?? Enumerable.Empty<string>(), StringComparer.Ordinal);
+        var flags = new HashSet<string>(featureFlagKeys ?? Enumerable.Empty<string>(), StringComparer.Ordinal);
+
+        return (key, _) =>
+        {
+            if (sec.Contains(key)) return ClassifyResult.Secret;
+            if (pub.Contains(key)) return ClassifyResult.Public;
+            if (flags.Contains(key)) return ClassifyResult.Skip;
+            return ClassifyResult.Public;
+        };
+    }
+
+    private static void AddKeysFromSection(JsonElement properties, string sectionName, HashSet<string> target)
+    {
+        if (!properties.TryGetProperty(sectionName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        if (!section.TryGetProperty("properties", out var keys) || keys.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in keys.EnumerateObject())
+        {
+            target.Add(prop.Name);
+        }
+    }
+
+    private static void AddKeysFromObject(JsonElement root, string objectName, HashSet<string> target)
+    {
+        if (!root.TryGetProperty(objectName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in section.EnumerateObject())
+        {
+            target.Add(prop.Name);
+        }
+    }
+}

--- a/dotnet/src/SmooAI.Config/Build/SmooConfigBuilder.cs
+++ b/dotnet/src/SmooAI.Config/Build/SmooConfigBuilder.cs
@@ -1,0 +1,186 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using SmooAI.Config.Models;
+
+namespace SmooAI.Config.Build;
+
+/// <summary>
+/// Deploy-time baker for <c>SmooAI.Config</c>. Wire-compatible with the
+/// TypeScript, Python, Rust and Go builders.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Fetches every config value for an environment via
+/// <see cref="SmooConfigClient"/>, partitions into <c>public</c> / <c>secret</c>
+/// sections based on a schema (feature flags are dropped — they stay
+/// live-fetched), encrypts with AES-256-GCM and a freshly-generated random key
+/// + 12-byte nonce, and returns the bundle bytes + base64-encoded key.
+/// </para>
+/// <para>
+/// Deploy glue writes the bundle to disk, ships it with the function, and
+/// sets two env vars so the function can decrypt at cold start:
+/// </para>
+/// <list type="bullet">
+///   <item><c>SMOO_CONFIG_KEY_FILE</c> = absolute path to the blob on disk</item>
+///   <item><c>SMOO_CONFIG_KEY</c> = returned <see cref="BuildBundleResult.KeyB64"/></item>
+/// </list>
+/// <para>
+/// Bundle layout: <c>nonce (12 bytes) || ciphertext || authTag (16 bytes)</c>.
+/// </para>
+/// </remarks>
+public static class SmooConfigBuilder
+{
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+    private const int KeySize = 32;
+
+    /// <summary>
+    /// Fetch every value for the given environment and encrypt into a bundle.
+    /// Provide a <see cref="BuildBundleOptions.Classify"/> delegate — or use
+    /// <see cref="SchemaClassifier.FromSchemaFile(string)"/> — so the baker knows
+    /// which keys are <c>public</c>, <c>secret</c>, or skipped.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">When <paramref name="client"/> or <paramref name="options"/> is null.</exception>
+    public static async Task<BuildBundleResult> BuildAsync(
+        SmooConfigClient client,
+        BuildBundleOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(options);
+
+        Func<string, JsonElement, ClassifyResult> classify = options.Classify ?? ((_, _) => ClassifyResult.Public);
+        var all = await client.GetAllValuesAsync(options.Environment, cancellationToken).ConfigureAwait(false);
+
+        var publicValues = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        var secretValues = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        var skipped = 0;
+
+        foreach (var (key, value) in all)
+        {
+            var tier = classify(key, value);
+            switch (tier)
+            {
+                case ClassifyResult.Skip:
+                    skipped++;
+                    break;
+                case ClassifyResult.Public:
+                    publicValues[key] = value;
+                    break;
+                case ClassifyResult.Secret:
+                    secretValues[key] = value;
+                    break;
+                default:
+                    publicValues[key] = value;
+                    break;
+            }
+        }
+
+        var partitioned = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>(StringComparer.Ordinal)
+        {
+            ["public"] = publicValues,
+            ["secret"] = secretValues,
+        };
+
+        var plaintext = JsonSerializer.SerializeToUtf8Bytes(partitioned, SerializerOptions);
+        var (bundle, keyB64) = Encrypt(plaintext);
+
+        return new BuildBundleResult(
+            keyB64: keyB64,
+            bundle: bundle,
+            keyCount: publicValues.Count + secretValues.Count,
+            skippedCount: skipped);
+    }
+
+    /// <summary>
+    /// Encrypt a pre-built plaintext payload. Useful for tests and for
+    /// callers that already have the partitioned <c>{public, secret}</c>
+    /// bytes and want to re-bundle without a live HTTP fetch.
+    /// </summary>
+    public static (byte[] bundle, string keyB64) Encrypt(ReadOnlySpan<byte> plaintext)
+    {
+        var key = RandomNumberGenerator.GetBytes(KeySize);
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[TagSize];
+
+        try
+        {
+            using var aes = new AesGcm(key, TagSize);
+            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+        }
+        finally
+        {
+            // Defence in depth — don't keep the key around in memory beyond
+            // the encode step. The caller gets it back base64-encoded.
+        }
+
+        var bundle = new byte[NonceSize + ciphertext.Length + TagSize];
+        Buffer.BlockCopy(nonce, 0, bundle, 0, NonceSize);
+        Buffer.BlockCopy(ciphertext, 0, bundle, NonceSize, ciphertext.Length);
+        Buffer.BlockCopy(tag, 0, bundle, NonceSize + ciphertext.Length, TagSize);
+
+        var keyB64 = Convert.ToBase64String(key);
+        Array.Clear(key, 0, key.Length);
+        return (bundle, keyB64);
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        // Compact output (no whitespace) matches the TS/Python outputs.
+        WriteIndented = false,
+    };
+}
+
+/// <summary>Classifier return values — matches the TS/Python/Rust/Go trinity.</summary>
+public enum ClassifyResult
+{
+    /// <summary>Include the key in the <c>public</c> partition.</summary>
+    Public,
+
+    /// <summary>Include the key in the <c>secret</c> partition.</summary>
+    Secret,
+
+    /// <summary>Skip — typically feature flags, which stay live-fetched.</summary>
+    Skip,
+}
+
+/// <summary>Options for <see cref="SmooConfigBuilder.BuildAsync"/>.</summary>
+public sealed class BuildBundleOptions
+{
+    /// <summary>Environment to bake. Defaults to the client's <c>DefaultEnvironment</c>.</summary>
+    public string? Environment { get; set; }
+
+    /// <summary>
+    /// Classifier. Return <see cref="ClassifyResult.Public"/>,
+    /// <see cref="ClassifyResult.Secret"/>, or <see cref="ClassifyResult.Skip"/> per key.
+    /// When null, everything is treated as <see cref="ClassifyResult.Public"/> —
+    /// almost never what you want. Use <see cref="SchemaClassifier.FromSchemaFile"/>
+    /// to route from a <c>schema.json</c> file.
+    /// </summary>
+    public Func<string, JsonElement, ClassifyResult>? Classify { get; set; }
+}
+
+/// <summary>Output of <see cref="SmooConfigBuilder.BuildAsync"/>.</summary>
+public sealed class BuildBundleResult
+{
+    /// <summary>Base64-encoded 32-byte AES-256 key. Set as <c>SMOO_CONFIG_KEY</c>.</summary>
+    public string KeyB64 { get; }
+
+    /// <summary>Encrypted bundle — <c>nonce (12) || ciphertext || tag (16)</c>.</summary>
+    public byte[] Bundle { get; }
+
+    /// <summary>Number of keys baked (public + secret).</summary>
+    public int KeyCount { get; }
+
+    /// <summary>Number of keys skipped (e.g. feature flags).</summary>
+    public int SkippedCount { get; }
+
+    internal BuildBundleResult(string keyB64, byte[] bundle, int keyCount, int skippedCount)
+    {
+        KeyB64 = keyB64;
+        Bundle = bundle;
+        KeyCount = keyCount;
+        SkippedCount = skippedCount;
+    }
+}

--- a/dotnet/src/SmooAI.Config/README.md
+++ b/dotnet/src/SmooAI.Config/README.md
@@ -1,57 +1,168 @@
 # SmooAI.Config
 
-.NET client for the [Smoo AI](https://smoo.ai) config platform. Reads and writes
-typed configuration values and secrets using OAuth2 client-credentials auth.
+[![NuGet](https://img.shields.io/nuget/v/SmooAI.Config.svg)](https://www.nuget.org/packages/SmooAI.Config)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Installation
+.NET client for **[SmooAI.Config](https://smoo.ai)** — the OpenAI-compatible
+configuration service for your entire stack. One schema, one API, every
+language. Typed access to public values, secrets, and feature flags from
+any .NET app, with a local-baked runtime for zero-latency cold starts.
+
+Wire-compatible with the TypeScript, Python, Rust and Go clients — the same
+encrypted bundle decrypts and resolves to the same keys no matter which
+language you ship.
+
+## Install
 
 ```sh
 dotnet add package SmooAI.Config
 ```
 
-## Usage
+## What you get
+
+- **HTTP client** with OAuth2 client-credentials auth, token caching, and 401 retry
+- **Local runtime** — AES-256-GCM decrypt of a baked config bundle for zero-network reads at cold start
+- **Build pipeline** — fetch all values and encrypt them into a bundle your deploy tool ships with the function
+- **Strongly-typed keys** via a Roslyn source generator — mis-typed keys fail at compile time
+- **Feature flag support** — live-fetched through the client, never baked
+
+## Quickstart
+
+### 1. Point the generator at your schema
+
+In your csproj:
+
+```xml
+<ItemGroup>
+  <AdditionalFiles Include="schema.json" SmooConfigSchema="true" />
+</ItemGroup>
+```
+
+Your `schema.json` (emitted by `smooai-config init` / `smooai-config push`):
+
+```json
+{
+    "publicConfigSchema": { "apiUrl": "stringSchema", "retries": "numberSchema" },
+    "secretConfigSchema": { "moonshotApiKey": "stringSchema", "anthropicApiKey": "stringSchema" },
+    "featureFlagSchema": { "newFlow": "booleanSchema" }
+}
+```
+
+### 2. Use the generated typed keys
 
 ```csharp
 using SmooAI.Config;
-using SmooAI.Config.Models;
+using SmooAI.Config.Generated;
+using SmooAI.Config.Runtime;
 
-var client = new SmooConfigClient(new SmooConfigClientOptions
+var runtime = SmooConfigRuntime.Load();  // reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY
+using var client = new SmooConfigClient(new SmooConfigClientOptions
 {
     ClientId     = Environment.GetEnvironmentVariable("SMOOAI_CLIENT_ID")!,
     ClientSecret = Environment.GetEnvironmentVariable("SMOOAI_CLIENT_SECRET")!,
     OrgId        = Environment.GetEnvironmentVariable("SMOOAI_ORG_ID")!,
-    BaseUrl      = "https://api.smoo.ai",          // optional, default
-    DefaultEnvironment = "production",              // optional, default
 });
 
-// Read a single value
-var value = await client.GetValueAsync("moonshotApiKey");
-
-// Read every value in an environment
-var all = await client.GetAllValuesAsync();
-
-// Write a value (requires schemaId + environmentId from the API)
-await client.SetValueAsync(
-    schemaId:      "uuid...",
-    environmentId: "uuid...",
-    key:           "moonshotApiKey",
-    value:         "sk-...",
-    tier:          ConfigTier.Secret);
+// Public + secret come from the baked runtime (sync, no network).
+// Feature flags fall through to the HTTP client automatically.
+var apiUrl    = await Public.ApiUrl.ResolveAsync(runtime, client);
+var moonshot  = await Secrets.MoonshotApiKey.ResolveAsync(runtime, client);
+var newFlow   = await FeatureFlags.NewFlow.ResolveAsync(runtime, client);
 ```
 
-## Auth
+No stringly-typed keys. Rename a key in `schema.json` and every call site
+becomes a compile-time error.
 
-- OAuth2 client-credentials exchange against `{baseUrl}/token` after rewriting
-  `api.` → `auth.` (so `api.smoo.ai` → `auth.smoo.ai`). Override via
-  `SmooConfigClientOptions.AuthUrl` if needed.
-- Tokens are cached in memory and refreshed 60 seconds before expiry.
-- On a 401 response the client invalidates its cached token and retries once.
+## The three pieces
 
-## Scope
+### HTTP client
 
-Phase 1: HTTP client + OAuth. The cohort-aware feature-flag evaluator and
-buildBundle / buildConfigRuntime helpers land in later phases.
+OAuth2 client-credentials flow against `{baseUrl}/token` (with the `api.`
+subdomain rewritten to `auth.`), tokens cached in memory and refreshed 60
+seconds before expiry, automatic 401 retry.
 
-## License
+```csharp
+using var client = new SmooConfigClient(new SmooConfigClientOptions
+{
+    ClientId     = "...",
+    ClientSecret = "sk_...",
+    OrgId        = "...",
+    BaseUrl      = "https://api.smoo.ai",       // default
+    DefaultEnvironment = "production",           // default
+});
 
-MIT
+// Untyped
+JsonElement value = await client.GetValueAsync("moonshotApiKey");
+Dictionary<string, JsonElement> all = await client.GetAllValuesAsync();
+
+// Typed (via generated keys)
+string? anthropic = await Secrets.AnthropicApiKey.GetAsync(client);
+```
+
+### Local runtime
+
+Decrypts a pre-built bundle at cold start and exposes it in-memory. Parity
+with the TS / Python / Rust / Go runtimes — blob layout is
+`nonce (12 bytes) || ciphertext || authTag (16 bytes)`, AES-256-GCM.
+
+Set two env vars on your function:
+
+| Variable               | Value                                      |
+| ---------------------- | ------------------------------------------ |
+| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
+| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+
+```csharp
+var runtime = SmooConfigRuntime.Load();   // null when env vars are unset — dev fallback
+if (runtime is null) {
+    // No baked bundle present; fall back to a live-fetching client.
+}
+
+var apiUrl = runtime?.GetPublic("apiUrl")?.GetString();
+var retries = runtime?.GetValue<int>("retries");
+```
+
+### Build pipeline
+
+Bake all public + secret values into an encrypted bundle at deploy time.
+Feature flags are skipped — they stay live-fetched so you can flip them
+without a redeploy.
+
+```csharp
+using var client = new SmooConfigClient(clientOptions);
+
+var classify = SchemaClassifier.FromSchemaFile(".smooai-config/schema.json");
+var result = await SmooConfigBuilder.BuildAsync(client, new BuildBundleOptions
+{
+    Environment = "production",
+    Classify    = classify,
+});
+
+File.WriteAllBytes("smoo-config.enc", result.Bundle);
+
+Console.WriteLine($"SMOO_CONFIG_KEY_FILE={Path.GetFullPath("smoo-config.enc")}");
+Console.WriteLine($"SMOO_CONFIG_KEY={result.KeyB64}");
+Console.WriteLine($"Baked {result.KeyCount} keys ({result.SkippedCount} feature flags skipped).");
+```
+
+Ship `smoo-config.enc` alongside the function bundle, set the two env vars
+on the function, and the runtime picks up both automatically.
+
+## Wire compatibility
+
+The `.NET` client produces and consumes **exactly** the same bundle format
+as every other SmooAI.Config language client:
+
+- `@smooai/config` (TypeScript)
+- `smooai-config` (Python)
+- `smooai_config` (Rust)
+- `github.com/smooai/config/go` (Go)
+
+You can bake the bundle in any language and decrypt it in any other.
+
+## Links
+
+- **Homepage**: [smoo.ai](https://smoo.ai)
+- **Source**: [github.com/SmooAI/config](https://github.com/SmooAI/config)
+- **Issues**: [github.com/SmooAI/config/issues](https://github.com/SmooAI/config/issues)
+- **License**: MIT

--- a/dotnet/src/SmooAI.Config/Runtime/BakedConfig.cs
+++ b/dotnet/src/SmooAI.Config/Runtime/BakedConfig.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+
+namespace SmooAI.Config.Runtime;
+
+/// <summary>
+/// Decrypted <c>{public, secret}</c> partition from a baked blob. Feature
+/// flags are never baked (they stay live-fetched), so this shape only ever
+/// carries public + secret keys.
+/// </summary>
+public sealed class BakedConfig
+{
+    /// <summary>Public (non-sensitive) values. Empty when not baked.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Public { get; }
+
+    /// <summary>Secret values. Empty when not baked.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Secret { get; }
+
+    internal BakedConfig(
+        IReadOnlyDictionary<string, JsonElement> publicValues,
+        IReadOnlyDictionary<string, JsonElement> secretValues)
+    {
+        Public = publicValues;
+        Secret = secretValues;
+    }
+
+    /// <summary>True when both partitions are empty.</summary>
+    public bool IsEmpty => Public.Count == 0 && Secret.Count == 0;
+
+    /// <summary>Total number of baked entries (public + secret).</summary>
+    public int Count => Public.Count + Secret.Count;
+
+    /// <summary>
+    /// Merged <c>{public, secret}</c> view. Secret wins on collisions —
+    /// matches the TS / Python / Rust / Go hydrator semantics.
+    /// </summary>
+    public IReadOnlyDictionary<string, JsonElement> Merged
+    {
+        get
+        {
+            var merged = new Dictionary<string, JsonElement>(Public.Count + Secret.Count, StringComparer.Ordinal);
+            foreach (var (k, v) in Public) merged[k] = v;
+            foreach (var (k, v) in Secret) merged[k] = v;
+            return merged;
+        }
+    }
+}

--- a/dotnet/src/SmooAI.Config/Runtime/SmooConfigRuntime.cs
+++ b/dotnet/src/SmooAI.Config/Runtime/SmooConfigRuntime.cs
@@ -1,0 +1,261 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace SmooAI.Config.Runtime;
+
+/// <summary>
+/// Bake-aware local runtime for <c>SmooAI.Config</c>. Parity with the
+/// TypeScript, Python, Rust and Go implementations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reads a pre-encrypted blob produced by the <c>@smooai/config</c> build
+/// pipeline (or any of its language ports) and exposes sync accessors to the
+/// decrypted <c>{public, secret}</c> values — no network call after the cold
+/// start.
+/// </para>
+/// <para>
+/// Environment variables:
+/// <list type="bullet">
+///   <item><c>SMOO_CONFIG_KEY_FILE</c> — absolute path to the encrypted blob on disk.</item>
+///   <item><c>SMOO_CONFIG_KEY</c> — base64-encoded 32-byte AES-256 key.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Blob layout (wire-compatible with every other language): <c>nonce (12 bytes) || ciphertext || authTag (16 bytes)</c>.
+/// </para>
+/// <para>
+/// Feature flags are never baked — they stay live-fetched via
+/// <see cref="SmooConfigClient"/>. The runtime only surfaces public + secret
+/// values from the blob.
+/// </para>
+/// </remarks>
+public sealed class SmooConfigRuntime
+{
+    /// <summary>Environment variable name for the blob file path.</summary>
+    public const string KeyFileEnvVar = "SMOO_CONFIG_KEY_FILE";
+
+    /// <summary>Environment variable name for the base64 AES key.</summary>
+    public const string KeyEnvVar = "SMOO_CONFIG_KEY";
+
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+    private const int KeySize = 32;
+
+    private static readonly object s_lock = new();
+    private static SmooConfigRuntime? s_cached;
+    private static bool s_cachedLoaded;
+
+    /// <summary>Decrypted baked config. Never null.</summary>
+    public BakedConfig Baked { get; }
+
+    private SmooConfigRuntime(BakedConfig baked)
+    {
+        Baked = baked;
+    }
+
+    /// <summary>
+    /// Load the runtime from environment variables. Returns <c>null</c> when
+    /// <see cref="KeyFileEnvVar"/> or <see cref="KeyEnvVar"/> is not set — the
+    /// caller should fall back to a live client on dev machines without a
+    /// baked blob.
+    /// </summary>
+    /// <remarks>
+    /// Subsequent calls return the cached singleton — decryption only happens
+    /// once per process. Thread-safe.
+    /// </remarks>
+    /// <exception cref="SmooConfigRuntimeException">
+    /// When the key or blob is present but malformed / tampered with. Missing
+    /// env vars return <c>null</c> (not throw).
+    /// </exception>
+    public static SmooConfigRuntime? Load()
+    {
+        if (s_cachedLoaded) return s_cached;
+
+        lock (s_lock)
+        {
+            if (s_cachedLoaded) return s_cached;
+
+            var keyFile = Environment.GetEnvironmentVariable(KeyFileEnvVar);
+            var keyB64 = Environment.GetEnvironmentVariable(KeyEnvVar);
+            if (string.IsNullOrEmpty(keyFile) || string.IsNullOrEmpty(keyB64))
+            {
+                s_cached = null;
+                s_cachedLoaded = true;
+                return null;
+            }
+
+            var baked = DecryptBlob(keyFile, keyB64);
+            s_cached = new SmooConfigRuntime(baked);
+            s_cachedLoaded = true;
+            return s_cached;
+        }
+    }
+
+    /// <summary>
+    /// Load from explicit file path + base64 key, bypassing env vars. Useful
+    /// for tests and one-off tooling; bypasses the process-wide cache.
+    /// </summary>
+    /// <param name="keyFile">Path to the <c>.enc</c> blob.</param>
+    /// <param name="keyB64">Base64 AES-256 key.</param>
+    public static SmooConfigRuntime LoadFrom(string keyFile, string keyB64)
+    {
+        if (string.IsNullOrWhiteSpace(keyFile)) throw new ArgumentException("Key file path is required.", nameof(keyFile));
+        if (string.IsNullOrWhiteSpace(keyB64)) throw new ArgumentException("Key (base64) is required.", nameof(keyB64));
+
+        return new SmooConfigRuntime(DecryptBlob(keyFile, keyB64));
+    }
+
+    /// <summary>
+    /// Reset the process-wide cache. Test-only — never call in production.
+    /// </summary>
+    internal static void ResetForTests()
+    {
+        lock (s_lock)
+        {
+            s_cached = null;
+            s_cachedLoaded = false;
+        }
+    }
+
+    /// <summary>
+    /// Get a value by key, checking the public partition first then falling
+    /// back to the secret partition (matches the TS/Python/Rust/Go merge
+    /// order). Returns <c>null</c> when the key is absent.
+    /// </summary>
+    public JsonElement? GetValue(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+
+        if (Baked.Secret.TryGetValue(key, out var secret)) return secret;
+        if (Baked.Public.TryGetValue(key, out var pub)) return pub;
+        return null;
+    }
+
+    /// <summary>
+    /// Get a public config value. Returns <c>null</c> when the key is not
+    /// present in the public partition.
+    /// </summary>
+    public JsonElement? GetPublic(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        return Baked.Public.TryGetValue(key, out var v) ? v : null;
+    }
+
+    /// <summary>
+    /// Get a secret config value. Returns <c>null</c> when the key is not
+    /// present in the secret partition.
+    /// </summary>
+    public JsonElement? GetSecret(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        return Baked.Secret.TryGetValue(key, out var v) ? v : null;
+    }
+
+    /// <summary>
+    /// Typed accessor — deserializes the value via <c>JsonElement.Deserialize&lt;T&gt;()</c>.
+    /// </summary>
+    public T? GetValue<T>(string key)
+    {
+        var el = GetValue(key);
+        if (el is null) return default;
+        return el.Value.Deserialize<T>(SmooConfigClient.JsonOptions);
+    }
+
+    /// <summary>
+    /// Decrypt a blob given an explicit path + base64 key. Exposed for
+    /// tests; most callers should use <see cref="Load"/>.
+    /// </summary>
+    internal static BakedConfig DecryptBlob(string keyFile, string keyB64)
+    {
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(keyB64);
+        }
+        catch (FormatException ex)
+        {
+            throw new SmooConfigRuntimeException($"{KeyEnvVar} is not valid base64: {ex.Message}", ex);
+        }
+
+        if (key.Length != KeySize)
+        {
+            throw new SmooConfigRuntimeException($"{KeyEnvVar} must decode to {KeySize} bytes (got {key.Length}).");
+        }
+
+        byte[] blob;
+        try
+        {
+            blob = File.ReadAllBytes(keyFile);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException or FileNotFoundException)
+        {
+            throw new SmooConfigRuntimeException($"Failed to read config blob at {keyFile}: {ex.Message}", ex);
+        }
+
+        if (blob.Length < NonceSize + TagSize)
+        {
+            throw new SmooConfigRuntimeException($"smoo-config blob too short ({blob.Length} bytes, expected at least {NonceSize + TagSize}).");
+        }
+
+        var nonce = blob.AsSpan(0, NonceSize);
+        var tag = blob.AsSpan(blob.Length - TagSize, TagSize);
+        var ciphertext = blob.AsSpan(NonceSize, blob.Length - NonceSize - TagSize);
+        var plaintext = new byte[ciphertext.Length];
+
+        try
+        {
+            using var aes = new AesGcm(key, TagSize);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new SmooConfigRuntimeException("AES-GCM decryption failed (wrong key or tampered blob).", ex);
+        }
+        finally
+        {
+            // Zero the key — we're done with it.
+            Array.Clear(key, 0, key.Length);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(plaintext);
+            var root = doc.RootElement;
+
+            var pub = ReadPartition(root, "public");
+            var sec = ReadPartition(root, "secret");
+            return new BakedConfig(pub, sec);
+        }
+        catch (JsonException ex)
+        {
+            throw new SmooConfigRuntimeException($"Failed to parse decrypted config JSON: {ex.Message}", ex);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, JsonElement> ReadPartition(JsonElement root, string name)
+    {
+        if (root.ValueKind != JsonValueKind.Object) return Empty;
+        if (!root.TryGetProperty(name, out var section) || section.ValueKind != JsonValueKind.Object)
+        {
+            return Empty;
+        }
+
+        var dict = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var prop in section.EnumerateObject())
+        {
+            // .Clone() so the value survives the JsonDocument Dispose().
+            dict[prop.Name] = prop.Value.Clone();
+        }
+        return dict;
+    }
+
+    private static readonly IReadOnlyDictionary<string, JsonElement> Empty = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+}
+
+/// <summary>Thrown when the runtime fails to load or decrypt a baked blob.</summary>
+public sealed class SmooConfigRuntimeException : Exception
+{
+    public SmooConfigRuntimeException(string message) : base(message) { }
+    public SmooConfigRuntimeException(string message, Exception inner) : base(message, inner) { }
+}

--- a/dotnet/src/SmooAI.Config/SmooAI.Config.csproj
+++ b/dotnet/src/SmooAI.Config/SmooAI.Config.csproj
@@ -12,12 +12,12 @@
 
   <PropertyGroup>
     <PackageId>SmooAI.Config</PackageId>
-    <Version>0.1.0</Version>
+    <Version>4.4.0</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Product>SmooAI.Config</Product>
-    <Description>.NET client for the Smoo AI config platform — read and write typed configuration values and secrets with OAuth2 client-credentials authentication.</Description>
-    <PackageTags>smooai;config;configuration;secrets;feature-flags</PackageTags>
+    <Description>.NET client for the Smoo AI config platform — typed configuration values, secrets, and feature flags with OAuth2 auth, a local AES-GCM baked runtime for zero-latency cold starts, and a Roslyn source generator for compile-time-safe key access. Wire-compatible with the TypeScript, Python, Rust, and Go clients.</Description>
+    <PackageTags>smooai;config;configuration;secrets;feature-flags;source-generator;roslyn</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/SmooAI/config</PackageProjectUrl>
     <RepositoryUrl>https://github.com/SmooAI/config</RepositoryUrl>
@@ -39,8 +39,31 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <!--
+    Ship the Roslyn source generator as an analyzer inside this package.
+    Consumers get typed `ConfigKey<T>` properties via a single
+    `dotnet add package SmooAI.Config`. The generator DLL is packed but NOT
+    referenced at compile time — ReferenceOutputAssembly=false avoids leaking
+    Microsoft.CodeAnalysis into consumer apps.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\SmooAI.Config.SourceGenerator\SmooAI.Config.SourceGenerator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer" />
+  </ItemGroup>
+
+  <Target Name="PackAnalyzer" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="..\SmooAI.Config.SourceGenerator\bin\$(Configuration)\netstandard2.0\SmooAI.Config.SourceGenerator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <InternalsVisibleTo Include="SmooAI.Config.Tests" />
+    <InternalsVisibleTo Include="SmooAI.Config.SourceGenerator.Tests" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/SmooAI.Config/SmooConfigClient.cs
+++ b/dotnet/src/SmooAI.Config/SmooConfigClient.cs
@@ -27,7 +27,7 @@ public sealed class SmooConfigClient : IDisposable
     private readonly string _defaultEnvironment;
 
     /// <summary>JSON options used for both request and response bodies.</summary>
-    internal static readonly JsonSerializerOptions JsonOptions = new()
+    public static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
+++ b/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using SmooAI.Config.Models;
+using SmooAI.Config.Runtime;
+
+namespace SmooAI.Config.Typed;
+
+/// <summary>
+/// Strongly-typed handle to a config key. Emitted by the
+/// <c>SmooAI.Config.SourceGenerator</c> from a <c>schema.json</c>, so mis-typed
+/// keys fail at compile time instead of runtime.
+/// </summary>
+/// <typeparam name="T">Expected value type (<see cref="string"/>, <see cref="bool"/>, <see cref="double"/>, or a custom POCO).</typeparam>
+public sealed class ConfigKey<T>
+{
+    /// <summary>Raw config key as stored server-side.</summary>
+    public string Key { get; }
+
+    /// <summary>Tier (<see cref="ConfigTier.Public"/> / <see cref="ConfigTier.Secret"/> / <see cref="ConfigTier.FeatureFlag"/>).</summary>
+    public ConfigTier Tier { get; }
+
+    /// <summary>Create a typed key. Normally called by generated code.</summary>
+    public ConfigKey(string key, ConfigTier tier)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        Key = key;
+        Tier = tier;
+    }
+
+    /// <summary>Fetch the value from the live HTTP API.</summary>
+    public async Task<T?> GetAsync(SmooConfigClient client, string? environment = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        var element = await client.GetValueAsync(Key, environment, cancellationToken).ConfigureAwait(false);
+        return Deserialize(element);
+    }
+
+    /// <summary>
+    /// Fetch the value from a local baked runtime. Returns <c>default</c>
+    /// when the runtime is <c>null</c> or the key is absent.
+    /// </summary>
+    public T? Get(SmooConfigRuntime? runtime)
+    {
+        if (runtime is null) return default;
+        var el = runtime.GetValue(Key);
+        return el.HasValue ? Deserialize(el.Value) : default;
+    }
+
+    /// <summary>
+    /// Resolve from a runtime when baked, else fall back to the HTTP client.
+    /// This is the typical production pattern: public + secret come from the
+    /// baked blob synchronously; everything else (feature flags, missing keys)
+    /// falls through to the network.
+    /// </summary>
+    public async Task<T?> ResolveAsync(
+        SmooConfigRuntime? runtime,
+        SmooConfigClient client,
+        string? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        if (runtime is not null)
+        {
+            var el = runtime.GetValue(Key);
+            if (el.HasValue) return Deserialize(el.Value);
+        }
+
+        return await GetAsync(client, environment, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static T? Deserialize(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Undefined || element.ValueKind == JsonValueKind.Null)
+        {
+            return default;
+        }
+
+        // Fast path for primitive generics — JsonElement.Deserialize<string>()
+        // on a string-valued element works correctly.
+        return element.Deserialize<T>(SmooConfigClient.JsonOptions);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"ConfigKey<{typeof(T).Name}>({Key}, {Tier})";
+}

--- a/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/GeneratorRunnerTests.cs
+++ b/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/GeneratorRunnerTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using SmooAI.Config.SourceGenerator;
+
+namespace SmooAI.Config.SourceGenerator.Tests;
+
+public class GeneratorRunnerTests
+{
+    [Fact]
+    public void Generator_EmitsFileForAdditionalSchemaJson()
+    {
+        var schema = """
+            {
+              "publicConfigSchema": { "apiUrl": "stringSchema" },
+              "secretConfigSchema": { "dbPassword": "stringSchema" },
+              "featureFlagSchema":  { "newFlow":  "booleanSchema" }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "ConsumerAssembly",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText("namespace ConsumerAssembly;") },
+            references: AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+                .Select(a => MetadataReference.CreateFromFile(a.Location))
+                .Cast<MetadataReference>()
+                .ToArray(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var additionalText = new InMemoryAdditionalText("schema.json", schema);
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(
+            new Dictionary<string, string>
+            {
+                ["build_metadata.AdditionalFiles.SmooConfigSchema"] = "true",
+                ["build_metadata.AdditionalFiles.SmooConfigNamespace"] = "ConsumerAssembly.Config",
+            });
+
+        var driver = CSharpGeneratorDriver
+            .Create(new SmooConfigSchemaGenerator())
+            .AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(additionalText))
+            .WithUpdatedAnalyzerConfigOptions(optionsProvider)
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+        Assert.Empty(result.Diagnostics);
+        Assert.Single(result.GeneratedTrees);
+
+        var generated = result.GeneratedTrees.Single().ToString();
+        Assert.Contains("namespace ConsumerAssembly.Config;", generated);
+        Assert.Contains("ConfigKey<string> ApiUrl", generated);
+        Assert.Contains("ConfigKey<string> DbPassword", generated);
+        Assert.Contains("ConfigKey<bool> NewFlow", generated);
+    }
+
+    [Fact]
+    public void Generator_ReportsDiagnosticOnInvalidJson()
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "ConsumerAssembly",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText("namespace ConsumerAssembly;") },
+            references: Array.Empty<MetadataReference>(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var additionalText = new InMemoryAdditionalText("schema.json", "{ not valid json");
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(
+            new Dictionary<string, string>
+            {
+                ["build_metadata.AdditionalFiles.SmooConfigSchema"] = "true",
+            });
+
+        var driver = CSharpGeneratorDriver
+            .Create(new SmooConfigSchemaGenerator())
+            .AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(additionalText))
+            .WithUpdatedAnalyzerConfigOptions(optionsProvider)
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+        Assert.Contains(result.Diagnostics, d => d.Id == "SMOOCFG001");
+    }
+
+    private sealed class InMemoryAdditionalText : AdditionalText
+    {
+        public override string Path { get; }
+        private readonly SourceText _text;
+        public InMemoryAdditionalText(string path, string content)
+        {
+            Path = path;
+            _text = SourceText.From(content);
+        }
+        public override SourceText GetText(CancellationToken cancellationToken = default) => _text;
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private readonly Dictionary<string, string> _map;
+        public TestAnalyzerConfigOptionsProvider(Dictionary<string, string> map) { _map = map; }
+        public override AnalyzerConfigOptions GlobalOptions => new TestOptions(new Dictionary<string, string>());
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => new TestOptions(new Dictionary<string, string>());
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => new TestOptions(_map);
+
+        private sealed class TestOptions : AnalyzerConfigOptions
+        {
+            private readonly Dictionary<string, string> _map;
+            public TestOptions(Dictionary<string, string> map) { _map = map; }
+            public override bool TryGetValue(string key, out string value)
+            {
+                if (_map.TryGetValue(key, out var v)) { value = v; return true; }
+                value = null!;
+                return false;
+            }
+        }
+    }
+}

--- a/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/SchemaParsingTests.cs
+++ b/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/SchemaParsingTests.cs
@@ -1,0 +1,108 @@
+using SmooAI.Config.SourceGenerator;
+
+namespace SmooAI.Config.SourceGenerator.Tests;
+
+public class SchemaParsingTests
+{
+    [Fact]
+    public void Parse_JsonSchemaShape_ExtractsAllThreeTiers()
+    {
+        var json = """
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "public":       { "type": "object", "properties": { "apiUrl":     { "type": "string"  } } },
+                "secret":       { "type": "object", "properties": { "dbPassword": { "type": "string"  } } },
+                "featureFlags": { "type": "object", "properties": { "newFlow":    { "type": "boolean" } } }
+              }
+            }
+            """;
+        var parsed = SmooConfigSchemaGenerator.Parse(json);
+        Assert.Collection(parsed.PublicKeys, k => { Assert.Equal("apiUrl", k.Name); Assert.Equal("string", k.ClrType); });
+        Assert.Collection(parsed.SecretKeys, k => { Assert.Equal("dbPassword", k.Name); Assert.Equal("string", k.ClrType); });
+        Assert.Collection(parsed.FeatureFlagKeys, k => { Assert.Equal("newFlow", k.Name); Assert.Equal("bool", k.ClrType); });
+    }
+
+    [Fact]
+    public void Parse_SerializedDefineConfigShape_MapsStringBooleanNumber()
+    {
+        var json = """
+            {
+              "publicConfigSchema": {
+                "apiUrl":  "stringSchema",
+                "retries": "numberSchema"
+              },
+              "secretConfigSchema": {
+                "dbPassword": "stringSchema"
+              },
+              "featureFlagSchema": {
+                "newFlow": "booleanSchema"
+              }
+            }
+            """;
+        var parsed = SmooConfigSchemaGenerator.Parse(json);
+
+        var pub = parsed.PublicKeys.ToDictionary(k => k.Name, k => k.ClrType);
+        Assert.Equal("string", pub["apiUrl"]);
+        Assert.Equal("double", pub["retries"]);
+        Assert.Equal("string", parsed.SecretKeys.Single().ClrType);
+        Assert.Equal("bool", parsed.FeatureFlagKeys.Single().ClrType);
+    }
+
+    [Fact]
+    public void Parse_EmptyOrInvalidRoot_ReturnsEmpty()
+    {
+        var parsed = SmooConfigSchemaGenerator.Parse("{}");
+        Assert.Empty(parsed.PublicKeys);
+        Assert.Empty(parsed.SecretKeys);
+        Assert.Empty(parsed.FeatureFlagKeys);
+    }
+
+    [Fact]
+    public void Render_EmitsAllThreeSectionsAndCorrectNamespace()
+    {
+        var json = """
+            {
+              "publicConfigSchema": { "apiUrl": "stringSchema" },
+              "secretConfigSchema": { "dbPassword": "stringSchema" },
+              "featureFlagSchema":  { "newFlow": "booleanSchema" }
+            }
+            """;
+        var parsed = SmooConfigSchemaGenerator.Parse(json);
+        var source = SmooConfigSchemaGenerator.Render(parsed, "My.App.Config");
+
+        Assert.Contains("namespace My.App.Config;", source);
+        Assert.Contains("public static class Public", source);
+        Assert.Contains("public static class Secrets", source);
+        Assert.Contains("public static class FeatureFlags", source);
+        Assert.Contains("ConfigKey<string> ApiUrl", source);
+        Assert.Contains("ConfigKey<string> DbPassword", source);
+        Assert.Contains("ConfigKey<bool> NewFlow", source);
+        Assert.Contains("ConfigTier.Public", source);
+        Assert.Contains("ConfigTier.Secret", source);
+        Assert.Contains("ConfigTier.FeatureFlag", source);
+    }
+
+    [Fact]
+    public void Render_PascalCasesSnakeAndKebabKeys()
+    {
+        var json = """
+            {
+              "publicConfigSchema": {
+                "snake_case_key": "stringSchema",
+                "kebab-case-key": "stringSchema",
+                "camelCaseKey":   "stringSchema",
+                "UPPER_SNAKE":    "stringSchema"
+              }
+            }
+            """;
+        var parsed = SmooConfigSchemaGenerator.Parse(json);
+        var source = SmooConfigSchemaGenerator.Render(parsed, "N");
+
+        Assert.Contains("SnakeCaseKey", source);
+        Assert.Contains("KebabCaseKey", source);
+        Assert.Contains("CamelCaseKey", source);
+        Assert.Contains("UpperSnake", source);
+    }
+}

--- a/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/SmooAI.Config.SourceGenerator.Tests.csproj
+++ b/dotnet/tests/SmooAI.Config.SourceGenerator.Tests/SmooAI.Config.SourceGenerator.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the generator as a normal assembly so we can exercise its
+         internal Parse/Render logic directly. No analyzer item type here. -->
+    <ProjectReference Include="..\..\src\SmooAI.Config.SourceGenerator\SmooAI.Config.SourceGenerator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/tests/SmooAI.Config.Tests/BuilderTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/BuilderTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Text.Json;
+using SmooAI.Config.Build;
+using SmooAI.Config.OAuth;
+using SmooAI.Config.Runtime;
+
+namespace SmooAI.Config.Tests;
+
+public class BuilderTests
+{
+    private static SmooConfigClientOptions Options() => new()
+    {
+        ClientId = "cid",
+        ClientSecret = "csec",
+        OrgId = "org-uuid",
+        BaseUrl = "https://api.smoo.ai",
+        AuthUrl = "https://auth.smoo.ai",
+        DefaultEnvironment = "production",
+    };
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler) CreateClient()
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+        var options = Options();
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task BuildAsync_PartitionsByClassifier_AndEncryptsRoundTrip()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """
+            {"values":{"apiUrl":"https://api.example.com","dbPassword":"s3cr3t","newFlow":true}}
+            """);
+
+        var classify = SchemaClassifier.FromKeys(
+            publicKeys: new[] { "apiUrl" },
+            secretKeys: new[] { "dbPassword" },
+            featureFlagKeys: new[] { "newFlow" });
+
+        var result = await SmooConfigBuilder.BuildAsync(client, new BuildBundleOptions
+        {
+            Environment = "test",
+            Classify = classify,
+        });
+
+        Assert.Equal(2, result.KeyCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Equal(32, Convert.FromBase64String(result.KeyB64).Length);
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, result.Bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, result.KeyB64);
+            Assert.Equal("https://api.example.com", runtime.GetPublic("apiUrl")!.Value.GetString());
+            Assert.Equal("s3cr3t", runtime.GetSecret("dbPassword")!.Value.GetString());
+            // Feature flag was skipped, so it's absent from both partitions.
+            Assert.Null(runtime.GetPublic("newFlow"));
+            Assert.Null(runtime.GetSecret("newFlow"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_DefaultClassifier_PutsEverythingInPublic()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"a":"1","b":"2"}}""");
+
+        var result = await SmooConfigBuilder.BuildAsync(client, new BuildBundleOptions
+        {
+            Environment = "test",
+        });
+
+        Assert.Equal(2, result.KeyCount);
+        Assert.Equal(0, result.SkippedCount);
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, result.Bundle);
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, result.KeyB64);
+            Assert.Equal(2, runtime.Baked.Public.Count);
+            Assert.Empty(runtime.Baked.Secret);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SchemaClassifier_FromJsonSchemaShape()
+    {
+        var schema = """
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "public": { "type": "object", "properties": { "apiUrl": {"type":"string"} } },
+                "secret": { "type": "object", "properties": { "dbPassword": {"type":"string"} } },
+                "featureFlags": { "type": "object", "properties": { "newFlow": {"type":"boolean"} } }
+              }
+            }
+            """;
+        var classify = SchemaClassifier.FromSchemaJson(schema);
+        Assert.Equal(ClassifyResult.Public, classify("apiUrl", default));
+        Assert.Equal(ClassifyResult.Secret, classify("dbPassword", default));
+        Assert.Equal(ClassifyResult.Skip, classify("newFlow", default));
+        Assert.Equal(ClassifyResult.Public, classify("unknown", default));
+    }
+
+    [Fact]
+    public void SchemaClassifier_FromSerializedDefineConfigShape()
+    {
+        var schema = """
+            {
+              "publicConfigSchema": { "apiUrl": "stringSchema" },
+              "secretConfigSchema": { "dbPassword": "stringSchema" },
+              "featureFlagSchema":  { "newFlow":    "booleanSchema" }
+            }
+            """;
+        var classify = SchemaClassifier.FromSchemaJson(schema);
+        Assert.Equal(ClassifyResult.Public, classify("apiUrl", default));
+        Assert.Equal(ClassifyResult.Secret, classify("dbPassword", default));
+        Assert.Equal(ClassifyResult.Skip, classify("newFlow", default));
+    }
+
+    [Fact]
+    public void SchemaClassifier_FromSchemaFile()
+    {
+        var schema = """
+            {
+              "publicConfigSchema": { "apiUrl": "stringSchema" }
+            }
+            """;
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, schema);
+        try
+        {
+            var classify = SchemaClassifier.FromSchemaFile(path);
+            Assert.Equal(ClassifyResult.Public, classify("apiUrl", default));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/dotnet/tests/SmooAI.Config.Tests/ConfigKeyTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/ConfigKeyTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using SmooAI.Config.Build;
+using SmooAI.Config.Models;
+using SmooAI.Config.OAuth;
+using SmooAI.Config.Runtime;
+using SmooAI.Config.Typed;
+
+namespace SmooAI.Config.Tests;
+
+public class ConfigKeyTests
+{
+    private static SmooConfigClientOptions Options() => new()
+    {
+        ClientId = "cid",
+        ClientSecret = "csec",
+        OrgId = "org-uuid",
+        BaseUrl = "https://api.smoo.ai",
+        AuthUrl = "https://auth.smoo.ai",
+        DefaultEnvironment = "production",
+    };
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler) CreateClient()
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+        var options = Options();
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task GetAsync_DeserializesString()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":"sk-abc"}""");
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.GetAsync(client);
+        Assert.Equal("sk-abc", value);
+    }
+
+    [Fact]
+    public async Task GetAsync_DeserializesBool()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":true}""");
+
+        var key = new ConfigKey<bool>("newFlow", ConfigTier.FeatureFlag);
+        var value = await key.GetAsync(client);
+        Assert.True(value);
+    }
+
+    [Fact]
+    public void Get_FromRuntime_Deserializes()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://api.example.com","retries":5}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+
+            var url = new ConfigKey<string>("apiUrl", ConfigTier.Public);
+            Assert.Equal("https://api.example.com", url.Get(runtime));
+
+            var retries = new ConfigKey<int>("retries", ConfigTier.Public);
+            Assert.Equal(5, retries.Get(runtime));
+
+            var missing = new ConfigKey<string>("missing", ConfigTier.Public);
+            Assert.Null(missing.Get(runtime));
+
+            // Null runtime is tolerated and returns default.
+            Assert.Null(url.Get(null));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PrefersRuntimeOverClient()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://baked.example.com"}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            var (client, _) = CreateClient();
+            // No additional response queued — client must NOT be called.
+
+            var key = new ConfigKey<string>("apiUrl", ConfigTier.Public);
+            var value = await key.ResolveAsync(runtime, client);
+            Assert.Equal("https://baked.example.com", value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToClientWhenRuntimeMissingKey()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            var (client, handler) = CreateClient();
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"flagged-on"}""");
+
+            var key = new ConfigKey<string>("newFlow", ConfigTier.FeatureFlag);
+            var value = await key.ResolveAsync(runtime, client);
+            Assert.Equal("flagged-on", value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/dotnet/tests/SmooAI.Config.Tests/RuntimeTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/RuntimeTests.cs
@@ -1,0 +1,251 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using SmooAI.Config.Build;
+using SmooAI.Config.Runtime;
+
+namespace SmooAI.Config.Tests;
+
+public class RuntimeTests : IDisposable
+{
+    public RuntimeTests()
+    {
+        SmooConfigRuntime.ResetForTests();
+    }
+
+    public void Dispose()
+    {
+        SmooConfigRuntime.ResetForTests();
+    }
+
+    [Fact]
+    public void DecryptBlob_RoundTrip_ReturnsPublicAndSecret()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://api.example.com"},"secret":{"dbPassword":"s3cr3t"}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.Equal("https://api.example.com", runtime.GetPublic("apiUrl")!.Value.GetString());
+            Assert.Equal("s3cr3t", runtime.GetSecret("dbPassword")!.Value.GetString());
+
+            // GetValue prefers secret on collision semantics — verify plain lookups.
+            Assert.Equal("https://api.example.com", runtime.GetValue("apiUrl")!.Value.GetString());
+            Assert.Equal("s3cr3t", runtime.GetValue("dbPassword")!.Value.GetString());
+            Assert.Null(runtime.GetValue("missingKey"));
+
+            Assert.Equal(2, runtime.Baked.Count);
+            Assert.False(runtime.Baked.IsEmpty);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_WrongKey_Throws()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://api.example.com"}}""");
+        var (bundle, _) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+        var wrongKey = Convert.ToBase64String(new byte[32]);
+
+        try
+        {
+            var ex = Assert.Throws<SmooConfigRuntimeException>(() => SmooConfigRuntime.LoadFrom(path, wrongKey));
+            Assert.Contains("AES-GCM", ex.Message);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_TamperedBlob_Throws()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://api.example.com"}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        // Flip a byte in the ciphertext region (past the 12-byte nonce).
+        bundle[20] ^= 0x01;
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            Assert.Throws<SmooConfigRuntimeException>(() => SmooConfigRuntime.LoadFrom(path, keyB64));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_InvalidKeyLength_Throws()
+    {
+        var shortKey = Convert.ToBase64String(new byte[16]);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, new byte[64]);
+
+        try
+        {
+            var ex = Assert.Throws<SmooConfigRuntimeException>(() => SmooConfigRuntime.LoadFrom(path, shortKey));
+            Assert.Contains("32 bytes", ex.Message);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_BlobTooShort_Throws()
+    {
+        var key = Convert.ToBase64String(new byte[32]);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, new byte[10]);
+
+        try
+        {
+            var ex = Assert.Throws<SmooConfigRuntimeException>(() => SmooConfigRuntime.LoadFrom(path, key));
+            Assert.Contains("too short", ex.Message);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_InvalidBase64Key_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, new byte[64]);
+
+        try
+        {
+            Assert.Throws<SmooConfigRuntimeException>(() => SmooConfigRuntime.LoadFrom(path, "not-valid-base64!!"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NoEnvVars_ReturnsNull()
+    {
+        var prevFile = Environment.GetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar);
+        var prevKey = Environment.GetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar);
+        Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar, null);
+        Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar, null);
+        SmooConfigRuntime.ResetForTests();
+
+        try
+        {
+            var runtime = SmooConfigRuntime.Load();
+            Assert.Null(runtime);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar, prevFile);
+            Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar, prevKey);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvVars_DecryptsAndCaches()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"apiUrl":"https://api.example.com"}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        var prevFile = Environment.GetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar);
+        var prevKey = Environment.GetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar);
+        Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar, path);
+        Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar, keyB64);
+        SmooConfigRuntime.ResetForTests();
+
+        try
+        {
+            var r1 = SmooConfigRuntime.Load();
+            Assert.NotNull(r1);
+            Assert.Equal("https://api.example.com", r1!.GetPublic("apiUrl")!.Value.GetString());
+
+            // Cached — second call returns the same instance.
+            var r2 = SmooConfigRuntime.Load();
+            Assert.Same(r1, r2);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyFileEnvVar, prevFile);
+            Environment.SetEnvironmentVariable(SmooConfigRuntime.KeyEnvVar, prevKey);
+            File.Delete(path);
+            SmooConfigRuntime.ResetForTests();
+        }
+    }
+
+    [Fact]
+    public void GetValue_Generic_Deserializes()
+    {
+        var payload = Encoding.UTF8.GetBytes("""{"public":{"retries":3,"enabled":true,"apiUrl":"https://api.example.com"}}""");
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(payload);
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.Equal(3, runtime.GetValue<int>("retries"));
+            Assert.True(runtime.GetValue<bool>("enabled"));
+            Assert.Equal("https://api.example.com", runtime.GetValue<string>("apiUrl"));
+            Assert.Null(runtime.GetValue<string>("missing"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WireCompat_DecryptsBlobBuiltByThisImpl()
+    {
+        // Layout: 12-byte nonce || ciphertext || 16-byte tag — what every
+        // other language emits. Rebuild it here byte-by-byte and check we
+        // decode it back to the same JSON.
+        var key = RandomNumberGenerator.GetBytes(32);
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var plaintext = Encoding.UTF8.GetBytes("""{"public":{"k":"v"},"secret":{}}""");
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[16];
+        using (var aes = new AesGcm(key, 16))
+        {
+            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+        }
+        var bundle = new byte[nonce.Length + ciphertext.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, bundle, 0, nonce.Length);
+        Buffer.BlockCopy(ciphertext, 0, bundle, nonce.Length, ciphertext.Length);
+        Buffer.BlockCopy(tag, 0, bundle, nonce.Length + ciphertext.Length, tag.Length);
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, Convert.ToBase64String(key));
+            Assert.Equal("v", runtime.GetPublic("k")!.Value.GetString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/rust/config/Cargo.lock
+++ b/rust/config/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -30,6 +30,12 @@ const files = [
         pattern: /^version = ".*"$/m,
         replacement: `version = "${version}"`,
     },
+    {
+        path: join(rootDir, 'dotnet', 'src', 'SmooAI.Config', 'SmooAI.Config.csproj'),
+        // Match only the top-level <Version> (not <PackageReference Version="..." />).
+        pattern: /<Version>[^<]*<\/Version>/,
+        replacement: `<Version>${version}</Version>`,
+    },
 ];
 
 // Go doesn't have a version file in go.mod, but we can add a version.go constant


### PR DESCRIPTION
## Summary

Ships the `.NET` phase 2 port of `@smooai/config` with full parity to the TypeScript, Python, Rust, and Go clients:

- **Local runtime** (`SmooConfigRuntime`) — AES-256-GCM decrypt of a baked bundle from `SMOO_CONFIG_KEY_FILE` + `SMOO_CONFIG_KEY`. Wire-compatible with every other language client (12-byte nonce || ciphertext || 16-byte tag).
- **Build pipeline** (`SmooConfigBuilder.BuildAsync`) — fetches all values, routes via a `Classify` delegate (feature flags skipped), emits encrypted bundle + base64 key. `SchemaClassifier` reads both JSON-Schema and serialized `defineConfig` shapes from `schema.json`.
- **Roslyn incremental source generator** — reads `schema.json` from `AdditionalFiles`, emits typed `Public.*`, `Secrets.*`, `FeatureFlags.*` static `ConfigKey<T>` properties under `SmooAI.Config.Generated`. Shipped inside the main `SmooAI.Config` NuGet as an analyzer.
- **Typed key API** (`ConfigKey<T>`) — `.GetAsync(client)`, `.Get(runtime)`, `.ResolveAsync(runtime, client)`.
- **Great NuGet README** — rewritten with quickstart, feature overview, wire-compat notes.
- **Version sync** — `scripts/sync-versions.mjs` now bumps `.csproj` to the npm version on every Changesets release. First synced release: `4.4.0`. `release.yml` publishes to NuGet alongside PyPI/crates.io/Go. `publish-nuget.yml` also triggers on `v*` and `@smooai/config@*` tags.

## Test plan

- [x] `dotnet build -c Release` succeeds with zero warnings
- [x] 46 dotnet tests pass (39 runtime/build/client + 7 generator)
- [x] `pnpm typecheck` green across TS / Python / Rust
- [x] `pnpm test` green across TS / Python / Rust / Go
- [x] Packed NuGet against a consumer project; source generator emits working typed keys from a real `schema.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)