### PR TITLE
SMOODEV-730: Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var to all workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,9 @@ on:
         branches: [main]
         types: [opened, synchronize]
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
     validate:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -12,6 +12,9 @@ on:
             - '@smooai/config@*'
     workflow_dispatch:
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
     CI: true
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
     version:


### PR DESCRIPTION
## Summary
- GitHub will force Node 24 by default starting June 2, 2026 and remove Node 20 from runners on Sept 16, 2026
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to top-level `env:` in every workflow
- Opts every workflow into Node 24 immediately while keeping all action versions pinned — no behavior change risk

## Why env-var only (no version bumps)
Every action used here either already supports Node 24 on its currently-pinned major (checkout v4, github-script v7, configure-aws-credentials v4, setup-node v4, setup-uv v6, etc.) OR has no Node 24 release available yet (e.g. `pulumi/actions`). Bumping pinned majors carries non-zero behavior risk. The env var solves the deprecation cleanly without that risk and is reversible by deleting one line. Action version bumps tracked as a separate follow-up.

## Reference
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)