### PR TITLE
SMOODEV-671: CLI push emits proper tiered JSON Schema for server-side storage

### DIFF
--- a/.changeset/smoodev-671-tiered-wire.md
+++ b/.changeset/smoodev-671-tiered-wire.md
@@ -1,0 +1,9 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-671: CLI push emits proper tiered JSON Schema for server-side storage
+
+`defineConfig()` now exposes `serializedAllConfigSchemaJsonSchema` — a full JSON Schema document with `publicConfigSchema` / `secretConfigSchema` / `featureFlagSchema` tier nodes and per-key `{type: 'string' | 'boolean' | 'number'}` (or full JSON Schema for zod/valibot/effect fields). This is the wire format the /apps/config dashboard expects.
+
+`smooai-config push` prefers this new property when available and falls back to the existing flat `serializedAllConfigSchema` (legacy configs) so pushes from older consumers keep working. The flat export is unchanged, so local runtime, buildBundle, and source generators are unaffected.

--- a/src/cli/utils/schema-loader.spec.ts
+++ b/src/cli/utils/schema-loader.spec.ts
@@ -86,5 +86,37 @@ describe('schema-loader', () => {
             expect(loaded!.format).toBe('json-schema');
             expect(loaded!.schemaName).toBe('fixture-json');
         });
+
+        it('prefers serializedAllConfigSchemaJsonSchema (tiered) over serializedAllConfigSchema (flat) — SMOODEV-671', async () => {
+            const loaded = await loadLocalSchema(join(FIXTURES, 'tiered/.smooai-config'));
+            expect(loaded).not.toBeNull();
+            expect(loaded!.format).toBe('typescript');
+            expect(loaded!.schemaName).toBe('fixture-tiered');
+
+            // The tiered property wins — we should see the nested
+            // publicConfigSchema node, not the flat API_URL key.
+            expect(loaded!.jsonSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    publicConfigSchema: {
+                        type: 'object',
+                        properties: { API_URL: { type: 'string' } },
+                    },
+                },
+            });
+            // Sanity: the flat property should NOT have been picked up.
+            expect((loaded!.jsonSchema as any).API_URL).toBeUndefined();
+        });
+
+        it('falls back to serializedAllConfigSchema when tiered form is absent — SMOODEV-671', async () => {
+            const loaded = await loadLocalSchema(join(FIXTURES, 'legacy-flat/.smooai-config'));
+            expect(loaded).not.toBeNull();
+            expect(loaded!.format).toBe('typescript');
+            expect(loaded!.schemaName).toBe('fixture-legacy-flat');
+            expect(loaded!.jsonSchema).toMatchObject({
+                type: 'object',
+                properties: { LEGACY_KEY: { type: 'string' } },
+            });
+        });
     });
 });

--- a/src/cli/utils/schema-loader.ts
+++ b/src/cli/utils/schema-loader.ts
@@ -128,10 +128,18 @@ export async function loadLocalSchema(configDir?: string): Promise<LoadedSchema 
             const mod = await loadTsConfigModule(tsPath);
             const configDef = ((mod as { default?: Record<string, unknown> }).default ?? mod) as Record<string, unknown>;
 
