### PR TITLE
SMOODEV-878: Fix Python ruff E501 errors that block @smooai/config release

### DIFF
--- a/python/src/smooai_config/config_manager.py
+++ b/python/src/smooai_config/config_manager.py
@@ -178,10 +178,12 @@ class ConfigManager:
         # guard the call would later flow into env-var-name conversion that
         # crashes with a cryptic AttributeError.
         if not isinstance(key, str) or not key:
+            kind = type(key).__name__ if key is None or not isinstance(key, str) else "empty string"
             raise ValueError(
-                f"@smooai/config: get() called with {type(key).__name__ if key is None or not isinstance(key, str) else 'empty string'} key. "
-                "Most common cause: reading SecretConfigKeys.<X> / PublicConfigKeys.<X> / FeatureFlagKeys.<X> "
-                "for a key that's not declared in your schema. Add it to .smooai-config/config.ts and run `smooai-config push`."
+                f"@smooai/config: get() called with {kind} key. "
+                "Most common cause: reading SecretConfigKeys.<X> / PublicConfigKeys.<X> / "
+                "FeatureFlagKeys.<X> for a key that's not declared in your schema. "
+                "Add it to .smooai-config/config.ts and run `smooai-config push`."
             )
         with self._lock:
             hit, value = self._get_from_cache(cache, key)

--- a/python/src/smooai_config/local.py
+++ b/python/src/smooai_config/local.py
@@ -73,9 +73,11 @@ class LocalConfigManager:
         # equivalent assertKeyDefined in src/server/internal.ts for the
         # original incident (Derek's ICVR dashboard).
         if not isinstance(key, str) or not key:
+            kind = type(key).__name__ if key is None or not isinstance(key, str) else "empty string"
             raise ValueError(
-                f"@smooai/config: get() called with {type(key).__name__ if key is None or not isinstance(key, str) else 'empty string'} key. "
-                "Most common cause: reading a typed-keys constant for a key that's not declared in your schema. "
+                f"@smooai/config: get() called with {kind} key. "
+                "Most common cause: reading a typed-keys constant for a key "
+                "that's not declared in your schema. "
                 "Add it to .smooai-config/config.ts and run `smooai-config push`."
             )
         with self._lock:


### PR DESCRIPTION
## Summary
The Release (Changesets 🦋) workflow has been failing on Lint since SMOODEV-847 landed — two error-message strings in python/src/smooai_config/{config_manager,local}.py exceed the 120-char limit. As a result, the @smooai/config 4.6.x minor (with the Turbopack-compatibility fix from PR #68) hasn't published.

Fix: extract the type-name into a local variable + break the strings into adjacent literals (Python concatenates).

## Test plan
- [x] \`pnpm lint\` clean
- [ ] Release workflow runs green after merge → publishes 4.6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)