### PR TITLE
SMOODEV-664: Rewrite READMEs — value-framed (drop HTTP/OAuth plumbing as headline)

### DIFF
--- a/.changeset/smoodev-664-readme-value-frame.md
+++ b/.changeset/smoodev-664-readme-value-frame.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-664: Rewrite READMEs to value-frame the package — lead with strongly-typed config/secrets/feature flags, cross-language parity, and zero-latency cold starts. Move HTTP/OAuth/AES-GCM protocol detail to an "Under the hood" section so the first scroll sells the outcome, not the plumbing. Applies to the npm, NuGet, PyPI, crates.io, and Go docs.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About @smooai/config
 
-**Type-safe configuration management for every layer of your stack** -- Define configuration schemas once, validate everywhere, and manage public settings, secrets, and feature flags with full TypeScript inference.
+**Type-safe config, secrets, and feature flags for every layer of your stack** -- One schema, one API, every language. Rename a key and every call site is a compile error, not a 3 AM page.
 
 ![NPM Version](https://img.shields.io/npm/v/%40smooai%2Fconfig?style=for-the-badge)
 ![NPM Downloads](https://img.shields.io/npm/dw/%40smooai%2Fconfig?style=for-the-badge)
@@ -36,14 +36,15 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ---
 
-### What's in the box
+### What you get
 
-- **`@smooai/config`** -- Server-side config SDK with the full priority chain (baked blob → env → HTTP → file) and typed sync + async accessors per tier (`publicConfig`, `secretConfig`, `featureFlag`).
-- **`@smooai/config/client`** -- Universal browser reader for feature flags and public config. Zero Node.js dependencies, works identically in Next.js, Vite, and any browser environment.
-- **`@smooai/config/nextjs/withSmooConfig`** -- Next.js config wrapper that bakes public config + feature-flag defaults into the bundle as `NEXT_PUBLIC_*` env vars, and inlines them into a runtime env bag for dynamic-key lookups.
-- **`@smooai/config/vite/smooConfigPlugin`** -- Vite plugin that does the same for `VITE_CONFIG_*` / `VITE_FEATURE_FLAG_*`.
-- **`@smooai/config/react`** -- Framework-agnostic React hooks (`useFeatureFlag`, `usePublicConfig`) + `ConfigProvider` for any React app.
-- **Typed key objects** -- `defineConfig()` returns `FeatureFlagKeys`, `PublicConfigKeys`, and `SecretConfigKeys` with auto-generated `UPPER_SNAKE_CASE` mappings and full TypeScript inference, so every config access is compile-time checked.
+- **Three tiers, one schema** -- public config, secrets, and feature flags defined once with Zod/Valibot/ArkType/Effect, validated everywhere they're read.
+- **Strongly-typed keys** -- `defineConfig()` gives you `PublicConfigKeys`, `SecretConfigKeys`, and `FeatureFlagKeys` with full inference. Mis-typed keys fail at compile time, not at runtime.
+- **Any environment, any key** -- same API for `development`, `staging`, `production`. Override per-stage without touching code.
+- **Zero-latency cold starts** -- values are baked into the bundle as env vars (Next.js, Vite) or resolved in-memory from a local runtime (server). No network round-trip on the hot path.
+- **Browser, server, framework-native** -- the same typed keys read cleanly from React client components, Server Components, Next.js, Vite, or plain Node.
+- **Live feature flags** -- toggled from the dashboard without a redeploy, but still typed.
+- **Native clients in every language** -- TypeScript, Python, Rust, Go, .NET (C#) all read from the same source of truth.
 
 ---
 

--- a/dotnet/src/SmooAI.Config/README.md
+++ b/dotnet/src/SmooAI.Config/README.md
@@ -3,14 +3,11 @@
 [![NuGet](https://img.shields.io/nuget/v/SmooAI.Config.svg)](https://www.nuget.org/packages/SmooAI.Config)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-.NET client for **[SmooAI.Config](https://smoo.ai)** — the OpenAI-compatible
-configuration service for your entire stack. One schema, one API, every
-language. Typed access to public values, secrets, and feature flags from
-any .NET app, with a local-baked runtime for zero-latency cold starts.
+**Type-safe config, secrets, and feature flags for .NET — one schema, every language, zero-latency cold starts.**
 
-Wire-compatible with the TypeScript, Python, Rust and Go clients — the same
-encrypted bundle decrypts and resolves to the same keys no matter which
-language you ship.
+.NET client for **[SmooAI.Config](https://smoo.ai)**. Retrieve config values, secrets, and feature flags from your `.NET` app with keys that are **compile-time checked** by a Roslyn source generator — rename a key and every miss becomes a build error, not a 3 AM page.
+
+The same encrypted bundle decrypts and resolves identically in the TypeScript, Python, Rust, and Go clients, so every service in your stack reads the same source of truth.
 
 ## Install
 
@@ -20,11 +17,12 @@ dotnet add package SmooAI.Config
 
 ## What you get
 
-- **HTTP client** with OAuth2 client-credentials auth, token caching, and 401 retry
-- **Local runtime** — AES-256-GCM decrypt of a baked config bundle for zero-network reads at cold start
-- **Build pipeline** — fetch all values and encrypt them into a bundle your deploy tool ships with the function
-- **Strongly-typed keys** via a Roslyn source generator — mis-typed keys fail at compile time
-- **Feature flag support** — live-fetched through the client, never baked
+- **Strongly-typed keys** — `Public.ApiUrl`, `Secrets.MoonshotApiKey`, `FeatureFlags.NewFlow`. Mis-typed keys fail at compile time.
+- **Schema-driven** — define your config once in `schema.json`; public values, secrets, and feature flags each get their own tier.
+- **Zero-latency cold starts** — values are baked into an encrypted bundle shipped with your deploy, so reads are in-memory with no network hop.
+- **Per-environment** — same keys, different values by stage (`development`, `staging`, `production`) with no code changes.
+- **Live feature flags** — flags fall through to the runtime client so you can flip them without a redeploy.
+- **Cross-language parity** — wire-compatible with the TypeScript, Python, Rust, and Go clients.
 
 ## Quickstart
 
@@ -73,60 +71,32 @@ var newFlow   = await FeatureFlags.NewFlow.ResolveAsync(runtime, client);
 No stringly-typed keys. Rename a key in `schema.json` and every call site
 becomes a compile-time error.
 
-## The three pieces
+## How it fits together
 
-### HTTP client
+Three pieces, one mental model: define the schema → bake the bundle at deploy → read typed values at runtime.
 
-OAuth2 client-credentials flow against `{baseUrl}/token` (with the `api.`
-subdomain rewritten to `auth.`), tokens cached in memory and refreshed 60
-seconds before expiry, automatic 401 retry.
+### Read typed values at runtime
 
-```csharp
-using var client = new SmooConfigClient(new SmooConfigClientOptions
-{
-    ClientId     = "...",
-    ClientSecret = "sk_...",
-    OrgId        = "...",
-    BaseUrl      = "https://api.smoo.ai",       // default
-    DefaultEnvironment = "production",           // default
-});
-
-// Untyped
-JsonElement value = await client.GetValueAsync("moonshotApiKey");
-Dictionary<string, JsonElement> all = await client.GetAllValuesAsync();
-
-// Typed (via generated keys)
-string? anthropic = await Secrets.AnthropicApiKey.GetAsync(client);
-```
-
-### Local runtime
-
-Decrypts a pre-built bundle at cold start and exposes it in-memory. Parity
-with the TS / Python / Rust / Go runtimes — blob layout is
-`nonce (12 bytes) || ciphertext || authTag (16 bytes)`, AES-256-GCM.
-
-Set two env vars on your function:
-
-| Variable               | Value                                      |
-| ---------------------- | ------------------------------------------ |
-| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
-| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+The baked bundle is decrypted into memory at cold start. Public + secret values resolve synchronously, in-process, with zero network calls. Feature flags fall through to the live client so they stay flip-on-flip-off.
 
 ```csharp
-var runtime = SmooConfigRuntime.Load();   // null when env vars are unset — dev fallback
-if (runtime is null) {
-    // No baked bundle present; fall back to a live-fetching client.
-}
-
 var apiUrl = runtime?.GetPublic("apiUrl")?.GetString();
 var retries = runtime?.GetValue<int>("retries");
 ```
 
-### Build pipeline
+Pair the runtime with the client for feature flags and cache misses:
 
-Bake all public + secret values into an encrypted bundle at deploy time.
-Feature flags are skipped — they stay live-fetched so you can flip them
-without a redeploy.
+```csharp
+// Public + secret come from the baked runtime (sync, no network).
+// Feature flags fall through to the HTTP client automatically.
+var apiUrl   = await Public.ApiUrl.ResolveAsync(runtime, client);
+var moonshot = await Secrets.MoonshotApiKey.ResolveAsync(runtime, client);
+var newFlow  = await FeatureFlags.NewFlow.ResolveAsync(runtime, client);
+```
+
+### Bake the bundle at deploy
+
+Fetch every current config value, encrypt them into a bundle, and ship that file alongside your function. Feature flags are skipped so you can still toggle them live.
 
 ```csharp
 using var client = new SmooConfigClient(clientOptions);
@@ -145,8 +115,36 @@ Console.WriteLine($"SMOO_CONFIG_KEY={result.KeyB64}");
 Console.WriteLine($"Baked {result.KeyCount} keys ({result.SkippedCount} feature flags skipped).");
 ```
 
-Ship `smoo-config.enc` alongside the function bundle, set the two env vars
-on the function, and the runtime picks up both automatically.
+Set two env vars on the function and the runtime picks them up automatically:
+
+| Variable               | Value                                      |
+| ---------------------- | ------------------------------------------ |
+| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
+| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+
+### Fetch live values (no bundle, or feature flags only)
+
+```csharp
+using var client = new SmooConfigClient(new SmooConfigClientOptions
+{
+    ClientId     = "...",
+    ClientSecret = "sk_...",
+    OrgId        = "...",
+    BaseUrl      = "https://api.smoo.ai",       // default
+    DefaultEnvironment = "production",           // default
+});
+
+// Typed
+string? anthropic = await Secrets.AnthropicApiKey.GetAsync(client);
+
+// Untyped
+JsonElement value = await client.GetValueAsync("moonshotApiKey");
+Dictionary<string, JsonElement> all = await client.GetAllValuesAsync();
+```
+
+## Under the hood
+
+If you want the protocol detail — auth is OAuth2 client-credentials against `{baseUrl}/token` (the `api.` subdomain rewrites to `auth.`), tokens are cached in-memory and refreshed 60s before expiry, and the client retries 401 once after re-auth. The baked bundle format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` with AES-256-GCM — wire-identical to the TS / Python / Rust / Go runtimes so a bundle baked in any language decrypts in any other.
 
 ## Wire compatibility
 

--- a/go/config/README.md
+++ b/go/config/README.md
@@ -24,7 +24,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-config (Go)
 
-**Type-safe configuration management for Go services** - Define configuration schemas with Go structs and struct tags, validate for cross-language interoperability, and fetch values from the centralized Smoo AI config server with a thread-safe client and local caching.
+**Type-safe config, secrets, and feature flags for Go** - Same schema, same keys, same source of truth as your TypeScript, Python, Rust, and .NET services. All typed, all thread-safe.
 
 ![GitHub License](https://img.shields.io/github/license/SmooAI/config?style=for-the-badge)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SmooAI/config/release.yml?style=for-the-badge)
@@ -32,21 +32,16 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ### Go Package
 
-A Go port of [@smooai/config](https://www.npmjs.com/package/@smooai/config) that mirrors the feature set of the TypeScript, Python, and Rust versions. The package exposes a struct-driven configuration API using `invopop/jsonschema` for JSON Schema reflection, a thread-safe HTTP client with `sync.RWMutex`-protected local caching, and a unified config manager that merges file config, remote API, and environment variables.
+Go port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Define your config with Go structs and tags — the same schema your TypeScript frontend or Rust service reads.
 
-### Why smooai-config?
+### What you get
 
-Ever scattered configuration across hardcoded values, config files, and environment variables across your Go services? Or struggled to keep configuration consistent between Go backends and TypeScript frontends? Traditional config management gives you the values, but not the cross-language safety.
-
-**smooai-config provides:**
-
-- **Three configuration tiers** - Separate public config, secrets, and feature flags with distinct schema types
-- **Native Go structs** - Use struct tags (`json`, `jsonschema`) for automatic JSON Schema generation via reflection
-- **`DefineConfigTyped` API** - Idiomatic Go API that generates JSON Schema from struct types with cross-language compatibility validation
-- **Thread-safe runtime client** - Fetch configuration from the Smoo AI config server with `sync.RWMutex`-protected caching
-- **Functional options pattern** - Configure the client and managers with idiomatic Go `...Option` parameters
-- **Environment variable fallback** - Zero-config client setup via `SMOOAI_CONFIG_*` environment variables
-- **`NewConfigClientFromEnv` constructor** - Load all credentials from environment with a single call
+- **Three tiers, one schema** - public config, secrets, and feature flags as three Go structs with struct tags.
+- **Native Go structs** - `json` and `jsonschema` tags are all you need; `DefineConfigTyped` generates the schema every other service reads.
+- **Any environment, any key** - same API for `development`, `staging`, `production` with per-stage overrides.
+- **Cross-language source of truth** - same schema lives in TypeScript, Python, Rust, and .NET services.
+- **Zero-config client setup** - `NewConfigClientFromEnv` picks up `SMOOAI_CONFIG_*` and goes.
+- **Thread-safe caching** - fetched values stay in-process between calls; invalidate on demand or set a TTL via `WithCacheTTL`.
 
 ### Install
 

--- a/python/README.md
+++ b/python/README.md
@@ -24,7 +24,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-config (Python)
 
-**Type-safe configuration management for Python services** - Define configuration schemas with Pydantic, validate across tiers, and fetch values from the centralized Smoo AI config server with local caching and thread safety.
+**Type-safe config, secrets, and feature flags for Python** - Same schema, same keys, same source of truth as your TypeScript, Rust, Go, and .NET services. Validated by Pydantic at the edge.
 
 ![PyPI Version](https://img.shields.io/pypi/v/smooai-config?style=for-the-badge)
 ![PyPI Downloads](https://img.shields.io/pypi/dw/smooai-config?style=for-the-badge)
@@ -36,21 +36,16 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ### Python Package
 
-This is the Python port of [@smooai/config](https://www.npmjs.com/package/@smooai/config), mirroring the TypeScript feature set for backend services. Define schemas with familiar Pydantic models, generate JSON Schema for cross-language interoperability, and use the runtime client to fetch live configuration values from any Python environment.
+The Python port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Define your schema with Pydantic `BaseModel` classes once and every Python service in your stack reads the same typed values as your TypeScript frontend or Go backend.
 
-### Why smooai-config?
+### What you get
 
-Ever scattered configuration across environment variables, dotenv files, and hardcoded values across your Python microservices? Or struggled to keep configuration consistent between TypeScript frontends and Python backends? Traditional config management gives you the values, but not the safety.
-
-**smooai-config provides:**
-
-- **Three configuration tiers** - Separate public config, secrets, and feature flags with distinct Pydantic schemas
-- **Pydantic-native schemas** - Use familiar `BaseModel` definitions with full type validation
-- **JSON Schema generation** - Export schemas for cross-language consumption by TypeScript, Rust, and Go services
-- **Cross-language compatibility validation** - Catches unsupported JSON Schema features at schema definition time
-- **Thread-safe runtime client** - Fetch configuration from the Smoo AI config server with local caching and `RLock` safety
-- **Context manager support** - Clean `with ConfigClient(...) as client:` usage with automatic HTTP connection cleanup
-- **Environment variable fallback** - Zero-config client setup via `SMOOAI_CONFIG_*` environment variables
+- **Three tiers, one schema** - public config, secrets, and feature flags separated cleanly as three Pydantic `BaseModel` classes.
+- **Pydantic-validated at the edge** - invalid values raise before they land in business logic.
+- **Any environment, any key** - same API for `development`, `staging`, `production` with per-stage overrides.
+- **Cross-language source of truth** - the schemas you define in Python are the same ones your TypeScript, Rust, Go, and .NET services read.
+- **Zero-config client setup** - pick up `SMOOAI_CONFIG_*` from env vars and go.
+- **Thread-safe + context-managed** - `with ConfigClient(...) as client:` handles caching and connection cleanup for you.
 
 ### Install
 

--- a/rust/config/README.md
+++ b/rust/config/README.md
@@ -24,7 +24,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-config (Rust)
 
-**Type-safe configuration management for Rust services** - Define configuration schemas with native Rust structs and schemars, validate for cross-language interoperability, and fetch values from the centralized Smoo AI config server with async reqwest and local caching.
+**Type-safe config, secrets, and feature flags for Rust** - Same schema, same keys, same source of truth as your TypeScript, Python, Go, and .NET services. All strongly typed, all async.
 
 ![Crates.io Version](https://img.shields.io/crates/v/smooai-config?style=for-the-badge)
 ![Crates.io Downloads](https://img.shields.io/crates/d/smooai-config?style=for-the-badge)
@@ -36,21 +36,16 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ### Rust Crate
 
-A Rust port of [@smooai/config](https://www.npmjs.com/package/@smooai/config) that mirrors the feature set of the TypeScript and Python versions. The crate exposes a type-driven configuration API using `schemars` for JSON Schema generation, an async `reqwest`-based runtime client with local caching, and a local config manager that merges file and environment variable sources.
+Rust port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Derive `JsonSchema` on your own Rust structs, generate the exact schema every other service in your stack reads, and resolve values through a cached async client.
 
-### Why smooai-config?
+### What you get
 
-Ever hardcoded configuration values across your Rust services or fought to keep configuration in sync between Rust backends and TypeScript frontends? Traditional config management gives you the values, but not the safety or cross-language consistency.
-
-**smooai-config provides:**
-
-- **Three configuration tiers** - Separate public config, secrets, and feature flags with distinct schema types
-- **Native Rust structs** - Derive `JsonSchema` on your own types via `schemars` for automatic JSON Schema generation
-- **`define_config_typed` API** - Idiomatic generic function that converts Rust struct types to validated JSON Schema
-- **Cross-language compatibility validation** - Catches unsupported JSON Schema features at schema definition time
-- **Async runtime client** - Fetch configuration from the Smoo AI config server with `tokio` + `reqwest` and local caching
-- **Environment variable fallback** - Zero-config client setup via `SMOOAI_CONFIG_*` environment variables
-- **`from_env()` constructor** - Load all credentials from environment with a single call
+- **Three tiers, one schema** - public config, secrets, and feature flags as three Rust structs with `#[derive(JsonSchema)]`.
+- **Strongly-typed, idiomatic Rust** - `define_config_typed::<Public, Secret, Flags>()` turns your structs into the schema every other service reads.
+- **Any environment, any key** - same API for `development`, `staging`, `production` with per-stage overrides.
+- **Cross-language source of truth** - the same schema lives in TypeScript, Python, Go, and .NET services.
+- **Zero-config client setup** - `ConfigClient::from_env()` picks up `SMOOAI_CONFIG_*` and goes.
+- **Async + cached** - fetched values stay in-process between calls; invalidate on demand or set a TTL.
 
 ### Install
 


### PR DESCRIPTION
## Summary

Rewrite every README in this repo so the first scroll sells **what the package lets you do** (strongly-typed config/secrets/feature flags, cross-language parity, zero-latency cold starts) instead of **how it works** (HTTP client, OAuth2, AES-GCM, token cache).

The kicker: the previous NuGet README led with _"HTTP client with OAuth2 client-credentials auth, token caching, and 401 retry"_ — plumbing, not value.

### What changed

- **Root `README.md`** — tightened "What's in the box" → "What you get" so the bullets lead with the outcome (three tiers / typed keys / zero-latency cold starts).
- **`dotnet/src/SmooAI.Config/README.md`** — replaced the plumbing lead with a compile-time-safety lead; added a "What you get" block; reorganized "The three pieces" → "How it fits together" (read typed values → bake the bundle → fetch live); moved OAuth/AES-GCM details into "Under the hood".
- **`python/README.md`**, **`rust/config/README.md`**, **`go/config/README.md`** — leads rewritten to emphasize cross-language source-of-truth + strong typing; dropped restatements of plumbing (Pydantic internals, `schemars` generation details, `sync.RWMutex` caching) from the headline bullets.
- **`.changeset/smoodev-664-readme-value-frame.md`** — patch bump so npm, NuGet, PyPI, crates.io, and Go all republish with the new README.

All technical detail survives — it's just relocated. Code blocks still run; anchors still resolve.

## Test plan

- [x] `pnpm lint` + `pnpm typecheck` + `pnpm test` + `pnpm build` via pre-commit hook
- [x] `pnpm format` via pre-commit hook
- [x] Verified `dotnet/src/SmooAI.Config/SmooAI.Config.csproj` still has `<PackageReadmeFile>README.md</PackageReadmeFile>` + `<None Include="README.md" Pack="true" PackagePath="\" />`
- [x] `.changeset` added — patch bump will cascade through `version:sync` so NuGet/Python/Rust/Go versions stay in lockstep with npm
- [ ] Merge triggers changesets release → new version on npm + NuGet + PyPI + crates.io + Go with the new README

Jira: [SMOODEV-664](https://smooai.atlassian.net/browse/SMOODEV-664)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-664]: https://smooai.atlassian.net/browse/SMOODEV-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