### PR TITLE
SMOODEV-848: Priority-chain integration tests across Python/Go/Rust/.NET

### DIFF
--- a/.changeset/smoodev-848-parity-tests.md
+++ b/.changeset/smoodev-848-parity-tests.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+Add priority-chain integration tests across Python, Go, Rust, and .NET so each language has parity coverage with TypeScript's `server.priority-chain.integration.test.ts`. Test-only — no source changes.

--- a/.changeset/smoodev-848-parity-tests.md
+++ b/.changeset/smoodev-848-parity-tests.md
@@ -3,3 +3,5 @@
 ---
 
 Add priority-chain integration tests across Python, Go, Rust, and .NET so each language has parity coverage with TypeScript's `server.priority-chain.integration.test.ts`. Test-only — no source changes.
+
+Documentation: per-SDK READMEs now cover the baked-runtime path (`SMOO_CONFIG_KEY_FILE` / `SMOO_CONFIG_KEY` env-var contract), have a Common errors section calling out the SMOODEV-847 schema-not-declared case, and the top-level README has a new Languages / SDKs section linking to each SDK's README. Added `dotnet/README.md` as the repo-level .NET entry point.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ---
 
+### Languages / SDKs
+
+Pick the SDK that matches your service. Every client reads the same schema, the same encrypted bundle, and the same config API — so a key renamed in one language ripples through all of them.
+
+| SDK            | One-liner                                                                                               | README                                           |
+| -------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **TypeScript** | Primary SDK. Schema definition, Next.js / Vite plugins, server runtime, React hooks.                    | [`README.md` (this file)](#about-smooaiconfig)   |
+| **Python**     | Pydantic-validated schemas, sync `ConfigClient`, `LocalConfigManager` + `ConfigManager`, baked runtime. | [`python/README.md`](python/README.md)           |
+| **Go**         | Native struct schemas, thread-safe `ConfigClient` / `ConfigManager`, baked-blob runtime.                | [`go/config/README.md`](go/config/README.md)     |
+| **Rust**       | `JsonSchema`-derived schemas, async `ConfigClient`, sync `ConfigManager`, baked-blob runtime.           | [`rust/config/README.md`](rust/config/README.md) |
+| **.NET**       | Roslyn source-generated typed keys, OAuth2 `SmooConfigClient`, AES-GCM `SmooConfigRuntime`.             | [`dotnet/README.md`](dotnet/README.md)           |
+
+---
+
 ### Install
 
 ```sh
@@ -494,9 +508,9 @@ client.invalidateCache();
 
 ## Multi-Language Support
 
-@smooai/config has native implementations in Python, Rust, and Go alongside the primary TypeScript package.
+@smooai/config has native implementations in Python, Rust, Go, and .NET (C#) alongside the primary TypeScript package. Every client reads the same encrypted bundle, the same schema, and the same config API. See the per-SDK READMEs linked above for full usage docs — the snippets below are five-line orientation only.
 
-### Python
+### Python — see [`python/README.md`](python/README.md)
 
 ```sh
 pip install smooai-config
@@ -504,41 +518,26 @@ pip install smooai-config
 ```
 
 ```python
-from pydantic import BaseModel
-from smooai_config import define_config
 from smooai_config.client import ConfigClient
 
-class PublicConfig(BaseModel):
-    api_url: str = "https://api.example.com"
-    max_retries: int = 3
-
-class SecretConfig(BaseModel):
-    database_url: str
-    api_key: str
-
-config = define_config(public=PublicConfig, secret=SecretConfig)
-
-with ConfigClient() as client:  # reads from env vars
+with ConfigClient() as client:  # reads SMOOAI_CONFIG_* env vars
     value = client.get_value("API_URL", environment="production")
-    all_values = client.get_all_values()
 ```
 
-### Rust
+### Rust — see [`rust/config/README.md`](rust/config/README.md)
 
-```toml
-[dependencies]
-smooai-config = { git = "https://github.com/SmooAI/config", package = "smooai-config" }
+```sh
+cargo add smooai-config
 ```
 
 ```rust
-use smooai_config::client::ConfigClient;
+use smooai_config::ConfigClient;
 
 let mut client = ConfigClient::from_env();
 let value = client.get_value("API_URL", None).await?;
-let all = client.get_all_values(Some("production")).await?;
 ```
 
-### Go
+### Go — see [`go/config/README.md`](go/config/README.md)
 
 ```sh
 go get github.com/SmooAI/config/go/config
@@ -549,9 +548,22 @@ import "github.com/SmooAI/config/go/config"
 
 client := config.NewConfigClientFromEnv()
 defer client.Close()
+value, _ := client.GetValue("API_URL", "production")
+```
 
-value, err := client.GetValue("API_URL", "production")
-allValues, err := client.GetAllValues("")
+### .NET — see [`dotnet/README.md`](dotnet/README.md)
+
+```sh
+dotnet add package SmooAI.Config
+```
+
+```csharp
+using SmooAI.Config;
+using SmooAI.Config.Runtime;
+
+var runtime = SmooConfigRuntime.Load();  // reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY
+using var client = new SmooConfigClient(options);
+var apiUrl = await Public.ApiUrl.ResolveAsync(runtime, client);
 ```
 
 ---

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,0 +1,87 @@
+# SmooAI.Config — .NET SDK
+
+[![NuGet](https://img.shields.io/nuget/v/SmooAI.Config.svg?style=for-the-badge)](https://www.nuget.org/packages/SmooAI.Config)
+[![License](https://img.shields.io/github/license/SmooAI/config?style=for-the-badge)](https://opensource.org/licenses/MIT)
+
+**Type-safe config, secrets, and feature flags for .NET — same schema, same encrypted bundle, same source of truth as the TypeScript, Python, Rust, and Go clients.**
+
+## Install
+
+```sh
+dotnet add package SmooAI.Config
+```
+
+## Five-line quickstart
+
+```csharp
+using SmooAI.Config;
+using SmooAI.Config.Generated;
+using SmooAI.Config.Runtime;
+
+var runtime = SmooConfigRuntime.Load();        // decrypts SMOO_CONFIG_KEY_FILE at cold start
+using var client = new SmooConfigClient(opts); // OAuth2 client for live values + flags
+var apiUrl = await Public.ApiUrl.ResolveAsync(runtime, client);
+```
+
+A Roslyn source generator turns the keys in `schema.json` into compile-checked properties (`Public.ApiUrl`, `Secrets.MoonshotApiKey`, `FeatureFlags.NewFlow`). Rename a key in the schema and every call site becomes a build error — exactly like every other SDK in this repo.
+
+## Read the full docs
+
+The canonical user-facing README is the one packed into the NuGet package:
+
+**→ [`src/SmooAI.Config/README.md`](src/SmooAI.Config/README.md)**
+
+It covers:
+
+- Quickstart with the source generator + typed keys
+- `SmooConfigRuntime` (AES-256-GCM blob, sync reads, no network)
+- `SmooConfigClient` (OAuth2, live values, feature flags)
+- `ConfigKey<T>.ResolveAsync` (runtime-first, HTTP fall-through)
+- Bake-the-bundle flow (`SmooConfigBuilder.BuildAsync` + `SchemaClassifier.FromSchemaFile`)
+- The `SMOO_CONFIG_KEY_FILE` / `SMOO_CONFIG_KEY` env-var contract
+- Wire compatibility with the TypeScript, Python, Rust, and Go runtimes
+- Common errors (typed-key not generated, AES-GCM decryption failed)
+
+The .NET package's NuGet `PackageReadmeFile` is wired to that file, so the docs you see on the package page are the authoritative source.
+
+## Repo layout
+
+| Path                                         | What                                                      |
+| -------------------------------------------- | --------------------------------------------------------- |
+| `src/SmooAI.Config/`                         | Main library (client, runtime, builder, models, OAuth).   |
+| `src/SmooAI.Config.SourceGenerator/`         | Roslyn analyzer that emits typed keys from `schema.json`. |
+| `tests/SmooAI.Config.Tests/`                 | xUnit tests (client, runtime, builder, priority chain).   |
+| `tests/SmooAI.Config.SourceGenerator.Tests/` | Source-generator snapshot + behaviour tests.              |
+| `SmooAI.Config.sln`                          | Solution file.                                            |
+
+## Develop
+
+```sh
+# Build everything
+dotnet build
+
+# Run the test suite
+dotnet test
+
+# Run only the priority-chain integration tests
+dotnet test --filter "FullyQualifiedName~PriorityChain"
+
+# Run only the source-generator tests
+dotnet test tests/SmooAI.Config.SourceGenerator.Tests
+```
+
+The package targets `net8.0`, `net9.0`, and `net10.0`. CI gates are wired through `.github/workflows/release.yml`.
+
+## All Language Packages
+
+| Language   | Package                                                          | Install                                     |
+| ---------- | ---------------------------------------------------------------- | ------------------------------------------- |
+| TypeScript | [`@smooai/config`](https://www.npmjs.com/package/@smooai/config) | `pnpm add @smooai/config`                   |
+| Python     | [`smooai-config`](https://pypi.org/project/smooai-config/)       | `pip install smooai-config`                 |
+| Rust       | [`smooai-config`](https://crates.io/crates/smooai-config)        | `cargo add smooai-config`                   |
+| Go         | `github.com/SmooAI/config/go/config`                             | `go get github.com/SmooAI/config/go/config` |
+| **.NET**   | [`SmooAI.Config`](https://www.nuget.org/packages/SmooAI.Config)  | `dotnet add package SmooAI.Config`          |
+
+## License
+
+MIT © SmooAI

--- a/dotnet/src/SmooAI.Config/README.md
+++ b/dotnet/src/SmooAI.Config/README.md
@@ -158,6 +158,21 @@ as every other SmooAI.Config language client:
 
 You can bake the bundle in any language and decrypt it in any other.
 
+## Common errors
+
+### `Public.X` / `Secrets.X` / `FeatureFlags.X` won't compile
+
+The Roslyn source generator only emits typed key properties for keys declared in the `schema.json` file marked `SmooConfigSchema="true"` in your csproj. If a key compiles in TypeScript but doesn't appear here, the schema your .NET project sees is stale. Either:
+
+1. Re-run your generator step (`smooai-config push` or equivalent) so `schema.json` picks up the new key, then rebuild — or
+2. Add the key to your config schema in the source repo and regenerate.
+
+A `dotnet build` after pulling latest is enough to refresh the generated keys.
+
+### `SmooConfigRuntimeException: AES-GCM decryption failed`
+
+The blob and key don't match. Check that `SMOO_CONFIG_KEY_FILE` points at the bundle baked with the key in `SMOO_CONFIG_KEY` — mismatched key/blob pairs surface as a tag-verification failure, which is what GCM is supposed to do. Re-bake the bundle and re-set both env vars together.
+
 ## Links
 
 - **Homepage**: [smoo.ai](https://smoo.ai)

--- a/dotnet/tests/SmooAI.Config.Tests/PriorityChainIntegrationTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/PriorityChainIntegrationTests.cs
@@ -1,0 +1,282 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using SmooAI.Config.Build;
+using SmooAI.Config.OAuth;
+using SmooAI.Config.Runtime;
+
+namespace SmooAI.Config.Tests;
+
+/// <summary>
+/// Integration tests for the .NET config priority chain.
+/// Parity with TypeScript <c>src/server/server.priority-chain.integration.test.ts</c>,
+/// adapted to the .NET architecture, which (per design) keeps the blob path
+/// and the HTTP path independent — there is no <c>ConfigManager</c> that
+/// merges <c>blob → env → HTTP → file</c>. The two paths must be exercised
+/// separately:
+/// <list type="bullet">
+///   <item><see cref="SmooConfigRuntime"/> — decrypts a baked AES-256-GCM blob and serves public/secret synchronously, no network.</item>
+///   <item><see cref="SmooConfigClient"/> — talks to the HTTP API for live values and feature flags.</item>
+/// </list>
+/// Coverage:
+/// <list type="bullet">
+///   <item>Blob: secret-over-public lookup precedence on collision.</item>
+///   <item>Blob: missing key → null (no crash).</item>
+///   <item>Blob: process bypasses HTTP entirely (no client construction needed).</item>
+///   <item>HTTP: GetValue / GetAllValues round-trip with auth + env query.</item>
+///   <item>HTTP: 5xx surfaces as <see cref="SmooConfigApiException"/> (no silent fall-through).</item>
+///   <item>HTTP: explicit-environment override wins over default.</item>
+/// </list>
+/// </summary>
+public class PriorityChainIntegrationTests : IDisposable
+{
+    private const string TestOrgId = "550e8400-e29b-41d4-a716-446655440000";
+    private const string TestEnv = "production";
+
+    public PriorityChainIntegrationTests() => SmooConfigRuntime.ResetForTests();
+    public void Dispose() => SmooConfigRuntime.ResetForTests();
+
+    // -----------------------------------------------------------------------
+    // Blob path — SmooConfigRuntime resolves public + secret offline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Blob_PublicValueResolvesOffline()
+    {
+        var (path, keyB64) = WriteBlob(
+            """{"public":{"apiUrl":"https://api.from-blob.example"},"secret":{"sendgridApiKey":"SG.from-blob"}}""");
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.Equal("https://api.from-blob.example", runtime.GetPublic("apiUrl")!.Value.GetString());
+            Assert.Equal("SG.from-blob", runtime.GetSecret("sendgridApiKey")!.Value.GetString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Blob_SecretWinsOverPublicOnKeyCollision()
+    {
+        // Both partitions ship the same key — GetValue prefers the secret
+        // tier, matching the TS/Python/Rust/Go merge order.
+        var (path, keyB64) = WriteBlob(
+            """{"public":{"apiKey":"public-value"},"secret":{"apiKey":"secret-value"}}""");
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.Equal("secret-value", runtime.GetValue("apiKey")!.Value.GetString());
+            // Direct accessors return their own partition's value.
+            Assert.Equal("public-value", runtime.GetPublic("apiKey")!.Value.GetString());
+            Assert.Equal("secret-value", runtime.GetSecret("apiKey")!.Value.GetString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Blob_MissingKeyReturnsNull()
+    {
+        var (path, keyB64) = WriteBlob("""{"public":{"apiUrl":"only-this"},"secret":{}}""");
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.Null(runtime.GetValue("missing"));
+            Assert.Null(runtime.GetPublic("missing"));
+            Assert.Null(runtime.GetSecret("missing"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Blob_PathDoesNotRequireHttpClient()
+    {
+        // The .NET architecture intentionally keeps SmooConfigRuntime
+        // independent of SmooConfigClient — the blob path must never try to
+        // reach the HTTP layer. This test pins that boundary by constructing
+        // and reading from a runtime without ever instantiating a client.
+        var (path, keyB64) = WriteBlob("""{"public":{"apiUrl":"https://api.example"},"secret":{}}""");
+
+        try
+        {
+            var runtime = SmooConfigRuntime.LoadFrom(path, keyB64);
+            Assert.NotNull(runtime);
+            Assert.Equal("https://api.example", runtime.GetPublic("apiUrl")!.Value.GetString());
+            // Sanity: no HttpClient field exists on the runtime; this assertion is
+            // just here to make the architectural intent self-documenting in tests.
+            var fields = runtime.GetType().GetFields(
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+            Assert.DoesNotContain(fields, f => f.FieldType == typeof(HttpClient));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP path — SmooConfigClient talks to the live API
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Http_GetValueAsyncReturnsValueWithEnvironmentParam()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"https://api.from-http.example"}""");
+
+            var result = await client.GetValueAsync("apiUrl");
+            Assert.Equal(JsonValueKind.String, result.ValueKind);
+            Assert.Equal("https://api.from-http.example", result.GetString());
+
+            // Token + GET = 2 requests; second carries the env query + Bearer header.
+            Assert.Equal(2, handler.Requests.Count);
+            var get = handler.Requests[1];
+            Assert.EndsWith($"/organizations/{TestOrgId}/config/values/apiUrl?environment={TestEnv}", get.RequestUri!.AbsolutePath + get.RequestUri.Query);
+            Assert.Equal("tok-1", get.Headers.Authorization!.Parameter);
+        }
+        finally
+        {
+            client.Dispose();
+            http.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Http_GetAllValuesAsyncReturnsValuesMap()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"apiUrl":"https://api.example","retries":3}}""");
+
+            var all = await client.GetAllValuesAsync();
+            Assert.Equal(2, all.Count);
+            Assert.Equal("https://api.example", all["apiUrl"].GetString());
+            Assert.Equal(3, all["retries"].GetInt32());
+        }
+        finally
+        {
+            client.Dispose();
+            http.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Http_5xxThrowsSmooConfigApiException()
+    {
+        // Unlike the merge-pipeline languages, .NET surfaces HTTP failures
+        // directly — there is no fall-through tier to consult. Pin that
+        // contract so callers can rely on it for retry/circuit-breaker logic.
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.InternalServerError, "boom");
+
+            var ex = await Assert.ThrowsAsync<SmooConfigApiException>(() => client.GetValueAsync("apiUrl"));
+            Assert.Equal(500, ex.StatusCode);
+            Assert.Contains("HTTP 500", ex.Message);
+        }
+        finally
+        {
+            client.Dispose();
+            http.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Http_ExplicitEnvironmentOverridesDefault()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"staging-value"}""");
+
+            await client.GetValueAsync("apiUrl", environment: "staging");
+
+            Assert.EndsWith("?environment=staging", handler.Requests[1].RequestUri!.ToString());
+        }
+        finally
+        {
+            client.Dispose();
+            http.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Http_TokenInvalidationForcesReExchange()
+    {
+        // Caching parity with the TS chain — InvalidateToken drops the cached
+        // OAuth credential so the next request triggers a new exchange. This
+        // is the .NET analogue of `cfg.invalidateCaches()` on the TS side.
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            // First read uses the seeded token-1.
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"v1"}""");
+            var v1 = await client.GetValueAsync("apiUrl");
+            Assert.Equal("v1", v1.GetString());
+            Assert.Equal("tok-1", handler.Requests[1].Headers.Authorization!.Parameter);
+
+            // Drop token; next call must re-exchange.
+            client.InvalidateToken();
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-2","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"v2"}""");
+
+            var v2 = await client.GetValueAsync("apiUrl");
+            Assert.Equal("v2", v2.GetString());
+            // Last request carried the new token.
+            Assert.Equal("tok-2", handler.Requests[^1].Headers.Authorization!.Parameter);
+        }
+        finally
+        {
+            client.Dispose();
+            http.Dispose();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static (string path, string keyB64) WriteBlob(string json)
+    {
+        var (bundle, keyB64) = SmooConfigBuilder.Encrypt(Encoding.UTF8.GetBytes(json));
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".enc");
+        File.WriteAllBytes(path, bundle);
+        return (path, keyB64);
+    }
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler, HttpClient http) CreateClient()
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        // Default: seed an OAuth token exchange for the first request.
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+
+        var options = new SmooConfigClientOptions
+        {
+            ClientId = "cid",
+            ClientSecret = "csec",
+            OrgId = TestOrgId,
+            BaseUrl = "https://api.smoo.ai",
+            AuthUrl = "https://auth.smoo.ai",
+            DefaultEnvironment = TestEnv,
+        };
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+        return (client, handler, http);
+    }
+}

--- a/go/config/README.md
+++ b/go/config/README.md
@@ -57,6 +57,7 @@ go get github.com/SmooAI/config/go/config
 | Python     | [`smooai-config`](https://pypi.org/project/smooai-config/)       | `pip install smooai-config`                 |
 | Rust       | [`smooai-config`](https://crates.io/crates/smooai-config)        | `cargo add smooai-config`                   |
 | Go         | `github.com/SmooAI/config/go/config`                             | `go get github.com/SmooAI/config/go/config` |
+| .NET       | [`SmooAI.Config`](https://www.nuget.org/packages/SmooAI.Config)  | `dotnet add package SmooAI.Config`          |
 
 ## Usage
 
@@ -226,6 +227,59 @@ value, err := manager.GetPublicConfig("API_URL")
 derived, err := manager.GetPublicConfig("DERIVED_URL")
 ```
 
+### Baked Runtime — zero-network cold starts
+
+For Lambda / ECS / long-lived services, bake every public + secret value into an AES-256-GCM blob at deploy time and decrypt it at cold start. `NewRuntimeConfigManager` decrypts the blob and installs the values as the manager's "remote" tier — public/secret reads then resolve from in-memory cache with no HTTP round-trip. Env vars still win on top, file config still layers underneath. Feature flags are skipped (the baker drops them) so they stay live-fetched.
+
+```go
+import "github.com/SmooAI/config/go/config"
+
+// At process boot. Reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY, decrypts
+// the blob, and uses it as the "remote" tier of the manager.
+mgr, err := config.NewRuntimeConfigManager(config.RuntimeOptions{
+    Environment: "production",
+})
+if err != nil { log.Fatal(err) }
+
+// Public + secret values come from the in-memory cache (no network).
+apiURL, _ := mgr.GetPublicConfig("apiUrl")
+sendgrid, _ := mgr.GetSecretConfig("sendgridApiKey")
+```
+
+Bake the bundle at deploy time:
+
+```go
+import "github.com/SmooAI/config/go/config"
+
+result, err := config.BuildBundle(context.Background(), config.BuildBundleOptions{
+    BaseURL:     "https://config.smooai.dev",
+    APIKey:      "your-api-key",
+    OrgID:       "your-org-id",
+    Environment: "production",
+    Classify: config.ClassifyFromSchema(
+        map[string]bool{"apiUrl": true},          // public
+        map[string]bool{"sendgridApiKey": true},  // secret
+        map[string]bool{"newFlow": true},         // feature flag — skipped
+    ),
+})
+if err != nil { log.Fatal(err) }
+
+os.WriteFile("smoo-config.enc", result.Blob, 0o600)
+fmt.Printf("SMOO_CONFIG_KEY_FILE=/abs/path/to/smoo-config.enc\n")
+fmt.Printf("SMOO_CONFIG_KEY=%s\n", result.KeyB64)
+```
+
+#### Blob env vars
+
+| Variable               | Value                                      |
+| ---------------------- | ------------------------------------------ |
+| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
+| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+
+Without both set, `NewRuntimeConfigManager` returns a regular `*ConfigManager` configured from the same `RuntimeOptions`, so dev machines without a baked blob still work.
+
+The blob format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` — wire-identical to the TypeScript, Python, Rust, and .NET runtimes. A blob baked in any language decrypts in any other.
+
 ## Environment Variables
 
 All clients read from the same set of environment variables:
@@ -253,6 +307,12 @@ export SMOOAI_CONFIG_ENV="production"
 | **Public**        | Client-visible settings | API URLs, feature toggles, UI config     |
 | **Secret**        | Server-side only        | Database URLs, API keys, JWT secrets     |
 | **Feature Flags** | Runtime toggles         | A/B tests, gradual rollouts, beta access |
+
+## Common errors
+
+### `GetValue` / `GetPublicConfig` returning empty string for a known key
+
+If you read `PublicConfigKeys.X` (or `SecretConfigKeys.X` / `FeatureFlagKeys.X`) for a key that wasn't declared in the schema your service was built against, the constant resolves to its zero value (empty string) and the manager returns `nil` from the merged map. The common cause is a schema rebase mismatch — the consumer was built against an older `schema.json` than what's in your config repo. Re-run the schema generator to pick up the new keys, or add the missing key to your schema.
 
 ## Built With
 
@@ -287,6 +347,7 @@ gofmt -w .
 - [@smooai/config](https://www.npmjs.com/package/@smooai/config) - TypeScript/JavaScript version
 - [smooai-config (Python)](https://pypi.org/project/smooai-config/) - Python version
 - [smooai-config (Rust)](https://crates.io/crates/smooai-config) - Rust version
+- [SmooAI.Config (NuGet)](https://www.nuget.org/packages/SmooAI.Config) - .NET version
 - [SmooAI/config](https://github.com/SmooAI/config) - GitHub repository
 
 <!-- CONTACT -->

--- a/go/config/priority_chain_integration_test.go
+++ b/go/config/priority_chain_integration_test.go
@@ -1,0 +1,409 @@
+package config
+
+// Integration tests for the Go config priority chain.
+//
+// Parity with TypeScript src/server/server.priority-chain.integration.test.ts,
+// adapted to the Go architecture. Unlike the TS path (which merges
+// blob → env → HTTP → file in one pipeline), the Go SDK splits the blob
+// tier into a separate hydrator: NewRuntimeConfigManager decrypts the blob
+// and installs it as the manager's "remote" tier in place of a live HTTP
+// fetch. NewConfigManager (no blob) follows the 3-tier merge file < HTTP < env.
+//
+// Coverage:
+//   - Each tier wins when higher tiers are absent (precedence)
+//   - Tier missing entirely → nil (no crash)
+//   - HTTP errors fall through to lower tiers (fault tolerance)
+//   - Caching: repeated reads memoize; Invalidate() drops them
+//   - Blob hydration: real AES-256-GCM blob is consumed by the manager
+//     as the "remote" tier; env vars still win on top, file still
+//     layers underneath.
+//   - When a blob is present, no HTTP fetch happens for public/secret reads.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Constants — match the TS reference
+// ---------------------------------------------------------------------------
+
+const (
+	pcAPIKey = "test-api-key-priority-chain"
+	pcOrgID  = "550e8400-e29b-41d4-a716-446655440000"
+	pcEnv    = "production"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// pcMakeConfigDir writes a `.smooai-config/` dir with a single default.json.
+func pcMakeConfigDir(t *testing.T, defaults map[string]any) string {
+	t.Helper()
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".smooai-config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	b, err := json.Marshal(defaults)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "default.json"), b, 0o644))
+	return configDir
+}
+
+// pcHTTPServer mocks the Smoo AI config API. handlerFn is called for every
+// request so tests can mutate the response between calls.
+func pcHTTPServer(t *testing.T, statusCode int, valuesByEnv map[string]map[string]any, hits *atomic.Int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			hits.Add(1)
+		}
+		// Auth check.
+		if r.Header.Get("Authorization") != "Bearer "+pcAPIKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
+			return
+		}
+		if statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "boom"})
+			return
+		}
+		envName := r.URL.Query().Get("environment")
+		if envName == "" {
+			envName = "development"
+		}
+		envValues := valuesByEnv[envName]
+		if envValues == nil {
+			envValues = map[string]any{}
+		}
+		path := r.URL.Path
+		base := "/organizations/" + pcOrgID + "/config/values"
+		if strings.HasPrefix(path, base+"/") {
+			key := strings.TrimPrefix(path, base+"/")
+			val, ok := envValues[key]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Not found"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": val})
+			return
+		}
+		if path == base {
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": envValues})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// pcEncryptBlob writes a real AES-256-GCM blob using the same envelope as
+// BuildBundle (nonce || ciphertext || tag).
+func pcEncryptBlob(t *testing.T, dir string, payload partitionedBundle) (string, string) {
+	t.Helper()
+	plaintext, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	key := make([]byte, 32)
+	_, err = io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+	nonce := make([]byte, 12)
+	_, err = io.ReadFull(rand.Reader, nonce)
+	require.NoError(t, err)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	blob := gcm.Seal(append([]byte(nil), nonce...), nonce, plaintext, nil)
+
+	path := filepath.Join(dir, "smoo-config.enc")
+	require.NoError(t, os.WriteFile(path, blob, 0o600))
+	return path, base64.StdEncoding.EncodeToString(key)
+}
+
+// ---------------------------------------------------------------------------
+// 3-tier merge: env > HTTP > file
+// ---------------------------------------------------------------------------
+
+func TestPriorityChain_EnvWinsOverHTTPAndFile(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{"API_URL": "https://api.from-file.example"})
+	srv := pcHTTPServer(t, http.StatusOK, map[string]map[string]any{
+		pcEnv: {"API_URL": "https://api.from-http.example"},
+	}, nil)
+
+	mgr := NewConfigManager(
+		WithAPIKey(pcAPIKey),
+		WithBaseURL(srv.URL),
+		WithOrgID(pcOrgID),
+		WithConfigEnvironment(pcEnv),
+		WithCMSchemaKeys(map[string]bool{"API_URL": true}),
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+			"API_URL":               "https://api.from-env.example",
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-env.example", v)
+}
+
+func TestPriorityChain_HTTPWinsOverFileWhenEnvAbsent(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{"API_URL": "https://api.from-file.example"})
+	srv := pcHTTPServer(t, http.StatusOK, map[string]map[string]any{
+		pcEnv: {"API_URL": "https://api.from-http.example"},
+	}, nil)
+
+	mgr := NewConfigManager(
+		WithAPIKey(pcAPIKey),
+		WithBaseURL(srv.URL),
+		WithOrgID(pcOrgID),
+		WithConfigEnvironment(pcEnv),
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-http.example", v)
+}
+
+func TestPriorityChain_FileWinsWhenHTTPAndEnvAbsent(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{"API_URL": "https://api.from-file.example"})
+
+	mgr := NewConfigManager(
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-file.example", v)
+}
+
+func TestPriorityChain_ReturnsNilWhenNoTierHasKey(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{})
+
+	mgr := NewConfigManager(
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+		}),
+	)
+
+	for _, tt := range []struct {
+		name string
+		fn   func(string) (any, error)
+	}{
+		{"public", mgr.GetPublicConfig},
+		{"secret", mgr.GetSecretConfig},
+		{"flag", mgr.GetFeatureFlag},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := tt.fn("MISSING_KEY")
+			require.NoError(t, err)
+			assert.Nil(t, v)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP fault tolerance
+// ---------------------------------------------------------------------------
+
+func TestPriorityChain_HTTP5xxFallsThroughToEnv(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{})
+	srv := pcHTTPServer(t, http.StatusInternalServerError, nil, nil)
+
+	mgr := NewConfigManager(
+		WithAPIKey(pcAPIKey),
+		WithBaseURL(srv.URL),
+		WithOrgID(pcOrgID),
+		WithConfigEnvironment(pcEnv),
+		WithCMSchemaKeys(map[string]bool{"API_URL": true}),
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+			"API_URL":               "https://api.from-env.example",
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-env.example", v)
+}
+
+func TestPriorityChain_HTTP5xxFallsThroughToFile(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{"API_URL": "https://api.from-file.example"})
+	srv := pcHTTPServer(t, http.StatusServiceUnavailable, nil, nil)
+
+	mgr := NewConfigManager(
+		WithAPIKey(pcAPIKey),
+		WithBaseURL(srv.URL),
+		WithOrgID(pcOrgID),
+		WithConfigEnvironment(pcEnv),
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-file.example", v)
+}
+
+// ---------------------------------------------------------------------------
+// Caching + invalidation
+// ---------------------------------------------------------------------------
+
+func TestPriorityChain_RepeatedReadsMemoizeUntilInvalidate(t *testing.T) {
+	configDir := pcMakeConfigDir(t, map[string]any{})
+	var hits atomic.Int64
+	srv := pcHTTPServer(t, http.StatusOK, map[string]map[string]any{
+		pcEnv: {"API_URL": "https://api.cached.example"},
+	}, &hits)
+
+	mgr := NewConfigManager(
+		WithAPIKey(pcAPIKey),
+		WithBaseURL(srv.URL),
+		WithOrgID(pcOrgID),
+		WithConfigEnvironment(pcEnv),
+		WithCMEnvOverride(map[string]string{
+			"SMOOAI_ENV_CONFIG_DIR": configDir,
+			"SMOOAI_CONFIG_ENV":     pcEnv,
+		}),
+	)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.cached.example", v)
+	first := hits.Load()
+	require.GreaterOrEqual(t, first, int64(1))
+
+	// Second read should be cached — no new HTTP.
+	v, err = mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.cached.example", v)
+	assert.Equal(t, first, hits.Load(), "cached read must not hit HTTP")
+
+	// Invalidate forces re-init → HTTP again.
+	mgr.Invalidate()
+	v, err = mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.cached.example", v)
+	assert.Greater(t, hits.Load(), first, "invalidate must trigger a refetch")
+}
+
+// ---------------------------------------------------------------------------
+// Blob hydration (NewRuntimeConfigManager) — separate path from live HTTP
+// ---------------------------------------------------------------------------
+
+func TestPriorityChain_BlobHydrationResolvesOffline(t *testing.T) {
+	dir := t.TempDir()
+	path, keyB64 := pcEncryptBlob(t, dir, partitionedBundle{
+		Public: map[string]any{"apiUrl": "https://api.from-blob.example"},
+		Secret: map[string]any{"sendgridApiKey": "SG.from-blob"},
+	})
+
+	// No BaseURL/APIKey/OrgID set — confirms we never attempt a network call.
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+		EnvOverride: map[string]string{
+			"SMOOAI_CONFIG_ENV": pcEnv,
+		},
+	})
+	require.NoError(t, err)
+
+	pub, err := mgr.GetPublicConfig("apiUrl")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-blob.example", pub)
+
+	sec, err := mgr.GetSecretConfig("sendgridApiKey")
+	require.NoError(t, err)
+	assert.Equal(t, "SG.from-blob", sec)
+}
+
+func TestPriorityChain_EnvOverridesBlob(t *testing.T) {
+	// Even with a baked blob, an env var wins — matches TS env-over-remote.
+	dir := t.TempDir()
+	path, keyB64 := pcEncryptBlob(t, dir, partitionedBundle{
+		Public: map[string]any{"API_URL": "https://api.from-blob.example"},
+		Secret: map[string]any{},
+	})
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+		EnvOverride: map[string]string{
+			"API_URL": "https://api.from-env.example",
+		},
+		Extra: []ConfigManagerOption{
+			WithCMSchemaKeys(map[string]bool{"API_URL": true}),
+		},
+	})
+	require.NoError(t, err)
+
+	v, err := mgr.GetPublicConfig("API_URL")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-env.example", v)
+}
+
+func TestPriorityChain_BlobBypassesHTTP(t *testing.T) {
+	// Confirms the architectural split: when a blob is present, no HTTP
+	// call happens for public/secret reads. Wire up an HTTP server that
+	// would fail the test on any hit, then drive the manager.
+	dir := t.TempDir()
+	path, keyB64 := pcEncryptBlob(t, dir, partitionedBundle{
+		Public: map[string]any{"apiUrl": "https://api.from-blob.example"},
+		Secret: map[string]any{},
+	})
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	mgr, err := NewRuntimeConfigManager(RuntimeOptions{
+		KeyFile: path,
+		KeyB64:  keyB64,
+		// Provide HTTP creds so the manager *would* fetch if the blob were
+		// not consulted. The test asserts no HTTP hit.
+		APIKey:      pcAPIKey,
+		BaseURL:     srv.URL,
+		OrgID:       pcOrgID,
+		Environment: pcEnv,
+	})
+	require.NoError(t, err)
+
+	v, err := mgr.GetPublicConfig("apiUrl")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.from-blob.example", v)
+	assert.Equal(t, int64(0), hits.Load(), "blob path must not hit HTTP for public reads")
+}

--- a/python/README.md
+++ b/python/README.md
@@ -67,6 +67,7 @@ uv add smooai-config
 | Python     | [`smooai-config`](https://pypi.org/project/smooai-config/)       | `pip install smooai-config`                 |
 | Rust       | [`smooai-config`](https://crates.io/crates/smooai-config)        | `cargo add smooai-config`                   |
 | Go         | `github.com/SmooAI/config/go/config`                             | `go get github.com/SmooAI/config/go/config` |
+| .NET       | [`SmooAI.Config`](https://www.nuget.org/packages/SmooAI.Config)  | `dotnet add package SmooAI.Config`          |
 
 ## Usage
 
@@ -194,6 +195,64 @@ manager = ConfigManager(
 value = manager.get_public_config("API_URL")
 ```
 
+### Baked Runtime — zero-network cold starts
+
+For Lambda / ECS / long-lived services, bake every public + secret value into an AES-256-GCM blob at deploy time and decrypt it at cold start. Reads then resolve from in-memory cache with no HTTP round-trip. Feature flags are intentionally skipped — they stay live-fetched so you can toggle without a redeploy.
+
+The runtime is a thin hydrator on top of `ConfigClient`: it decrypts the blob and pre-seeds the client cache. Subsequent `client.get_value(key)` calls resolve sync from cache.
+
+```python
+from smooai_config.runtime import build_config_runtime
+
+# At process boot (cold start). Reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY,
+# decrypts the blob, and seeds an internal ConfigClient cache.
+client = build_config_runtime()
+
+# Public + secret values come from the in-memory cache (no network).
+api_url = client.get_value("apiUrl")
+sendgrid = client.get_value("sendgridApiKey")
+
+# Feature flags are not baked — these still hit the API.
+new_flow = client.get_value("newFlow")
+```
+
+Bake the bundle at deploy time:
+
+```python
+from smooai_config.build import build_bundle, classify_from_schema
+
+result = build_bundle(
+    base_url="https://config.smooai.dev",
+    api_key="your-api-key",
+    org_id="your-org-id",
+    environment="production",
+    classify=classify_from_schema(
+        public_keys={"apiUrl"},
+        secret_keys={"sendgridApiKey"},
+        feature_flag_keys={"newFlow"},  # skipped (stays live)
+    ),
+)
+
+# Write the blob next to your deploy artifact and set both env vars on the
+# function. The blob layout is wire-compatible with every other SDK.
+with open("smoo-config.enc", "wb") as fh:
+    fh.write(result.bundle)
+
+print(f"SMOO_CONFIG_KEY_FILE=/abs/path/to/smoo-config.enc")
+print(f"SMOO_CONFIG_KEY={result.key_b64}")
+```
+
+#### Blob env vars
+
+| Variable               | Value                                      |
+| ---------------------- | ------------------------------------------ |
+| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
+| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+
+Without both set, `build_config_runtime()` falls back to a plain `ConfigClient` so dev machines without a baked blob still work — the API stays uniform either way.
+
+The blob format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` — wire-identical to the TypeScript, Rust, Go, and .NET runtimes. A blob baked in any language decrypts in any other.
+
 ## Environment Variables
 
 All clients read from the same set of environment variables:
@@ -222,6 +281,12 @@ export SMOOAI_CONFIG_ENV="production"
 | **Secret**        | Server-side only        | Database URLs, API keys, JWT secrets     |
 | **Feature Flags** | Runtime toggles         | A/B tests, gradual rollouts, beta access |
 
+## Common errors
+
+### `Cannot read properties of undefined` / passing `None` to `get_value`
+
+If you read `SecretConfigKeys.X` (or `PublicConfigKeys.X` / `FeatureFlagKeys.X`) for a key that wasn't declared in the schema your service was built against, the constant resolves to `None` / `undefined` and you'll see a typed error pointing at the missing key. The common cause is a schema rebase mismatch — the consumer was built against an older `schema.json` than the one declared in your config repo. Re-run `smooai-config push` (or the equivalent generator step) to pick up the new keys, or add the missing key to your schema.
+
 ## Built With
 
 - Python 3.13+ - Full type hints and Pydantic v2 support
@@ -235,6 +300,8 @@ export SMOOAI_CONFIG_ENV="production"
 - [@smooai/config](https://www.npmjs.com/package/@smooai/config) - TypeScript/JavaScript version
 - [smooai-config (Python)](https://pypi.org/project/smooai-config/) - This package
 - [smooai-config (Rust)](https://crates.io/crates/smooai-config) - Rust version
+- `github.com/SmooAI/config/go/config` - Go version
+- [SmooAI.Config (NuGet)](https://www.nuget.org/packages/SmooAI.Config) - .NET version
 - [SmooAI/config](https://github.com/SmooAI/config) - GitHub repository
 
 ## Development

--- a/python/tests/test_priority_chain_integration.py
+++ b/python/tests/test_priority_chain_integration.py
@@ -1,0 +1,362 @@
+"""Integration tests for the Python config priority chain.
+
+Parity with TypeScript ``src/server/server.priority-chain.integration.test.ts``,
+adapted to the Python architecture, which splits the blob tier out of
+``ConfigManager`` into a separate hydrator (``runtime.py``):
+
+  ConfigManager merge:   file < remote (HTTP) < env
+  Runtime hydrator:      decrypt baked AES-256-GCM blob → seed ConfigClient cache
+
+These integration tests exercise:
+
+  - precedence (each tier wins when higher tiers absent)
+  - tier-missing → ``None`` (no crash)
+  - HTTP errors (5xx) fall through to lower tiers without losing them
+  - caching: repeated reads memoize, ``invalidate()`` drops them
+  - blob-tier hydration: real AES-256-GCM blob seeded into ``ConfigClient``
+    resolves keys offline (no network)
+  - blob does not silently leak into ``ConfigManager``'s 3-tier path
+    (architecture intent — the blob hydrator is a separate code path)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from smooai_config.client import ConfigClient
+from smooai_config.config_manager import ConfigManager
+from smooai_config.file_config import _clear_config_dir_cache
+from smooai_config.runtime import (
+    _reset_runtime_caches_for_tests,
+    hydrate_config_client,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TEST_BASE_URL = "https://config.smooai.test"
+TEST_API_KEY = "test-api-key-priority-chain"
+TEST_ORG_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    _clear_config_dir_cache()
+    _reset_runtime_caches_for_tests()
+
+
+def _make_config_dir(tmp_path: Path, default: dict[str, object]) -> str:
+    """Create a ``.smooai-config/`` dir with a single ``default.json``."""
+    config_dir = tmp_path / ".smooai-config"
+    config_dir.mkdir()
+    (config_dir / "default.json").write_text(json.dumps(default))
+    return str(config_dir)
+
+
+# ---------------------------------------------------------------------------
+# HTTP tier — mock transport modeled after Smoo AI config API
+# ---------------------------------------------------------------------------
+
+
+def _make_http_transport(
+    *,
+    values: dict[str, dict[str, object]],
+    status_code: int = 200,
+    require_auth: bool = True,
+) -> httpx.MockTransport:
+    """Mock the config API. ``values`` is keyed by environment name."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if status_code != 200:
+            return httpx.Response(status_code, json={"error": "boom"})
+
+        if require_auth and request.headers.get("authorization") != f"Bearer {TEST_API_KEY}":
+            return httpx.Response(401, json={"error": "Unauthorized"})
+
+        env_name = dict(request.url.params).get("environment", "development")
+        env_values = values.get(env_name, {})
+
+        url_path = request.url.path
+        prefix = f"/organizations/{TEST_ORG_ID}/config/values/"
+        base = f"/organizations/{TEST_ORG_ID}/config/values"
+
+        if url_path.startswith(prefix) and url_path != base:
+            key = url_path[len(prefix) :]
+            if key not in env_values:
+                return httpx.Response(404, json={"error": "Not found"})
+            return httpx.Response(200, json={"value": env_values[key]})
+
+        if url_path == base:
+            return httpx.Response(200, json={"values": env_values})
+
+        return httpx.Response(404, json={"error": "Not found"})
+
+    return httpx.MockTransport(handler)
+
+
+def _patch_client_transport(transport: httpx.MockTransport):
+    """Force every ``httpx.Client`` instantiated under us to use ``transport``."""
+    original_init = httpx.Client.__init__
+
+    def patched_init(self: httpx.Client, **kwargs: object) -> None:
+        kwargs["transport"] = transport  # type: ignore[assignment]
+        original_init(self, **kwargs)
+
+    return patch.object(httpx.Client, "__init__", patched_init)
+
+
+# ---------------------------------------------------------------------------
+# Blob tier — encrypt fixture exactly like the SST baker
+# ---------------------------------------------------------------------------
+
+
+def _encrypt_blob(tmp_path: Path, payload: dict[str, dict[str, object]]) -> tuple[str, str]:
+    """Write a real AES-256-GCM blob; return ``(key_b64, blob_path)``."""
+    plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    key_bytes = os.urandom(32)
+    nonce = os.urandom(12)
+    ct_tag = AESGCM(key_bytes).encrypt(nonce, plaintext, associated_data=None)
+    blob_path = tmp_path / "smoo-config.enc"
+    blob_path.write_bytes(nonce + ct_tag)
+    return base64.b64encode(key_bytes).decode("ascii"), str(blob_path)
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager — 3-tier (env > HTTP > file) precedence
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerPriority:
+    """env > HTTP > file precedence in ``ConfigManager._initialize``."""
+
+    def test_env_wins_over_http_and_file(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "https://api.from-file.example"})
+        transport = _make_http_transport(
+            values={"production": {"API_URL": "https://api.from-http.example"}},
+        )
+
+        with _patch_client_transport(transport):
+            mgr = ConfigManager(
+                api_key=TEST_API_KEY,
+                base_url=TEST_BASE_URL,
+                org_id=TEST_ORG_ID,
+                environment="production",
+                schema_keys={"API_URL"},
+                env={
+                    "SMOOAI_ENV_CONFIG_DIR": config_dir,
+                    "SMOOAI_CONFIG_ENV": "production",
+                    "API_URL": "https://api.from-env.example",
+                },
+            )
+            assert mgr.get_public_config("API_URL") == "https://api.from-env.example"
+
+    def test_http_wins_over_file_when_env_absent(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "https://api.from-file.example"})
+        transport = _make_http_transport(
+            values={"production": {"API_URL": "https://api.from-http.example"}},
+        )
+
+        with _patch_client_transport(transport):
+            mgr = ConfigManager(
+                api_key=TEST_API_KEY,
+                base_url=TEST_BASE_URL,
+                org_id=TEST_ORG_ID,
+                environment="production",
+                env={"SMOOAI_ENV_CONFIG_DIR": config_dir, "SMOOAI_CONFIG_ENV": "production"},
+            )
+            assert mgr.get_public_config("API_URL") == "https://api.from-http.example"
+
+    def test_file_wins_when_http_and_env_absent(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "https://api.from-file.example"})
+
+        mgr = ConfigManager(
+            env={"SMOOAI_ENV_CONFIG_DIR": config_dir, "SMOOAI_CONFIG_ENV": "production"},
+        )
+        assert mgr.get_public_config("API_URL") == "https://api.from-file.example"
+
+    def test_returns_none_when_no_tier_has_key(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {})
+
+        mgr = ConfigManager(
+            env={"SMOOAI_ENV_CONFIG_DIR": config_dir, "SMOOAI_CONFIG_ENV": "production"},
+        )
+        assert mgr.get_public_config("MISSING_KEY") is None
+        assert mgr.get_secret_config("MISSING_SECRET") is None
+        assert mgr.get_feature_flag("MISSING_FLAG") is None
+
+
+class TestConfigManagerHttpFault:
+    """``ConfigManager`` swallows HTTP errors so file/env tiers still resolve."""
+
+    def test_http_5xx_falls_through_to_env(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {})
+        transport = _make_http_transport(values={}, status_code=500)
+
+        with _patch_client_transport(transport):
+            mgr = ConfigManager(
+                api_key=TEST_API_KEY,
+                base_url=TEST_BASE_URL,
+                org_id=TEST_ORG_ID,
+                environment="production",
+                schema_keys={"API_URL"},
+                env={
+                    "SMOOAI_ENV_CONFIG_DIR": config_dir,
+                    "SMOOAI_CONFIG_ENV": "production",
+                    "API_URL": "https://api.from-env.example",
+                },
+            )
+            # HTTP 500 must not erase the env tier.
+            assert mgr.get_public_config("API_URL") == "https://api.from-env.example"
+
+    def test_http_5xx_falls_through_to_file(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "https://api.from-file.example"})
+        transport = _make_http_transport(values={}, status_code=503)
+
+        with _patch_client_transport(transport):
+            mgr = ConfigManager(
+                api_key=TEST_API_KEY,
+                base_url=TEST_BASE_URL,
+                org_id=TEST_ORG_ID,
+                environment="production",
+                env={"SMOOAI_ENV_CONFIG_DIR": config_dir, "SMOOAI_CONFIG_ENV": "production"},
+            )
+            assert mgr.get_public_config("API_URL") == "https://api.from-file.example"
+
+
+class TestConfigManagerCaching:
+    """Repeated reads memoize; ``invalidate()`` drops the cache."""
+
+    def test_repeated_reads_memoize_then_invalidate_drops(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "from-file"})
+        # Tally HTTP requests so we can prove memoization.
+        request_count = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            request_count["n"] += 1
+            env = dict(request.url.params).get("environment", "development")
+            data = {"production": {"API_URL": "from-http-1"}}.get(env, {})
+            url_path = request.url.path
+            base = f"/organizations/{TEST_ORG_ID}/config/values"
+            if url_path == base:
+                return httpx.Response(200, json={"values": data})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+
+        with _patch_client_transport(transport):
+            mgr = ConfigManager(
+                api_key=TEST_API_KEY,
+                base_url=TEST_BASE_URL,
+                org_id=TEST_ORG_ID,
+                environment="production",
+                env={"SMOOAI_ENV_CONFIG_DIR": config_dir, "SMOOAI_CONFIG_ENV": "production"},
+            )
+
+            assert mgr.get_public_config("API_URL") == "from-http-1"
+            initial = request_count["n"]
+            assert initial >= 1
+
+            # Subsequent read serves from per-tier cache — no new HTTP.
+            assert mgr.get_public_config("API_URL") == "from-http-1"
+            assert request_count["n"] == initial
+
+            mgr.invalidate()
+            assert mgr.get_public_config("API_URL") == "from-http-1"
+            # invalidate() forces re-init → at least one new fetch.
+            assert request_count["n"] > initial
+
+
+# ---------------------------------------------------------------------------
+# Runtime blob hydrator — separate path that pre-seeds ``ConfigClient`` cache
+# ---------------------------------------------------------------------------
+
+
+class TestBlobHydration:
+    """The blob path bypasses HTTP entirely by seeding the client cache."""
+
+    def test_hydrated_client_resolves_offline(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        key_b64, blob_path = _encrypt_blob(
+            tmp_path,
+            {
+                "public": {"apiUrl": "https://api.from-blob.example"},
+                "secret": {"sendgridApiKey": "SG.from-blob"},
+            },
+        )
+        monkeypatch.setenv("SMOO_CONFIG_KEY_FILE", blob_path)
+        monkeypatch.setenv("SMOO_CONFIG_KEY", key_b64)
+
+        # No transport → any HTTP call would explode. We rely on the cache.
+        client = ConfigClient(
+            base_url=TEST_BASE_URL,
+            api_key=TEST_API_KEY,
+            org_id=TEST_ORG_ID,
+            environment="production",
+        )
+        try:
+            count = hydrate_config_client(client)
+            assert count == 2
+
+            # These resolve from cache — no HTTP.
+            assert client.get_value("apiUrl") == "https://api.from-blob.example"
+            assert client.get_value("sendgridApiKey") == "SG.from-blob"
+        finally:
+            client.close()
+
+    def test_blob_hydration_is_noop_without_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SMOO_CONFIG_KEY_FILE", raising=False)
+        monkeypatch.delenv("SMOO_CONFIG_KEY", raising=False)
+
+        client = ConfigClient(
+            base_url=TEST_BASE_URL,
+            api_key=TEST_API_KEY,
+            org_id=TEST_ORG_ID,
+            environment="production",
+        )
+        try:
+            assert hydrate_config_client(client) == 0
+        finally:
+            client.close()
+
+    def test_blob_path_is_independent_of_config_manager(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``ConfigManager`` does not consume the blob — confirms the split.
+
+        TypeScript merges blob → env → HTTP → file in a single pipeline.
+        Python's ``ConfigManager`` does **not** read the blob; it must be
+        consumed via ``hydrate_config_client``. This test pins that boundary
+        so a future refactor can't quietly cross-wire them.
+        """
+        # Set up a blob the ConfigManager would otherwise prefer.
+        key_b64, blob_path = _encrypt_blob(
+            tmp_path,
+            {"public": {"API_URL": "from-blob"}, "secret": {}},
+        )
+        monkeypatch.setenv("SMOO_CONFIG_KEY_FILE", blob_path)
+        monkeypatch.setenv("SMOO_CONFIG_KEY", key_b64)
+
+        config_dir = _make_config_dir(tmp_path, {"API_URL": "from-file"})
+
+        mgr = ConfigManager(
+            env={
+                "SMOOAI_ENV_CONFIG_DIR": config_dir,
+                "SMOOAI_CONFIG_ENV": "production",
+                # Blob env vars are also set above via monkeypatch but
+                # ConfigManager's env dict drives its own resolution; the
+                # important point is the merge result.
+            },
+        )
+        # File wins because the blob path is not consulted by ConfigManager.
+        assert mgr.get_public_config("API_URL") == "from-file"

--- a/rust/config/README.md
+++ b/rust/config/README.md
@@ -70,6 +70,7 @@ cargo add smooai-config
 | Python     | [`smooai-config`](https://pypi.org/project/smooai-config/)       | `pip install smooai-config`                 |
 | Rust       | [`smooai-config`](https://crates.io/crates/smooai-config)        | `cargo add smooai-config`                   |
 | Go         | `github.com/SmooAI/config/go/config`                             | `go get github.com/SmooAI/config/go/config` |
+| .NET       | [`SmooAI.Config`](https://www.nuget.org/packages/SmooAI.Config)  | `dotnet add package SmooAI.Config`          |
 
 ## Usage
 
@@ -215,6 +216,75 @@ let db_url = manager.get_secret_config("DATABASE_URL")?;
 let new_ui = manager.get_feature_flag("ENABLE_NEW_UI")?;
 ```
 
+### Baked Runtime — zero-network cold starts
+
+For Lambda / ECS / long-lived services, bake every public + secret value into an AES-256-GCM blob at deploy time and decrypt it at cold start. `build_config_runtime` decrypts the blob and seeds the manager's merged config map, so public/secret reads resolve from in-memory cache with no HTTP round-trip. Feature flags are skipped (the baker drops them) so they stay live-fetched.
+
+```rust
+use smooai_config::{build_config_runtime, RuntimeOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Reads SMOO_CONFIG_KEY_FILE + SMOO_CONFIG_KEY, decrypts the blob, and
+    // seeds the manager. With no env vars set, returns a regular live-fetch
+    // ConfigManager — same API either way.
+    let manager = build_config_runtime(RuntimeOptions {
+        environment: Some("production".to_string()),
+        ..Default::default()
+    })
+    .await?;
+
+    let api_url = manager.get_public_config("apiUrl")?;
+    let sendgrid = manager.get_secret_config("sendgridApiKey")?;
+    Ok(())
+}
+```
+
+Bake the bundle at deploy time:
+
+```rust
+use std::collections::HashSet;
+use smooai_config::{build_bundle, BuildBundleOptions, Classification};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Schema-driven classifier — feature flags must return Skip so they stay live.
+    let public_keys: HashSet<String> = ["apiUrl"].into_iter().map(String::from).collect();
+    let secret_keys: HashSet<String> = ["sendgridApiKey"].into_iter().map(String::from).collect();
+    let flag_keys: HashSet<String> = ["newFlow"].into_iter().map(String::from).collect();
+
+    let result = build_bundle(BuildBundleOptions {
+        base_url: "https://config.smooai.dev".to_string(),
+        api_key: "your-api-key".to_string(),
+        org_id: "your-org-id".to_string(),
+        environment: Some("production".to_string()),
+        classify: Some(Box::new(move |key, _v| {
+            if secret_keys.contains(key) { Classification::Secret }
+            else if flag_keys.contains(key) { Classification::Skip }
+            else if public_keys.contains(key) { Classification::Public }
+            else { Classification::Public }
+        })),
+    })
+    .await?;
+
+    std::fs::write("smoo-config.enc", &result.blob)?;
+    println!("SMOO_CONFIG_KEY_FILE=/abs/path/to/smoo-config.enc");
+    println!("SMOO_CONFIG_KEY={}", result.key_b64);
+    Ok(())
+}
+```
+
+#### Blob env vars
+
+| Variable               | Value                                      |
+| ---------------------- | ------------------------------------------ |
+| `SMOO_CONFIG_KEY_FILE` | Absolute path to the `.enc` bundle on disk |
+| `SMOO_CONFIG_KEY`      | Base64-encoded 32-byte AES-256 key         |
+
+Without both set, `build_config_runtime` returns a plain `ConfigManager` so dev machines without a baked blob still work — the API stays uniform either way.
+
+The blob format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` — wire-identical to the TypeScript, Python, Go, and .NET runtimes. A blob baked in any language decrypts in any other.
+
 ## Environment Variables
 
 All clients read from the same set of environment variables:
@@ -242,6 +312,12 @@ export SMOOAI_CONFIG_ENV="production"
 | **Public**        | Client-visible settings | API URLs, feature toggles, UI config     |
 | **Secret**        | Server-side only        | Database URLs, API keys, JWT secrets     |
 | **Feature Flags** | Runtime toggles         | A/B tests, gradual rollouts, beta access |
+
+## Common errors
+
+### `get_public_config` / `get_secret_config` returning `Ok(None)` for a known key
+
+If you read a key that wasn't declared in the schema your service was built against, the manager's merged map has no entry and lookups return `Ok(None)`. The common cause is a schema rebase mismatch — the consumer was built against an older `schema.json` than what's in your config repo. Re-run the schema generator to pick up the new keys, or add the missing key to your schema.
 
 ## Built With
 
@@ -277,6 +353,8 @@ cargo fmt
 - [@smooai/config](https://www.npmjs.com/package/@smooai/config) - TypeScript/JavaScript version
 - [smooai-config (Python)](https://pypi.org/project/smooai-config/) - Python version
 - [smooai-config (Rust)](https://crates.io/crates/smooai-config) - This package
+- `github.com/SmooAI/config/go/config` - Go version
+- [SmooAI.Config (NuGet)](https://www.nuget.org/packages/SmooAI.Config) - .NET version
 - [SmooAI/config](https://github.com/SmooAI/config) - GitHub repository
 
 <!-- CONTACT -->

--- a/rust/config/tests/priority_chain_integration.rs
+++ b/rust/config/tests/priority_chain_integration.rs
@@ -1,0 +1,415 @@
+//! Integration tests for the Rust config priority chain.
+//!
+//! Parity with TypeScript `src/server/server.priority-chain.integration.test.ts`,
+//! adapted to the Rust architecture. Unlike TS (one pipeline merging
+//! `blob → env → HTTP → file`), the Rust SDK splits the blob into a
+//! separate hydrator: `build_config_runtime` decrypts the blob and seeds
+//! the manager's merged config map directly via `seed_from_baked`,
+//! bypassing the file/env/HTTP pipeline entirely. `ConfigManager::new()`
+//! (no blob) follows the 3-tier merge `file < HTTP < env`.
+//!
+//! Coverage:
+//!   - Each tier wins when higher tiers are absent (precedence)
+//!   - Tier missing entirely → `None` (no crash)
+//!   - HTTP errors fall through to lower tiers (fault tolerance)
+//!   - Caching: repeated reads memoize; `invalidate()` drops them
+//!   - Blob hydration: real AES-256-GCM blob is consumed by
+//!     `build_config_runtime`; reads resolve offline (no HTTP).
+//!   - When a blob is configured, no HTTP fetch happens for public/secret
+//!     reads — pinned with a wiremock that asserts zero hits.
+
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::path::PathBuf;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{AeadCore, Aes256Gcm, Nonce};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use serde_json::{json, Value};
+use smooai_config::{build_config_runtime, ConfigManager, RuntimeOptions};
+use wiremock::matchers::{header, method, path_regex, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PC_API_KEY: &str = "test-api-key-priority-chain";
+const PC_ORG_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+const PC_ENV: &str = "production";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_config_dir(tmp: &tempfile::TempDir, defaults: &Value) -> String {
+    let config_dir = tmp.path().join(".smooai-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let mut f = std::fs::File::create(config_dir.join("default.json")).unwrap();
+    f.write_all(defaults.to_string().as_bytes()).unwrap();
+    config_dir.to_string_lossy().to_string()
+}
+
+fn base_env(config_dir: &str, extra: &[(&str, &str)]) -> HashMap<String, String> {
+    let mut env: HashMap<String, String> = extra.iter().map(|(k, v)| ((*k).into(), (*v).into())).collect();
+    env.insert("SMOOAI_ENV_CONFIG_DIR".into(), config_dir.into());
+    env.insert("SMOOAI_CONFIG_ENV".into(), PC_ENV.into());
+    env
+}
+
+/// Encrypt a `{public, secret}` partition with AES-256-GCM, matching the
+/// envelope produced by `build_bundle` (nonce || ciphertext || tag).
+fn encrypt_blob(tmp: &tempfile::TempDir, public: Value, secret: Value) -> (PathBuf, String) {
+    use aes_gcm::aead::OsRng;
+    let plaintext = json!({"public": public, "secret": secret}).to_string();
+
+    let key = Aes256Gcm::generate_key(&mut OsRng);
+    let nonce_arr = Aes256Gcm::generate_nonce(&mut OsRng);
+    let cipher = Aes256Gcm::new(&key);
+    let nonce = Nonce::from_slice(&nonce_arr);
+    let ciphertext_and_tag = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext.as_bytes(),
+                aad: &[],
+            },
+        )
+        .unwrap();
+
+    let mut blob = nonce_arr.to_vec();
+    blob.extend_from_slice(&ciphertext_and_tag);
+
+    let path = tmp.path().join("smoo-config.enc");
+    std::fs::write(&path, &blob).unwrap();
+    (path, B64.encode(key))
+}
+
+/// Mount an OK responder returning the given values map for any GET
+/// `/organizations/.../config/values?environment=PC_ENV` with valid auth.
+async fn mount_ok_values(server: &MockServer, values: Value) {
+    Mock::given(method("GET"))
+        .and(path_regex(r"/organizations/.+/config/values"))
+        .and(query_param("environment", PC_ENV))
+        .and(header("Authorization", format!("Bearer {}", PC_API_KEY)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"values": values})))
+        .mount(server)
+        .await;
+}
+
+/// Mount a failure responder returning the given status for any GET
+/// `/organizations/.../config/values?environment=PC_ENV` with valid auth.
+async fn mount_failure(server: &MockServer, status: u16) {
+    Mock::given(method("GET"))
+        .and(path_regex(r"/organizations/.+/config/values"))
+        .and(query_param("environment", PC_ENV))
+        .and(header("Authorization", format!("Bearer {}", PC_API_KEY)))
+        .respond_with(ResponseTemplate::new(status).set_body_json(json!({"error": "boom"})))
+        .mount(server)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// 3-tier merge: env > HTTP > file
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn env_wins_over_http_and_file() {
+    let server = MockServer::start().await;
+    mount_ok_values(&server, json!({"API_URL": "https://api.from-http.example"})).await;
+
+    let url = server.uri();
+    let result = tokio::task::spawn_blocking(move || {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({"API_URL": "https://api.from-file.example"}));
+        let env = base_env(&config_dir, &[("API_URL", "https://api.from-env.example")]);
+
+        let mut schema_keys = HashSet::new();
+        schema_keys.insert("API_URL".into());
+
+        let mgr = ConfigManager::new()
+            .with_api_key(PC_API_KEY)
+            .with_base_url(&url)
+            .with_org_id(PC_ORG_ID)
+            .with_environment(PC_ENV)
+            .with_schema_keys(schema_keys)
+            .with_env(env);
+
+        mgr.get_public_config("API_URL").unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, Some(json!("https://api.from-env.example")));
+}
+
+#[tokio::test]
+async fn http_wins_over_file_when_env_absent() {
+    let server = MockServer::start().await;
+    mount_ok_values(&server, json!({"API_URL": "https://api.from-http.example"})).await;
+
+    let url = server.uri();
+    let result = tokio::task::spawn_blocking(move || {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({"API_URL": "https://api.from-file.example"}));
+        let env = base_env(&config_dir, &[]);
+
+        let mgr = ConfigManager::new()
+            .with_api_key(PC_API_KEY)
+            .with_base_url(&url)
+            .with_org_id(PC_ORG_ID)
+            .with_environment(PC_ENV)
+            .with_env(env);
+
+        mgr.get_public_config("API_URL").unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, Some(json!("https://api.from-http.example")));
+}
+
+#[tokio::test]
+async fn file_wins_when_http_and_env_absent() {
+    let result = tokio::task::spawn_blocking(|| {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({"API_URL": "https://api.from-file.example"}));
+        let env = base_env(&config_dir, &[]);
+
+        let mgr = ConfigManager::new().with_env(env);
+        mgr.get_public_config("API_URL").unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, Some(json!("https://api.from-file.example")));
+}
+
+#[tokio::test]
+async fn returns_none_when_no_tier_has_key() {
+    let result = tokio::task::spawn_blocking(|| {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({}));
+        let env = base_env(&config_dir, &[]);
+
+        let mgr = ConfigManager::new().with_env(env);
+        (
+            mgr.get_public_config("MISSING").unwrap(),
+            mgr.get_secret_config("MISSING_SECRET").unwrap(),
+            mgr.get_feature_flag("MISSING_FLAG").unwrap(),
+        )
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result.0, None);
+    assert_eq!(result.1, None);
+    assert_eq!(result.2, None);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP fault tolerance
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_5xx_falls_through_to_env() {
+    let server = MockServer::start().await;
+    mount_failure(&server, 500).await;
+
+    let url = server.uri();
+    let result = tokio::task::spawn_blocking(move || {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({}));
+        let env = base_env(&config_dir, &[("API_URL", "https://api.from-env.example")]);
+
+        let mut schema_keys = HashSet::new();
+        schema_keys.insert("API_URL".into());
+
+        let mgr = ConfigManager::new()
+            .with_api_key(PC_API_KEY)
+            .with_base_url(&url)
+            .with_org_id(PC_ORG_ID)
+            .with_environment(PC_ENV)
+            .with_schema_keys(schema_keys)
+            .with_env(env);
+
+        mgr.get_public_config("API_URL").unwrap()
+    })
+    .await
+    .unwrap();
+
+    // HTTP 500 must not erase the env tier.
+    assert_eq!(result, Some(json!("https://api.from-env.example")));
+}
+
+#[tokio::test]
+async fn http_5xx_falls_through_to_file() {
+    let server = MockServer::start().await;
+    mount_failure(&server, 503).await;
+
+    let url = server.uri();
+    let result = tokio::task::spawn_blocking(move || {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({"API_URL": "https://api.from-file.example"}));
+        let env = base_env(&config_dir, &[]);
+
+        let mgr = ConfigManager::new()
+            .with_api_key(PC_API_KEY)
+            .with_base_url(&url)
+            .with_org_id(PC_ORG_ID)
+            .with_environment(PC_ENV)
+            .with_env(env);
+
+        mgr.get_public_config("API_URL").unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, Some(json!("https://api.from-file.example")));
+}
+
+// ---------------------------------------------------------------------------
+// Caching + invalidation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn repeated_reads_memoize_until_invalidate() {
+    let server = MockServer::start().await;
+    // Single mount handles both pre- and post-invalidate fetches; we count
+    // the number of times the API is hit across the two read phases.
+    Mock::given(method("GET"))
+        .and(path_regex(r"/organizations/.+/config/values"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": {"API_URL": "https://api.cached.example"}
+        })))
+        .mount(&server)
+        .await;
+
+    let url = server.uri();
+    let server_ref = server;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = make_config_dir(&tmp, &json!({}));
+        let env = base_env(&config_dir, &[]);
+
+        let mgr = ConfigManager::new()
+            .with_api_key(PC_API_KEY)
+            .with_base_url(&url)
+            .with_org_id(PC_ORG_ID)
+            .with_environment(PC_ENV)
+            .with_env(env);
+
+        let v1 = mgr.get_public_config("API_URL").unwrap();
+        // Cached read — must not trigger a new HTTP request.
+        let v2 = mgr.get_public_config("API_URL").unwrap();
+
+        mgr.invalidate();
+        // Post-invalidate read — re-fetches.
+        let v3 = mgr.get_public_config("API_URL").unwrap();
+
+        (v1, v2, v3)
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result.0, Some(json!("https://api.cached.example")));
+    assert_eq!(result.1, Some(json!("https://api.cached.example")));
+    assert_eq!(result.2, Some(json!("https://api.cached.example")));
+
+    // Two distinct fetches: one before the cached read, one after invalidate.
+    let received = server_ref.received_requests().await.unwrap();
+    assert_eq!(
+        received.len(),
+        2,
+        "expected exactly 2 HTTP fetches; got {}",
+        received.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Blob hydrator — separate path that bypasses HTTP for public/secret reads
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn blob_hydration_resolves_offline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (blob_path, key_b64) = encrypt_blob(
+        &tmp,
+        json!({"apiUrl": "https://api.from-blob.example"}),
+        json!({"sendgridApiKey": "SG.from-blob"}),
+    );
+
+    let manager = build_config_runtime(RuntimeOptions {
+        key_file: Some(blob_path),
+        key_b64: Some(key_b64),
+        environment: Some(PC_ENV.into()),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        manager.get_public_config("apiUrl").unwrap(),
+        Some(json!("https://api.from-blob.example"))
+    );
+    assert_eq!(
+        manager.get_secret_config("sendgridApiKey").unwrap(),
+        Some(json!("SG.from-blob"))
+    );
+}
+
+#[tokio::test]
+async fn blob_bypasses_http_entirely() {
+    // Stand up a wiremock that fails the test if hit, then drive the
+    // blob-seeded manager. `seed_from_baked` marks the manager initialized
+    // and replaces the merged map outright, so file / env / HTTP tiers are
+    // not consulted — pin that boundary here.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"/organizations/.+/config/values"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (blob_path, key_b64) = encrypt_blob(&tmp, json!({"apiUrl": "https://api.from-blob.example"}), json!({}));
+
+    let manager = build_config_runtime(RuntimeOptions {
+        key_file: Some(blob_path),
+        key_b64: Some(key_b64),
+        environment: Some(PC_ENV.into()),
+    })
+    .await
+    .unwrap();
+
+    // Sanity: read resolves from the seeded blob.
+    let value = tokio::task::spawn_blocking(move || manager.get_public_config("apiUrl").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(value, Some(json!("https://api.from-blob.example")));
+
+    // wiremock's `.expect(0)` plus drop-time verification asserts no hits.
+    drop(server);
+}
+
+#[tokio::test]
+async fn blob_fallback_when_env_vars_absent() {
+    // No blob configured → build_config_runtime returns a regular manager
+    // that lazy-loads from file/env/HTTP on first access. Confirms graceful
+    // fallback for dev environments without baked config.
+    let manager = build_config_runtime(RuntimeOptions {
+        key_file: None,
+        key_b64: None,
+        environment: Some(PC_ENV.into()),
+    })
+    .await
+    .unwrap();
+
+    let result = tokio::task::spawn_blocking(move || {
+        // No file dir / no API creds set → empty merged config; lookups
+        // return None rather than panicking.
+        manager.get_public_config("anyKey").unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, None);
+}


### PR DESCRIPTION
## Summary

Two-part patch (test-only + docs-only — no source changes):

1. **Priority-chain integration tests** in Python, Go, Rust, and .NET so each language has parity coverage with TypeScript's `src/server/server.priority-chain.integration.test.ts`.
2. **User-facing usage docs** for every SDK README, plus a top-level "Languages / SDKs" section so a new dev knows where to start.

### Per-language test counts (all green)

- Python: 10 tests (`tests/test_priority_chain_integration.py`) — full suite 287 passing
- Go: 13 tests (`go/config/priority_chain_integration_test.go`) — full suite 261 passing
- Rust: 10 tests (`rust/config/tests/priority_chain_integration.rs`) — full suite 206 passing
- .NET: 9 tests (`dotnet/tests/SmooAI.Config.Tests/PriorityChainIntegrationTests.cs`) — full suite 55 passing

## Architectural note (tests are not a 1:1 TS port)

TypeScript merges `blob → env → HTTP → file` in one path. The other languages split the blob tier into a separate hydrator, so "parity" means each language's actual merge order with HTTP mocked + a real AES-256-GCM blob fixture where applicable:

- **Python**: `ConfigManager` is 3-tier (env → HTTP → file); `runtime.py` decrypts the blob and pre-seeds a `ConfigClient` cache. Tests pin that the blob hydrator does **not** leak into `ConfigManager`'s 3-tier path.
- **Go**: `ConfigManager` is 3-tier; `NewRuntimeConfigManager` decrypts and installs the blob as the manager's "remote" tier. Tests confirm zero HTTP hits when a blob is present, and that env vars still win over baked values.
- **Rust**: `ConfigManager::new()` is 3-tier; `build_config_runtime` decrypts and calls `seed_from_baked` to replace the merged map outright. Tests pin that the blob path bypasses HTTP entirely (wiremock `.expect(0)`).
- **.NET**: Architectural intent is no merge — `SmooConfigRuntime` (blob) and `SmooConfigClient` (HTTP) are independent. Tests cover both paths separately, plus an architectural-pin assertion that the runtime holds no `HttpClient` field.

## Documentation changes

- **`README.md`** (repo top-level) — added a "Languages / SDKs" table near the top with one sentence + link per SDK, and refreshed the "Multi-Language Support" section to include .NET.
- **`python/README.md`** — added a Baked Runtime section (`build_config_runtime` + `build_bundle`), the `SMOO_CONFIG_KEY_FILE` / `SMOO_CONFIG_KEY` env-var contract, a Common errors section covering the SMOODEV-847 schema-not-declared case, and added .NET to the cross-language list.
- **`go/config/README.md`** — same shape: `NewRuntimeConfigManager` + `BuildBundle` docs, blob env vars, Common errors, .NET in the cross-language list.
- **`rust/config/README.md`** — same shape: `build_config_runtime` + `build_bundle` docs, blob env vars, Common errors, .NET in the cross-language list.
- **`dotnet/README.md`** — new repo-level .NET entry point (the canonical NuGet README at `dotnet/src/SmooAI.Config/README.md` stays where it is; `PackageReadmeFile` is already wired correctly). Repo layout, dev commands, link to the NuGet README.
- **`dotnet/src/SmooAI.Config/README.md`** — added a Common errors section covering source-generator typed-key staleness and AES-GCM decryption failures.

## Test plan

- [x] `cd python && uv run pytest tests/test_priority_chain_integration.py` — 10 passed
- [x] `cd python && uv run pytest` — 287 passed (was 277, +10)
- [x] `cd go/config && go test -run TestPriorityChain ./...` — 13 passed
- [x] `cd go/config && go test ./...` — 261 passed (was 248, +13)
- [x] `cd rust/config && cargo test --test priority_chain_integration` — 10 passed
- [x] `cd rust/config && cargo test` — 206 passed (was 196, +10)
- [x] `cd dotnet && dotnet test --filter "FullyQualifiedName~PriorityChain"` — 9 passed
- [x] `cd dotnet && dotnet test` — 55 passed (was 46, +9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
