### PR TITLE
SMOODEV-666: Multi-target SmooAI.Config to net8.0;net9.0;net10.0

### DIFF
--- a/.changeset/smoodev-666-multi-target.md
+++ b/.changeset/smoodev-666-multi-target.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-666: Multi-target the SmooAI.Config NuGet package to `net8.0;net9.0;net10.0` so consumers on every current .NET LTS + STS release get a native framework match. The Roslyn source generator stays at `netstandard2.0` (required by the Roslyn host).

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,7 +26,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Restore
               working-directory: dotnet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/dotnet/src/SmooAI.Config/SmooAI.Config.csproj
+++ b/dotnet/src/SmooAI.Config/SmooAI.Config.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>SmooAI.Config</PackageId>
-    <Version>4.5.1</Version>
+    <Version>4.5.2</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Product>SmooAI.Config</Product>


### PR DESCRIPTION
## Summary
- Switch `SmooAI.Config.csproj` from `<TargetFramework>net8.0</TargetFramework>` to `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>` so the NuGet package ships `lib/net8.0/`, `lib/net9.0/`, and `lib/net10.0/` and consumers on every current .NET LTS + STS release get a native match.
- Source generator project (`SmooAI.Config.SourceGenerator`) stays on `netstandard2.0` — that's a Roslyn host requirement and must not change.
- Update all three .NET CI workflows (pr-checks, release, publish-nuget) to install 8.0.x + 9.0.x + 10.0.x SDKs so the multi-target build resolves on the runner.
- Version bumped to 4.5.2 and changeset added.

## Test plan
- [x] `dotnet restore` — resolves on all three TFMs locally (SDK 10 ships net8 + net10 runtimes; net9 reference pack pulled by NuGet)
- [x] `dotnet build -c Release` — succeeds for net8.0, net9.0, net10.0 (3 DLLs produced)
- [x] `dotnet test -c Release` — Config.Tests (39/39) + SourceGenerator.Tests (7/7) pass
- [x] `dotnet pack` — inspected nupkg; contains `lib/net{8,9,10}.0/SmooAI.Config.dll` + `analyzers/dotnet/cs/SmooAI.Config.SourceGenerator.dll`
- [ ] PR CI (ubuntu) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)