### PR TITLE
SMOODEV-847: Throw clear error on get() with undefined key

### DIFF
--- a/.changeset/smoodev-847-undef-key-guard.md
+++ b/.changeset/smoodev-847-undef-key-guard.md
@@ -1,0 +1,17 @@
+---
+'@smooai/config': minor
+---
+
+Throw a clear error when `secretConfig.get()` / `publicConfig.get()` /
+`featureFlag.get()` (or their `getSync` siblings) receive `undefined` /
+`null` / non-string keys, instead of cascading into `envVarNameFor`'s
+`undefined.replace(...)` and surfacing as the cryptic
+`Cannot read properties of undefined (reading 'replace')`.
+
+Most common cause: reading `SecretConfigKeys.<X>` (or
+`PublicConfigKeys.<X>` / `FeatureFlagKeys.<X>`) for a key that wasn't
+declared in the consumer's schema. The new error spells that out and
+points at `smooai-config push`. Cost real prod debug time on
+SMOODEV-841 — the route handler crashed deep inside `@smooai/config`'s
+internals while the actual fix was one declaration in
+`.smooai-config/config.ts`.

--- a/dotnet/src/SmooAI.Config/Runtime/SmooConfigRuntime.cs
+++ b/dotnet/src/SmooAI.Config/Runtime/SmooConfigRuntime.cs
@@ -125,7 +125,7 @@ public sealed class SmooConfigRuntime
     /// </summary>
     public JsonElement? GetValue(string key)
     {
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
 
         if (Baked.Secret.TryGetValue(key, out var secret)) return secret;
         if (Baked.Public.TryGetValue(key, out var pub)) return pub;
@@ -138,7 +138,7 @@ public sealed class SmooConfigRuntime
     /// </summary>
     public JsonElement? GetPublic(string key)
     {
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
         return Baked.Public.TryGetValue(key, out var v) ? v : null;
     }
 
@@ -148,7 +148,7 @@ public sealed class SmooConfigRuntime
     /// </summary>
     public JsonElement? GetSecret(string key)
     {
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
         return Baked.Secret.TryGetValue(key, out var v) ? v : null;
     }
 

--- a/dotnet/src/SmooAI.Config/SmooConfigClient.cs
+++ b/dotnet/src/SmooAI.Config/SmooConfigClient.cs
@@ -95,7 +95,7 @@ public sealed class SmooConfigClient : IDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     public async Task<JsonElement> GetValueAsync(string key, string? environment = null, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
         var env = ResolveEnv(environment);
 
         var url = $"{_baseUrl}/organizations/{_orgId}/config/values/{Uri.EscapeDataString(key)}?environment={Uri.EscapeDataString(env)}";
@@ -136,7 +136,7 @@ public sealed class SmooConfigClient : IDisposable
     {
         if (string.IsNullOrWhiteSpace(schemaId)) throw new ArgumentException("SchemaId is required.", nameof(schemaId));
         if (string.IsNullOrWhiteSpace(environmentId)) throw new ArgumentException("EnvironmentId is required.", nameof(environmentId));
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
 
         var body = new SetValueRequest
         {

--- a/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
+++ b/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
@@ -21,7 +21,7 @@ public sealed class ConfigKey<T>
     /// <summary>Create a typed key. Normally called by generated code.</summary>
     public ConfigKey(string key, ConfigTier tier)
     {
-        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("@smooai/config: get() called with null/empty key. Most common cause: reading a typed-keys constant for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`.", nameof(key));
         Key = key;
         Tier = tier;
     }

--- a/go/config/config_manager.go
+++ b/go/config/config_manager.go
@@ -219,6 +219,14 @@ func (m *ConfigManager) initialize() error {
 }
 
 func (m *ConfigManager) getFromTier(key string, cache map[string]localCacheEntry) (any, error) {
+	// SMOODEV-847 — guard against empty keys. Matches the assertKeyDefined
+	// behavior in the TypeScript SDK; surfaces a clear error instead of
+	// silently returning nil from the merged config map.
+	if key == "" {
+		return nil, fmt.Errorf("@smooai/config: get() called with empty key. " +
+			"Most common cause: reading a typed-keys constant for a key that's not declared in your schema. " +
+			"Add it to .smooai-config/config.ts and run `smooai-config push`")
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/go/config/local_config.go
+++ b/go/config/local_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -104,6 +105,12 @@ func (m *LocalConfigManager) initialize() error {
 }
 
 func (m *LocalConfigManager) getValue(key string, cache map[string]localCacheEntry) (any, error) {
+	// SMOODEV-847 — guard against empty keys (matches ConfigManager.getFromTier).
+	if key == "" {
+		return nil, fmt.Errorf("@smooai/config: get() called with empty key. " +
+			"Most common cause: reading a typed-keys constant for a key that's not declared in your schema. " +
+			"Add it to .smooai-config/config.ts and run `smooai-config push`")
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/python/src/smooai_config/config_manager.py
+++ b/python/src/smooai_config/config_manager.py
@@ -172,6 +172,17 @@ class ConfigManager:
 
     def _get_value(self, key: str, cache: dict[str, tuple[Any, float]]) -> Any | None:
         """Get config value from merged config with per-tier caching."""
+        # SMOODEV-847 — guard against None / empty / non-string keys. Most
+        # common cause is reading a typed-keys constant for a key that
+        # wasn't declared in the schema and resolves to None. Without this
+        # guard the call would later flow into env-var-name conversion that
+        # crashes with a cryptic AttributeError.
+        if not isinstance(key, str) or not key:
+            raise ValueError(
+                f"@smooai/config: get() called with {type(key).__name__ if key is None or not isinstance(key, str) else 'empty string'} key. "
+                "Most common cause: reading SecretConfigKeys.<X> / PublicConfigKeys.<X> / FeatureFlagKeys.<X> "
+                "for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`."
+            )
         with self._lock:
             hit, value = self._get_from_cache(cache, key)
             if hit:

--- a/python/src/smooai_config/local.py
+++ b/python/src/smooai_config/local.py
@@ -69,6 +69,15 @@ class LocalConfigManager:
 
     def _get_value(self, key: str, cache: dict[str, tuple[Any, float]]) -> Any | None:
         """Get config value. File config takes precedence over env config."""
+        # SMOODEV-847 — guard against None / empty / non-string keys. See the
+        # equivalent assertKeyDefined in src/server/internal.ts for the
+        # original incident (Derek's ICVR dashboard).
+        if not isinstance(key, str) or not key:
+            raise ValueError(
+                f"@smooai/config: get() called with {type(key).__name__ if key is None or not isinstance(key, str) else 'empty string'} key. "
+                "Most common cause: reading a typed-keys constant for a key that's not declared in your schema. "
+                "Add it to .smooai-config/config.ts and run `smooai-config push`."
+            )
         with self._lock:
             hit, value = self._get_from_cache(cache, key)
             if hit:

--- a/rust/config/src/config_manager.rs
+++ b/rust/config/src/config_manager.rs
@@ -265,6 +265,15 @@ impl ConfigManager {
         key: &str,
         cache_selector: fn(&mut ManagerInner) -> &mut HashMap<String, CacheEntry>,
     ) -> Result<Option<Value>, SmooaiConfigError> {
+        // SMOODEV-847 — guard against empty keys (matches LocalConfigManager
+        // and the TS assertKeyDefined). See SMOODEV-841 incident.
+        if key.is_empty() {
+            return Err(SmooaiConfigError::new(
+                "@smooai/config: get() called with empty key. \
+                 Most common cause: reading a typed-keys constant for a key that's not declared in your schema. \
+                 Add it to .smooai-config/config.ts and run `smooai-config push`",
+            ));
+        }
         let mut inner = self
             .inner
             .write()

--- a/rust/config/src/local.rs
+++ b/rust/config/src/local.rs
@@ -118,6 +118,17 @@ impl LocalConfigManager {
         key: &str,
         cache_selector: fn(&mut Inner) -> &mut HashMap<String, CacheEntry>,
     ) -> Result<Option<Value>, SmooaiConfigError> {
+        // SMOODEV-847 — guard against empty keys. Matches assertKeyDefined
+        // behavior in the TypeScript SDK; gives a clear error instead of
+        // silently returning None for an unset key (which can mask schema
+        // mistakes). Cost real prod debug time on the TS side.
+        if key.is_empty() {
+            return Err(SmooaiConfigError::new(
+                "@smooai/config: get() called with empty key. \
+                 Most common cause: reading a typed-keys constant for a key that's not declared in your schema. \
+                 Add it to .smooai-config/config.ts and run `smooai-config push`",
+            ));
+        }
         let mut inner = self
             .inner
             .write()

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -102,6 +102,7 @@ function readClientEnv(): Record<string, string> {
  * e.g., `"aboutPage"` → `NEXT_PUBLIC_FEATURE_FLAG_ABOUT_PAGE`
  */
 export function getClientFeatureFlag(key: string): boolean {
+    assertClientKeyDefined(key, 'featureFlag');
     const envKey = toUpperSnakeCase(key);
     const env = readClientEnv();
     const raw = env[`NEXT_PUBLIC_FEATURE_FLAG_${envKey}`] ?? env[`VITE_FEATURE_FLAG_${envKey}`];
@@ -120,6 +121,7 @@ export function getClientFeatureFlag(key: string): boolean {
  * e.g., `"apiBaseUrl"` → `NEXT_PUBLIC_CONFIG_API_BASE_URL`
  */
 export function getClientPublicConfig(key: string): string | undefined {
+    assertClientKeyDefined(key, 'public');
     const envKey = toUpperSnakeCase(key);
     const env = readClientEnv();
     return env[`NEXT_PUBLIC_CONFIG_${envKey}`] ?? env[`VITE_CONFIG_${envKey}`];

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -42,6 +42,25 @@ export function toUpperSnakeCase(key: string): string {
 }
 
 /**
+ * Guard for the client get() / getSync() entry points: throw a clear error
+ * if a caller passes `undefined` / `null`. Most common cause: reading
+ * `PublicConfigKeys.<X>` / `FeatureFlagKeys.<X>` for a key that wasn't
+ * declared in the schema — the index lookup returns `undefined` and
+ * without this guard `toUpperSnakeCase(undefined)` crashes with the
+ * cryptic "Cannot read properties of undefined (reading 'replace')".
+ * Mirrors `assertKeyDefined` in `@/server/internal` (SMOODEV-841).
+ */
+function assertClientKeyDefined(key: unknown, tier: 'public' | 'featureFlag'): asserts key is string {
+    if (typeof key === 'string' && key.length > 0) return;
+    const tierEnum = tier === 'public' ? 'PublicConfigKeys' : 'FeatureFlagKeys';
+    throw new Error(
+        `@smooai/config (client): ${tier}Config.get() called with ${key === undefined ? 'undefined' : key === null ? 'null' : `non-string (${typeof key})`} key. ` +
+            `Most common cause: reading \`${tierEnum}.<X>\` for a key that's not declared in your schema. ` +
+            `Add it to .smooai-config/config.ts and run \`smooai-config push\`.`,
+    );
+}
+
+/**
  * Read the unified bundler-baked env bag.
  *
  * Both `smooConfigPlugin` (Vite) and `withSmooConfig` (Next.js) replace
@@ -180,6 +199,7 @@ export function buildClientConfig<Schema extends ReturnType<typeof defineConfig>
     const httpClient = options?.httpClient ?? new ConfigClient({ cacheTtlMs: 30_000, ...(options?.httpClientOptions ?? {}) });
 
     async function getPublic<K extends PublicKey>(key: K): Promise<ConfigType[K] | undefined> {
+        assertClientKeyDefined(key, 'public');
         const fromBundle = getClientPublicConfig(key as string);
         if (fromBundle !== undefined) return fromBundle as unknown as ConfigType[K];
 
@@ -193,6 +213,7 @@ export function buildClientConfig<Schema extends ReturnType<typeof defineConfig>
     }
 
     async function getFlag<K extends FlagKey>(key: K): Promise<ConfigType[K] | undefined> {
+        assertClientKeyDefined(key, 'featureFlag');
         try {
             const fromHttp = await httpClient.getValue(key as string);
             if (fromHttp !== undefined && fromHttp !== null && fromHttp !== '') return fromHttp as ConfigType[K];
@@ -208,6 +229,7 @@ export function buildClientConfig<Schema extends ReturnType<typeof defineConfig>
         publicConfig: {
             get: getPublic,
             getSync: <K extends PublicKey>(key: K): ConfigType[K] | undefined => {
+                assertClientKeyDefined(key, 'public');
                 const v = getClientPublicConfig(key as string);
                 return v as unknown as ConfigType[K] | undefined;
             },
@@ -215,6 +237,7 @@ export function buildClientConfig<Schema extends ReturnType<typeof defineConfig>
         featureFlag: {
             get: getFlag,
             getSync: <K extends FlagKey>(key: K): ConfigType[K] | undefined => {
+                assertClientKeyDefined(key, 'featureFlag');
                 const v = getClientFeatureFlag(key as string);
                 return v as unknown as ConfigType[K] | undefined;
             },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -46,7 +46,7 @@ import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig, InferConfigTypes } from '@/config/config';
 import { createSyncFn } from 'synckit';
-import { buildConfigAsync, BuildConfigAsyncOptions } from './internal';
+import { assertKeyDefined, buildConfigAsync, BuildConfigAsyncOptions } from './internal';
 import { WORKER_SOURCE } from './sync-worker-source.generated';
 
 export type { BuildConfigAsyncOptions as BuildConfigOptions } from './internal';
@@ -152,18 +152,24 @@ export function buildConfig<Schema extends ReturnType<typeof defineConfig>>(sche
     return {
         publicConfig: {
             get: asyncCore.publicConfig.get,
-            getSync: <K extends PublicKey>(key: K): ConfigType[K] | undefined =>
-                unpack<ConfigType[K]>(publicSync(schema, 'public', key) as WorkerEnvelope, key as string),
+            getSync: <K extends PublicKey>(key: K): ConfigType[K] | undefined => {
+                assertKeyDefined(key, 'public');
+                return unpack<ConfigType[K]>(publicSync(schema, 'public', key) as WorkerEnvelope, key as string);
+            },
         },
         secretConfig: {
             get: asyncCore.secretConfig.get,
-            getSync: <K extends SecretKey>(key: K): ConfigType[K] | undefined =>
-                unpack<ConfigType[K]>(secretSync(schema, 'secret', key) as WorkerEnvelope, key as string),
+            getSync: <K extends SecretKey>(key: K): ConfigType[K] | undefined => {
+                assertKeyDefined(key, 'secret');
+                return unpack<ConfigType[K]>(secretSync(schema, 'secret', key) as WorkerEnvelope, key as string);
+            },
         },
         featureFlag: {
             get: asyncCore.featureFlag.get,
-            getSync: <K extends FlagKey>(key: K): ConfigType[K] | undefined =>
-                unpack<ConfigType[K]>(flagSync(schema, 'flag', key) as WorkerEnvelope, key as string),
+            getSync: <K extends FlagKey>(key: K): ConfigType[K] | undefined => {
+                assertKeyDefined(key, 'featureFlag');
+                return unpack<ConfigType[K]>(flagSync(schema, 'flag', key) as WorkerEnvelope, key as string);
+            },
         },
         invalidateCaches: asyncCore.invalidateCaches,
         getSource: asyncCore.getSource,

--- a/src/server/internal.assert-key.test.ts
+++ b/src/server/internal.assert-key.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for `assertKeyDefined` — the guard that fronts every server-side
+ * `get()` / `getSync()` so callers don't fall into envVarNameFor's
+ * `undefined.replace(...)` cascade when they pass a key that isn't declared
+ * in the schema (SMOODEV-841 / SMOODEV-847).
+ */
+import { BooleanSchema, defineConfig, StringSchema } from '@/config/config';
+import { describe, expect, it } from 'vitest';
+import { assertKeyDefined, buildConfigAsync } from './internal';
+
+describe('assertKeyDefined', () => {
+    it('passes for non-empty strings', () => {
+        expect(() => assertKeyDefined('apiUrl', 'public')).not.toThrow();
+        expect(() => assertKeyDefined('myKey', 'secret')).not.toThrow();
+        expect(() => assertKeyDefined('flagName', 'featureFlag')).not.toThrow();
+    });
+
+    it('throws a clear error for undefined', () => {
+        expect(() => assertKeyDefined(undefined, 'secret')).toThrow(/SecretConfigKeys/);
+        expect(() => assertKeyDefined(undefined, 'secret')).toThrow(/undefined/);
+        expect(() => assertKeyDefined(undefined, 'public')).toThrow(/PublicConfigKeys/);
+        expect(() => assertKeyDefined(undefined, 'featureFlag')).toThrow(/FeatureFlagKeys/);
+    });
+
+    it('throws for null', () => {
+        expect(() => assertKeyDefined(null, 'secret')).toThrow(/null/);
+    });
+
+    it('throws for non-strings', () => {
+        expect(() => assertKeyDefined(42, 'secret')).toThrow(/non-string/);
+        expect(() => assertKeyDefined({}, 'public')).toThrow(/non-string/);
+    });
+
+    it('throws for empty string', () => {
+        expect(() => assertKeyDefined('', 'secret')).toThrow();
+    });
+
+    it('mentions the schema-declaration fix in the message', () => {
+        expect(() => assertKeyDefined(undefined, 'secret')).toThrow(/declared in your schema/);
+        expect(() => assertKeyDefined(undefined, 'secret')).toThrow(/smooai-config push/);
+    });
+});
+
+describe('build*Config get() guards against undefined key', () => {
+    const schema = defineConfig({
+        publicConfigSchema: { apiUrl: StringSchema },
+        secretConfigSchema: { sendgridApiKey: StringSchema },
+        featureFlagSchema: { observability: BooleanSchema },
+    });
+
+    it('secretConfig.get(undefined) throws clear error (was: cryptic .replace crash)', async () => {
+        const cfg = buildConfigAsync(schema);
+        await expect(cfg.secretConfig.get(undefined as unknown as 'sendgridApiKey')).rejects.toThrow(/SecretConfigKeys/);
+        await expect(cfg.secretConfig.get(undefined as unknown as 'sendgridApiKey')).rejects.not.toThrow(
+            /Cannot read properties of undefined \(reading 'replace'\)/,
+        );
+    });
+
+    it('publicConfig.get(undefined) throws clear error', async () => {
+        const cfg = buildConfigAsync(schema);
+        await expect(cfg.publicConfig.get(undefined as unknown as 'apiUrl')).rejects.toThrow(/PublicConfigKeys/);
+    });
+
+    it('featureFlag.get(undefined) throws clear error', async () => {
+        const cfg = buildConfigAsync(schema);
+        await expect(cfg.featureFlag.get(undefined as unknown as 'observability')).rejects.toThrow(/FeatureFlagKeys/);
+    });
+});

--- a/src/server/internal.ts
+++ b/src/server/internal.ts
@@ -106,6 +106,26 @@ function envVarNameFor(key: string): string {
     return key.replace(/([A-Z])/g, '_$1').toUpperCase();
 }
 
+/**
+ * Guard for the get() / getSync() entry points: throw a clear error if a
+ * caller passes `undefined` / `null`. The most common cause is reading
+ * `SecretConfigKeys.<X>` (or `PublicConfigKeys.<X>` / `FeatureFlagKeys.<X>`)
+ * for a key that wasn't declared in the schema — the index lookup then
+ * returns `undefined` and the value flows in here. Without this guard the
+ * next line is `key.replace(...)` and you get the cryptic "Cannot read
+ * properties of undefined (reading 'replace')" stack from envVarNameFor,
+ * which has cost real prod debug time (SMOODEV-841).
+ */
+export function assertKeyDefined(key: unknown, tier: 'public' | 'secret' | 'featureFlag'): asserts key is string {
+    if (typeof key === 'string' && key.length > 0) return;
+    const tierEnum = tier === 'public' ? 'PublicConfigKeys' : tier === 'secret' ? 'SecretConfigKeys' : 'FeatureFlagKeys';
+    throw new Error(
+        `@smooai/config: ${tier}Config.get() called with ${key === undefined ? 'undefined' : key === null ? 'null' : `non-string (${typeof key})`} key. ` +
+            `Most common cause: reading \`${tierEnum}.<X>\` for a key that's not declared in your schema. ` +
+            `Add it to .smooai-config/config.ts and run \`smooai-config push\`.`,
+    );
+}
+
 function readFromEnv<Schema extends ReturnType<typeof defineConfig>>(schema: Schema, key: string): unknown {
     const raw = process.env[envVarNameFor(key)];
     if (raw === undefined) return undefined;
@@ -178,6 +198,7 @@ export function buildConfigAsync<Schema extends ReturnType<typeof defineConfig>>
     }
 
     async function getPublic<K extends PublicKey>(key: K): Promise<ConfigType[K] | undefined> {
+        assertKeyDefined(key, 'public');
         const keyStr = key as unknown as string;
         const cached = publicValueCache.get(keyStr);
         if (cached !== undefined) return cached as ConfigType[K];
@@ -215,6 +236,7 @@ export function buildConfigAsync<Schema extends ReturnType<typeof defineConfig>>
     }
 
     async function getSecret<K extends SecretKey>(key: K): Promise<ConfigType[K] | undefined> {
+        assertKeyDefined(key, 'secret');
         const keyStr = key as unknown as string;
         const cached = secretValueCache.get(keyStr);
         if (cached !== undefined) return cached as ConfigType[K];
@@ -252,6 +274,7 @@ export function buildConfigAsync<Schema extends ReturnType<typeof defineConfig>>
     }
 
     async function getFlag<K extends FlagKey>(key: K): Promise<ConfigType[K] | undefined> {
+        assertKeyDefined(key, 'featureFlag');
         const keyStr = key as unknown as string;
         const cached = flagValueCache.get(keyStr);
         if (cached !== undefined) return cached as ConfigType[K];


### PR DESCRIPTION
## Summary
- Server: `secretConfig.get()` / `publicConfig.get()` / `featureFlag.get()` + their `getSync` variants now throw a typed error when the key is `undefined` / `null` / non-string, instead of cascading into `envVarNameFor`'s `undefined.replace(...)` and surfacing as the cryptic `Cannot read properties of undefined (reading 'replace')`.
- Client: same guard for `publicConfig.get()` / `featureFlag.get()` + sync (mirrors `assertKeyDefined`).
- 9 new unit tests in `src/server/internal.assert-key.test.ts`.
- Changeset: minor bump.

## Why
Most common cause of an undefined key passing in is reading `SecretConfigKeys.<X>` (or `PublicConfigKeys.<X>` / `FeatureFlagKeys.<X>`) for a key that wasn't declared in the consumer's schema — the index lookup returns `undefined` and flows in here. The new error spells that out and points at `smooai-config push`.

Cost real prod debug time on SMOODEV-841 (Derek Dettman ICVR dashboard 500-d for hours) — the actual fix was one schema declaration in `.smooai-config/config.ts` but the stack pointed deep inside `@smooai/config`'s internals.

## Test plan
- [x] New test file passes (9 tests)
- [x] Local typecheck clean
- [ ] CI green
- [ ] After merge: bump `@smooai/config` in smooai monorepo + redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)