-            if (configDef.serializedAllConfigSchema) {
+            // SMOODEV-671: prefer the tiered JSON Schema wire format when the
+            // config module exposes it. Older `@smooai/config` versions only
+            // exported the flat `serializedAllConfigSchema` (internal
+            // `{key: 'stringSchema'}` form); fall back to that so legacy
+            // configs still push — though the UI won't render flat shapes
+            // correctly until the producer bumps past 4.x.
+            const tieredJsonSchema = configDef.serializedAllConfigSchemaJsonSchema as Record<string, unknown> | undefined;
+            const flatSchema = configDef.serializedAllConfigSchema as Record<string, unknown> | undefined;
+            if (tieredJsonSchema || flatSchema) {
                 return {
                     format: 'typescript',
-                    jsonSchema: configDef.serializedAllConfigSchema as Record<string, unknown>,
+                    jsonSchema: (tieredJsonSchema ?? flatSchema) as Record<string, unknown>,
                     filePath: tsPath,
                     schemaName: pickSchemaName(mod, configDef),
                 };

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- ok */
 import { describe, expect, it } from 'vitest';
 import z from 'zod';
-import { defineConfig, InferConfigTypes, StringSchema, NumberSchema, BooleanSchema } from './config';
+import { defineConfig, InferConfigTypes, StringSchema, NumberSchema, BooleanSchema, serializeConfigSchemaToJsonSchema } from './config';
 import { generateZodSchemas, parseConfig } from './parseConfigSchema';
 
 describe('defineConfig', () => {
@@ -275,5 +275,112 @@ describe('defineConfig', () => {
             expect(parsedConfig.enableLogging).toBe(true);
             expect(typeof parsedConfig.loggingConfig).toBe('function');
         }
+    });
+});
+
+describe('serializeConfigSchemaToJsonSchema (SMOODEV-671 tiered wire format)', () => {
+    it('wraps all three tiers under their canonical keys', () => {
+        const jsonSchema = serializeConfigSchemaToJsonSchema({
+            publicConfigSchema: { apiUrl: StringSchema, debugMode: BooleanSchema, maxRetries: NumberSchema },
+            secretConfigSchema: { apiKey: StringSchema },
+            featureFlagSchema: { enableNewUI: BooleanSchema },
+        });
+
+        expect(jsonSchema).toEqual({
+            type: 'object',
+            properties: {
+                publicConfigSchema: {
+                    type: 'object',
+                    properties: {
+                        apiUrl: { type: 'string' },
+                        debugMode: { type: 'boolean' },
+                        maxRetries: { type: 'number' },
+                    },
+                },
+                secretConfigSchema: {
+                    type: 'object',
+                    properties: {
+                        apiKey: { type: 'string' },
+                    },
+                },
+                featureFlagSchema: {
+                    type: 'object',
+                    properties: {
+                        enableNewUI: { type: 'boolean' },
+                    },
+                },
+            },
+        });
+    });
+
+    it('emits an empty tier node when a schema is missing', () => {
+        const jsonSchema = serializeConfigSchemaToJsonSchema({
+            publicConfigSchema: { apiUrl: StringSchema },
+        }) as any;
+
+        expect(jsonSchema.properties.publicConfigSchema.properties).toEqual({ apiUrl: { type: 'string' } });
+        expect(jsonSchema.properties.secretConfigSchema).toEqual({ type: 'object', properties: {} });
+        expect(jsonSchema.properties.featureFlagSchema).toEqual({ type: 'object', properties: {} });
+    });
+
+    it('nests real JSON Schema for zod standard-schema fields', () => {
+        const jsonSchema = serializeConfigSchemaToJsonSchema({
+            publicConfigSchema: {
+                database: z.object({
+                    host: z.string(),
+                    port: z.number(),
+                }),
+            },
+        }) as any;
+
+        const dbNode = jsonSchema.properties.publicConfigSchema.properties.database;
+        expect(dbNode.type).toBe('object');
+        expect(dbNode.properties.host).toMatchObject({ type: 'string' });
+        expect(dbNode.properties.port).toMatchObject({ type: 'number' });
+    });
+});
+
+describe('defineConfig exposes serializedAllConfigSchemaJsonSchema (SMOODEV-671)', () => {
+    it('attaches the tiered JSON Schema alongside the flat serialization', () => {
+        const config = defineConfig({
+            publicConfigSchema: { apiUrl: StringSchema },
+            secretConfigSchema: { apiKey: StringSchema },
+            featureFlagSchema: { enableNewUI: BooleanSchema },
+        });
+
+        // Flat internal form preserved for local runtime / source generator.
+        expect(config.serializedAllConfigSchema).toMatchObject({
+            apiUrl: 'stringSchema',
+            apiKey: 'stringSchema',
+            enableNewUI: 'booleanSchema',
+        });
+
+        // Tiered form shipped to the server for the /apps/config UI.
+        const wire = (config as any).serializedAllConfigSchemaJsonSchema;
+        expect(wire).toBeDefined();
+        expect(wire.type).toBe('object');
+        expect(wire.properties.publicConfigSchema.properties.apiUrl).toEqual({ type: 'string' });
+        expect(wire.properties.secretConfigSchema.properties.apiKey).toEqual({ type: 'string' });
+        expect(wire.properties.featureFlagSchema.properties.enableNewUI).toEqual({ type: 'boolean' });
+
+        // Standard public keys (ENV, CLOUD_PROVIDER, REGION, IS_LOCAL) are
+        // merged into the public tier on the wire so the UI sees every key
+        // the runtime will load.
+        expect(wire.properties.publicConfigSchema.properties.ENV).toEqual({ type: 'string' });
+        expect(wire.properties.publicConfigSchema.properties.IS_LOCAL).toEqual({ type: 'boolean' });
+
+        type Types = InferConfigTypes<typeof config>;
+        const _type: Types = {} as any; // type-level smoke check: compiles
+        void _type;
+    });
+
+    it('tolerates missing optional tiers', () => {
+        const config = defineConfig({
+            publicConfigSchema: { apiUrl: StringSchema },
+        });
+
+        const wire = (config as any).serializedAllConfigSchemaJsonSchema;
+        expect(wire.properties.secretConfigSchema.properties).toEqual({});
+        expect(wire.properties.featureFlagSchema.properties).toEqual({});
     });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -152,6 +152,65 @@ export function serializeConfigSchema<T extends ConfigSchema>(configSchema: T) {
     }, {} as ZodOutputType<T>);
 }
 
+/**
+ * Convert a single-tier `ConfigSchema` to a JSON Schema object node with
+ * `type: 'object'` + per-key `properties`. This is the SMOODEV-671 wire
+ * format: each key gets a real JSON Schema node (e.g. `{ type: 'string' }`)
+ * instead of the internal `'stringSchema'` sentinel string used by
+ * `serializeConfigSchema`.
+ */
+function tierConfigSchemaToJsonSchema<T extends ConfigSchema>(configSchema: T): Record<string, unknown> {
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(configSchema)) {
+        if (value === StringSchema) {
+            properties[key] = { type: 'string' };
+        } else if (value === BooleanSchema) {
+            properties[key] = { type: 'boolean' };
+        } else if (value === NumberSchema) {
+            properties[key] = { type: 'number' };
+        } else if (value && typeof value === 'object' && '~standard' in (value as object)) {
+            properties[key] = standardSchemaToJson(value as StandardSchemaV1);
+        }
+    }
+    return { type: 'object', properties };
+}
+
+/**
+ * Build the tiered JSON Schema used as the CLI push wire format
+ * (SMOODEV-671). The /apps/config dashboard renders the schemas / feature
+ * flags / values tabs off this shape — it expects three top-level tier
+ * nodes, each a proper JSON Schema object with nested per-key schemas.
+ *
+ * Shape:
+ *   {
+ *     type: 'object',
+ *     properties: {
+ *       publicConfigSchema:  { type: 'object', properties: { apiUrl: { type: 'string' }, ... } },
+ *       secretConfigSchema:  { type: 'object', properties: { ... } },
+ *       featureFlagSchema:   { type: 'object', properties: { ... } }
+ *     }
+ *   }
+ *
+ * This is kept separate from `serializeConfigSchema` (which still emits the
+ * flat `{ key: 'stringSchema' }` internal form) so local-runtime / source-
+ * generator consumers that read `serializedAllConfigSchema` are unaffected.
+ */
+export function serializeConfigSchemaToJsonSchema<Pub extends ConfigSchema, Sec extends ConfigSchema, FF extends ConfigSchema>(tiers: {
+    publicConfigSchema?: Pub | undefined;
+    secretConfigSchema?: Sec | undefined;
+    featureFlagSchema?: FF | undefined;
+}): Record<string, unknown> {
+    const { publicConfigSchema, secretConfigSchema, featureFlagSchema } = tiers;
+    return {
+        type: 'object',
+        properties: {
+            publicConfigSchema: tierConfigSchemaToJsonSchema(publicConfigSchema ?? ({} as Pub)),
+            secretConfigSchema: tierConfigSchemaToJsonSchema(secretConfigSchema ?? ({} as Sec)),
+            featureFlagSchema: tierConfigSchemaToJsonSchema(featureFlagSchema ?? ({} as FF)),
+        },
+    };
+}
+
 export function deserializeConfigSchema<T extends SeralizedConfigSchema>(configSchema: T) {
     return Object.entries(configSchema).reduce((acc, [key, value]) => {
         if (value === 'stringSchema') {
@@ -245,7 +304,8 @@ export /**
  *   - PublicConfigKeys: Object mapping public configuration keys to their snake_case versions
  *   - SecretConfigKeys: Object mapping secret configuration keys to their snake_case versions
  *   - FeatureFlagKeys: Object mapping feature flag keys to their snake_case versions
- *   - serializedAllConfigSchema: Serialized version of the complete configuration schema
+ *   - serializedAllConfigSchema: Flat internal serialization (e.g. `{ apiUrl: 'stringSchema' }`) — kept for local runtime, source generators, and the Zod-regen path
+ *   - serializedAllConfigSchemaJsonSchema: Tiered JSON Schema wire format used by `smooai-config push` and the /apps/config dashboard
  *   - _configTypeInput: Type helper for input configuration
  *   - _configTypeOutput: Type helper for output configuration
  *   - _configType: Type helper for configuration
@@ -364,6 +424,16 @@ function defineConfig<Pub extends ConfigSchema, Sec extends ConfigSchema, FF ext
 
     const serializedAllConfigSchema = serializeConfigSchema(allConfigSchema);
 
+    // SMOODEV-671: CLI `smooai-config push` reads this tiered JSON Schema
+    // (not the flat `serializedAllConfigSchema`) so the /apps/config UI can
+    // render proper schemas / feature-flag / values tabs. The flat form
+    // stays intact for local-runtime and source-generator consumers.
+    const serializedAllConfigSchemaJsonSchema = serializeConfigSchemaToJsonSchema({
+        publicConfigSchema: allPublicConfigSchema as Pub,
+        secretConfigSchema,
+        featureFlagSchema,
+    });
+
     // const { objectWithDeferFunctions: allConfigZodSchemaWithDeferFunctions, object: allConfigZodSchema } = generateConfigSchema(allConfigSchema);
 
     // const parseConfig = (
@@ -398,6 +468,7 @@ function defineConfig<Pub extends ConfigSchema, Sec extends ConfigSchema, FF ext
         SecretConfigKeys,
         FeatureFlagKeys,
         serializedAllConfigSchema,
+        serializedAllConfigSchemaJsonSchema,
         _configTypeInput,
         _configTypeOutput,
         _configType,
@@ -480,6 +551,7 @@ export type InferConfigTypes<T> = T extends {
     SecretConfigKeys: infer SK;
     FeatureFlagKeys: infer FK;
     serializedAllConfigSchema: infer _SACS;
+    serializedAllConfigSchemaJsonSchema?: infer _SJS;
     _configType: infer CT;
     _configTypeInput: infer CIT;
     _configTypeOutput: infer COT;

--- a/test-fixtures/cli-schema-loader/legacy-flat/.smooai-config/config.ts
+++ b/test-fixtures/cli-schema-loader/legacy-flat/.smooai-config/config.ts
@@ -1,0 +1,19 @@
+// SMOODEV-671 fallback fixture: a legacy config that only exposes the flat
+// `serializedAllConfigSchema` property (e.g. a project pinned to an older
+// `@smooai/config`). The loader should still push it rather than bail.
+
+function defineConfig<T extends Record<string, unknown>>(input: T): T {
+    return input;
+}
+
+const config = defineConfig({
+    serializedAllConfigSchema: {
+        type: 'object',
+        properties: {
+            LEGACY_KEY: { type: 'string' },
+        },
+    },
+    schemaName: 'fixture-legacy-flat',
+});
+
+export default config;

--- a/test-fixtures/cli-schema-loader/tiered/.smooai-config/config.ts
+++ b/test-fixtures/cli-schema-loader/tiered/.smooai-config/config.ts
@@ -1,0 +1,32 @@
+// SMOODEV-671 fixture: config modules built against @smooai/config >= 5.x
+// expose both the flat `serializedAllConfigSchema` (internal runtime form)
+// and the tiered `serializedAllConfigSchemaJsonSchema` (JSON Schema wire
+// format). The CLI loader must prefer the tiered one when both are present.
+
+function defineConfig<T extends Record<string, unknown>>(input: T): T {
+    return input;
+}
+
+const config = defineConfig({
+    // Legacy flat form — what pre-SMOODEV-671 servers stored.
+    serializedAllConfigSchema: {
+        API_URL: 'stringSchema',
+    },
+    // New tiered JSON Schema — what the /apps/config UI expects.
+    serializedAllConfigSchemaJsonSchema: {
+        type: 'object',
+        properties: {
+            publicConfigSchema: {
+                type: 'object',
+                properties: {
+                    API_URL: { type: 'string' },
+                },
+            },
+            secretConfigSchema: { type: 'object', properties: {} },
+            featureFlagSchema: { type: 'object', properties: {} },
+        },
+    },
+    schemaName: 'fixture-tiered',
+});
+
+export default config;


### PR DESCRIPTION
## Summary

`/apps/config` was broken on prod: Schemas tab showed "Schema of type any", Feature Flags tab showed "no feature-flag keys yet" even with `googleAuth` + `observability` defined. Root cause: `smooai-config push` was shipping the internal flat serialization (`{ apiUrl: "stringSchema", moonshotApiKey: "stringSchema" }`) instead of a proper JSON Schema, and the UI expects a tiered JSON Schema with `publicConfigSchema` / `secretConfigSchema` / `featureFlagSchema` sub-properties.

## What changed

- `defineConfig()` now exposes a new `serializedAllConfigSchemaJsonSchema` property — a full JSON Schema document with 3 tier nodes, each a proper `{type: "object", properties: {...}}` with per-key schemas. Zod/valibot/effect fields still flow through `standardSchemaToJson` for real nested JSON Schema.
- The CLI loader (`schema-loader.ts`) prefers this tiered export when available and falls back to the flat `serializedAllConfigSchema` for legacy configs.
- Flat `serializedAllConfigSchema` is **unchanged** — local runtime (`parseConfigSchema` → `deserializeConfigSchema` → zod regen), buildBundle, and the source generator keep reading the same internal form.

## Old vs new wire format

**Before (broken for UI):**

```json
{
  "ENV": "stringSchema",
  "apiUrl": "stringSchema",
  "moonshotApiKey": "stringSchema",
  "googleAuth": "booleanSchema",
  "observability": "booleanSchema"
}
```

**After (renders correctly in /apps/config):**

```json
{
  "type": "object",
  "properties": {
    "publicConfigSchema": {
      "type": "object",
      "properties": {
        "ENV": { "type": "string" },
        "CLOUD_PROVIDER": { "type": "string" },
        "REGION": { "type": "string" },
        "IS_LOCAL": { "type": "boolean" },
        "apiUrl": { "type": "string" }
      }
    },
    "secretConfigSchema": {
      "type": "object",
      "properties": { "moonshotApiKey": { "type": "string" } }
    },
    "featureFlagSchema": {
      "type": "object",
      "properties": {
        "googleAuth": { "type": "boolean" },
        "observability": { "type": "boolean" }
      }
    }
  }
}
```

## Back-compat

- Flat `serializedAllConfigSchema` export is unchanged — local runtime, source generator, buildBundle all unaffected.
- CLI loader falls back to the flat form if the project is pinned to an older `@smooai/config` (so old configs still push; the UI just won't render them optimally until they bump).
- Cross-language schema validator (`validateSmooaiSchema`) uses only supported keywords (`type`, `properties`) — passes.

## Tests

- `src/config/config.spec.ts` — 3 new tests for `serializeConfigSchemaToJsonSchema` + `defineConfig` tiered output (empty tiers, zod fields, standard public keys merged into public tier).
- `src/cli/utils/schema-loader.spec.ts` — 2 new fixtures (`tiered/`, `legacy-flat/`) + tests verifying loader prefers tiered form but falls back gracefully.
- Full test suite: 18 files / 176 tests passing.

## Follow-up (smooai monorepo)

1. Bump `@smooai/config` dep to the new patch version.
2. Re-push the smooai schema via the new CLI — creates `smooai` v8 with the proper tiered shape.
3. Verify /apps/config tabs render correctly.

Jira: SMOODEV-671 (P1)

## Test plan

- [x] Unit: `serializeConfigSchemaToJsonSchema` produces the expected shape for each tier
- [x] Unit: `defineConfig` exposes both flat + tiered properties
- [x] Unit: CLI loader prefers tiered, falls back to flat
- [x] Typecheck + build pass
- [ ] After release: re-push smooai schema and confirm /apps/config?tab=schemas, ?tab=flags, ?tab=values all render correctly