### PR TITLE
SMOODEV-880…884: Add @smooai/config/bootstrap cold-start fetch helper across all 5 SDKs

### DIFF
--- a/.changeset/smoodev-880-bootstrap-fetch.md
+++ b/.changeset/smoodev-880-bootstrap-fetch.md
@@ -1,0 +1,26 @@
+---
+'@smooai/config': minor
+---
+
+SMOODEV-880: Add `@smooai/config/bootstrap` cold-start fetch helper across all five SDKs
+
+Adds a lightweight, dependency-free entry point for reading a single config value
+via plain HTTP — OAuth `client_credentials` exchange + `GET /organizations/{orgId}/config/values`
+with per-process per-env caching. Designed for deploy scripts, container entry-points,
+and other cold-start contexts where importing the full SDK is too heavy or pulls in
+a transitive dependency that breaks the host runtime.
+
+Public surface per language:
+
+- **TypeScript**: `import { bootstrapFetch } from '@smooai/config/bootstrap'` — `bootstrapFetch(key, { environment? })`
+- **Python**: `from smooai_config.bootstrap import bootstrap_fetch` — `bootstrap_fetch(key, environment=None)`
+- **Go**: `import ".../go/config/bootstrap"` — `bootstrap.Fetch(ctx, key, bootstrap.WithEnvironment(...))`
+- **Rust**: `use smooai_config::bootstrap_fetch` — `bootstrap_fetch(key, environment).await`
+- **.NET**: `using SmooAI.Config.Bootstrap` — `Bootstrap.FetchAsync(key, new BootstrapOptions { Environment = ... })`
+
+Each implementation reads creds from `SMOOAI_CONFIG_{API_URL,AUTH_URL,CLIENT_ID,CLIENT_SECRET,ORG_ID}`
+(legacy `SMOOAI_CONFIG_API_KEY` and `SMOOAI_AUTH_URL` accepted), auto-detects the
+environment from `SST_STAGE` / `NEXT_PUBLIC_SST_STAGE` / `SST_RESOURCE_App` JSON /
+`SMOOAI_CONFIG_ENV`, and caches the values map per-env so repeated reads in the
+same process avoid the round-trip. None of the implementations import anything else
+from the SDK or pull in non-stdlib dependencies beyond what the crate/package already requires.

--- a/dotnet/src/SmooAI.Config/Bootstrap/BootstrapFetch.cs
+++ b/dotnet/src/SmooAI.Config/Bootstrap/BootstrapFetch.cs
@@ -1,0 +1,284 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SmooAI.Config.Bootstrap;
+
+/// <summary>
+/// Lightweight cold-start config fetcher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This static class exists for callers that need to read a single
+/// config value from a deploy script, container entry-point, or other
+/// cold-start context where the full <see cref="SmooConfigClient"/>
+/// SDK is too heavy or pulls in a transitive dependency that breaks
+/// the host runtime.
+/// </para>
+/// <para>
+/// It has zero dependencies on the rest of the SmooAI.Config SDK (no
+/// logger, no fetch wrapper, no schema validation) and uses only
+/// <c>System.Net.Http</c> + <c>System.Text.Json</c>.
+/// </para>
+/// <para>
+/// It performs a single OAuth client_credentials exchange, then a
+/// single GET against <c>/organizations/{orgId}/config/values</c> and
+/// caches the values map per-process per-env so repeated reads inside
+/// the same process avoid the round-trip.
+/// </para>
+/// <para>
+/// Inputs (read from <see cref="Environment.GetEnvironmentVariable(string)"/>):
+/// <list type="bullet">
+///   <item><c>SMOOAI_CONFIG_API_URL</c> — base URL (default <c>https://api.smoo.ai</c>)</item>
+///   <item><c>SMOOAI_CONFIG_AUTH_URL</c> — OAuth base URL (default <c>https://auth.smoo.ai</c>; legacy <c>SMOOAI_AUTH_URL</c> also accepted)</item>
+///   <item><c>SMOOAI_CONFIG_CLIENT_ID</c> — OAuth M2M client id</item>
+///   <item><c>SMOOAI_CONFIG_CLIENT_SECRET</c> — OAuth M2M client secret (legacy <c>SMOOAI_CONFIG_API_KEY</c> accepted)</item>
+///   <item><c>SMOOAI_CONFIG_ORG_ID</c> — target org id</item>
+///   <item><c>SMOOAI_CONFIG_ENV</c> — default env name (fallback when no SST stage detected)</item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class Bootstrap
+{
+    private static readonly object CacheLock = new();
+    private static string? _cachedEnv;
+    private static Dictionary<string, JsonElement>? _cachedValues;
+
+    private static readonly HttpClient DefaultClient = new();
+
+    /// <summary>
+    /// Fetch a single config value by camelCase key. Returns <c>null</c> if
+    /// the key is not present in the values map; throws on env / auth /
+    /// network failures.
+    /// </summary>
+    public static Task<string?> FetchAsync(
+        string key,
+        BootstrapOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return FetchInternalAsync(key, options ?? new BootstrapOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Test-only: clear the in-process cache. Not part of the supported
+    /// public API.
+    /// </summary>
+    public static void ResetCache()
+    {
+        lock (CacheLock)
+        {
+            _cachedEnv = null;
+            _cachedValues = null;
+        }
+    }
+
+    internal static async Task<string?> FetchInternalAsync(
+        string key,
+        BootstrapOptions options,
+        CancellationToken cancellationToken)
+    {
+        var getEnv = options.GetEnv ?? Environment.GetEnvironmentVariable;
+        var httpClient = options.HttpClient ?? DefaultClient;
+
+        var env = ResolveEnv(getEnv, options.Environment);
+
+        Dictionary<string, JsonElement>? values;
+        lock (CacheLock)
+        {
+            values = _cachedEnv == env ? _cachedValues : null;
+        }
+
+        if (values is null)
+        {
+            var creds = ReadCreds(getEnv);
+            var token = await MintAccessTokenAsync(httpClient, creds, cancellationToken).ConfigureAwait(false);
+            var fetched = await FetchValuesAsync(httpClient, creds, token, env, cancellationToken).ConfigureAwait(false);
+            lock (CacheLock)
+            {
+                _cachedEnv = env;
+                _cachedValues = fetched;
+                values = fetched;
+            }
+        }
+
+        if (!values.TryGetValue(key, out var element)) return null;
+        return ElementToString(element);
+    }
+
+    internal static string ResolveEnv(Func<string, string?> getEnv, string? explicitEnv)
+    {
+        if (!string.IsNullOrEmpty(explicitEnv)) return explicitEnv;
+        var stage = NonEmpty(getEnv("SST_STAGE")) ?? NonEmpty(getEnv("NEXT_PUBLIC_SST_STAGE"));
+        if (stage is null)
+        {
+            var raw = NonEmpty(getEnv("SST_RESOURCE_App"));
+            if (raw is not null)
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(raw);
+                    if (doc.RootElement.ValueKind == JsonValueKind.Object
+                        && doc.RootElement.TryGetProperty("stage", out var s)
+                        && s.ValueKind == JsonValueKind.String)
+                    {
+                        var parsed = s.GetString();
+                        if (!string.IsNullOrEmpty(parsed)) stage = parsed;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // fall through
+                }
+            }
+        }
+        if (stage is null) return NonEmpty(getEnv("SMOOAI_CONFIG_ENV")) ?? "development";
+        return stage == "production" ? "production" : stage;
+    }
+
+    private static string? NonEmpty(string? s) => string.IsNullOrEmpty(s) ? null : s;
+
+    private static BootstrapCreds ReadCreds(Func<string, string?> getEnv)
+    {
+        var apiUrl = NonEmpty(getEnv("SMOOAI_CONFIG_API_URL")) ?? "https://api.smoo.ai";
+        var authUrl = NonEmpty(getEnv("SMOOAI_CONFIG_AUTH_URL"))
+                      ?? NonEmpty(getEnv("SMOOAI_AUTH_URL"))
+                      ?? "https://auth.smoo.ai";
+        var clientId = NonEmpty(getEnv("SMOOAI_CONFIG_CLIENT_ID"));
+        var clientSecret = NonEmpty(getEnv("SMOOAI_CONFIG_CLIENT_SECRET"))
+                           ?? NonEmpty(getEnv("SMOOAI_CONFIG_API_KEY"));
+        var orgId = NonEmpty(getEnv("SMOOAI_CONFIG_ORG_ID"));
+
+        if (clientId is null || clientSecret is null || orgId is null)
+        {
+            throw new BootstrapException(
+                "[SmooAI.Config.Bootstrap] missing SMOOAI_CONFIG_{CLIENT_ID,CLIENT_SECRET,ORG_ID} in env. " +
+                "Set these (e.g. via `pnpm sst shell --stage <stage>`) before calling FetchAsync.");
+        }
+        return new BootstrapCreds(apiUrl, authUrl, clientId, clientSecret, orgId);
+    }
+
+    private static async Task<string> MintAccessTokenAsync(
+        HttpClient http,
+        BootstrapCreds creds,
+        CancellationToken cancellationToken)
+    {
+        var authUrl = creds.AuthUrl.TrimEnd('/') + "/token";
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("provider", "client_credentials"),
+            new KeyValuePair<string, string>("client_id", creds.ClientId),
+            new KeyValuePair<string, string>("client_secret", creds.ClientSecret),
+        });
+        using var req = new HttpRequestMessage(HttpMethod.Post, authUrl) { Content = form };
+        using var resp = await http.SendAsync(req, cancellationToken).ConfigureAwait(false);
+        var body = await SafeReadAsync(resp, cancellationToken).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            throw new BootstrapException(
+                $"[SmooAI.Config.Bootstrap] OAuth token exchange failed: HTTP {(int)resp.StatusCode} {body}");
+        }
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<TokenResponse>(body);
+            var token = parsed?.AccessToken;
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new BootstrapException("[SmooAI.Config.Bootstrap] OAuth token endpoint returned no access_token");
+            }
+            return token;
+        }
+        catch (JsonException ex)
+        {
+            throw new BootstrapException($"[SmooAI.Config.Bootstrap] OAuth response not JSON: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> FetchValuesAsync(
+        HttpClient http,
+        BootstrapCreds creds,
+        string token,
+        string env,
+        CancellationToken cancellationToken)
+    {
+        var apiBase = creds.ApiUrl.TrimEnd('/');
+        var url = $"{apiBase}/organizations/{Uri.EscapeDataString(creds.OrgId)}/config/values?environment={Uri.EscapeDataString(env)}";
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var resp = await http.SendAsync(req, cancellationToken).ConfigureAwait(false);
+        var body = await SafeReadAsync(resp, cancellationToken).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            throw new BootstrapException(
+                $"[SmooAI.Config.Bootstrap] GET /config/values failed: HTTP {(int)resp.StatusCode} {body}");
+        }
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ValuesResponse>(body);
+            return parsed?.Values is not null
+                ? new Dictionary<string, JsonElement>(parsed.Values)
+                : new Dictionary<string, JsonElement>();
+        }
+        catch (JsonException ex)
+        {
+            throw new BootstrapException($"[SmooAI.Config.Bootstrap] values response not JSON: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<string> SafeReadAsync(HttpResponseMessage resp, CancellationToken cancellationToken)
+    {
+        try { return await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false); }
+        catch { return string.Empty; }
+    }
+
+    private static string? ElementToString(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.Undefined => null,
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Number => element.GetRawText(),
+            _ => element.GetRawText(),
+        };
+    }
+
+    private sealed record BootstrapCreds(string ApiUrl, string AuthUrl, string ClientId, string ClientSecret, string OrgId);
+
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string? AccessToken { get; init; }
+    }
+
+    private sealed class ValuesResponse
+    {
+        [JsonPropertyName("values")]
+        public Dictionary<string, JsonElement>? Values { get; init; }
+    }
+}
+
+/// <summary>Options for <see cref="Bootstrap.FetchAsync"/>.</summary>
+public sealed class BootstrapOptions
+{
+    /// <summary>Explicit environment name. Bypasses auto-detection when set.</summary>
+    public string? Environment { get; set; }
+
+    /// <summary>Override the HTTP client (mainly for tests).</summary>
+    public HttpClient? HttpClient { get; set; }
+
+    /// <summary>Override the env-lookup function (test-only).</summary>
+    internal Func<string, string?>? GetEnv { get; set; }
+}
+
+/// <summary>Raised when <see cref="Bootstrap.FetchAsync"/> cannot complete.</summary>
+public sealed class BootstrapException : Exception
+{
+    public BootstrapException(string message) : base(message) { }
+    public BootstrapException(string message, Exception inner) : base(message, inner) { }
+}

--- a/dotnet/tests/SmooAI.Config.Tests/Bootstrap/BootstrapFetchTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/Bootstrap/BootstrapFetchTests.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using System.Text.Json;
+using SmooAI.Config.Bootstrap;
+
+namespace SmooAI.Config.Tests.Bootstrap;
+
+[Collection("BootstrapCache")]
+public class BootstrapFetchTests
+{
+    private static (HttpClient client, StubHttpMessageHandler handler) CreateHttp()
+    {
+        var handler = new StubHttpMessageHandler();
+        var client = new HttpClient(handler);
+        return (client, handler);
+    }
+
+    private static Func<string, string?> Env(params (string Key, string Value)[] pairs)
+    {
+        var map = pairs.ToDictionary(p => p.Key, p => p.Value);
+        return k => map.TryGetValue(k, out var v) ? v : null;
+    }
+
+    private static (string Key, string Value)[] BaseEnv() => new[]
+    {
+        ("SMOOAI_CONFIG_API_URL", "https://api.example.test"),
+        ("SMOOAI_CONFIG_AUTH_URL", "https://auth.example.test"),
+        ("SMOOAI_CONFIG_CLIENT_ID", "client-id-123"),
+        ("SMOOAI_CONFIG_CLIENT_SECRET", "client-secret-456"),
+        ("SMOOAI_CONFIG_ORG_ID", "org-789"),
+    };
+
+    public BootstrapFetchTests()
+    {
+        SmooAI.Config.Bootstrap.Bootstrap.ResetCache();
+    }
+
+    [Fact]
+    public async Task ReturnsValueForKnownKey()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"TOKEN"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"databaseUrl":"postgres://x"}}""");
+
+        var value = await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "databaseUrl",
+            new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) });
+        Assert.Equal("postgres://x", value);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ReturnsNullForMissingKey()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"other":"x"}}""");
+
+        var value = await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "databaseUrl",
+            new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) });
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public async Task CachesValuesPerEnv()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"a":"1","b":"2"}}""");
+
+        var options = new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) };
+        Assert.Equal("1", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("a", options));
+        Assert.Equal("2", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("b", options));
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task RefetchesOnEnvChange()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T1"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"a":"dev"}}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T2"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"a":"prod"}}""");
+
+        var envFn = Env(BaseEnv());
+        Assert.Equal("dev", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "a", new BootstrapOptions { HttpClient = http, GetEnv = envFn, Environment = "development" }));
+        Assert.Equal("prod", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "a", new BootstrapOptions { HttpClient = http, GetEnv = envFn, Environment = "production" }));
+        Assert.Equal(4, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task OAuthRequestShape()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"TOKEN"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"k":"v"}}""");
+
+        await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "k", new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) });
+
+        var auth = handler.Requests[0];
+        Assert.Equal(HttpMethod.Post, auth.Method);
+        Assert.Equal("https://auth.example.test/token", auth.RequestUri!.ToString());
+        Assert.Equal("application/x-www-form-urlencoded", auth.Content!.Headers.ContentType!.MediaType);
+        var body = handler.RequestBodies[0];
+        Assert.Contains("grant_type=client_credentials", body);
+        Assert.Contains("client_id=client-id-123", body);
+        Assert.Contains("client_secret=client-secret-456", body);
+        Assert.Contains("provider=client_credentials", body);
+    }
+
+    [Fact]
+    public async Task ValuesRequestShape()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"TOKEN"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"k":"v"}}""");
+
+        await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "k",
+            new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()), Environment = "staging env" });
+
+        var values = handler.Requests[1];
+        Assert.Equal(HttpMethod.Get, values.Method);
+        Assert.Equal(
+            "https://api.example.test/organizations/org-789/config/values?environment=staging%20env",
+            values.RequestUri!.AbsoluteUri);
+        Assert.Equal("Bearer", values.Headers.Authorization!.Scheme);
+        Assert.Equal("TOKEN", values.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task MissingCredsThrows()
+    {
+        var (http, _) = CreateHttp();
+        var env = BaseEnv().Where(p => p.Key != "SMOOAI_CONFIG_CLIENT_ID").ToArray();
+        var ex = await Assert.ThrowsAsync<BootstrapException>(() =>
+            SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("k",
+                new BootstrapOptions { HttpClient = http, GetEnv = Env(env) }));
+        Assert.Contains("CLIENT_ID,CLIENT_SECRET,ORG_ID", ex.Message);
+    }
+
+    [Fact]
+    public async Task AcceptsLegacyApiKey()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"k":"v"}}""");
+
+        var env = BaseEnv().Where(p => p.Key != "SMOOAI_CONFIG_CLIENT_SECRET")
+            .Append(("SMOOAI_CONFIG_API_KEY", "legacy-secret")).ToArray();
+
+        var value = await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "k", new BootstrapOptions { HttpClient = http, GetEnv = Env(env) });
+        Assert.Equal("v", value);
+        Assert.Contains("client_secret=legacy-secret", handler.RequestBodies[0]);
+    }
+
+    [Fact]
+    public async Task AcceptsLegacyAuthUrl()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"k":"v"}}""");
+
+        var env = BaseEnv().Where(p => p.Key != "SMOOAI_CONFIG_AUTH_URL")
+            .Append(("SMOOAI_AUTH_URL", "https://legacy-auth.example.test")).ToArray();
+
+        await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync(
+            "k", new BootstrapOptions { HttpClient = http, GetEnv = Env(env) });
+        Assert.Equal("https://legacy-auth.example.test/token", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task OAuthFailureThrows()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.Unauthorized, "invalid_client", "text/plain");
+        var ex = await Assert.ThrowsAsync<BootstrapException>(() =>
+            SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("k",
+                new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) }));
+        Assert.Contains("OAuth token exchange failed: HTTP 401", ex.Message);
+    }
+
+    [Fact]
+    public async Task ValuesFailureThrows()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.InternalServerError, "boom", "text/plain");
+
+        var ex = await Assert.ThrowsAsync<BootstrapException>(() =>
+            SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("k",
+                new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) }));
+        Assert.Contains("GET /config/values failed: HTTP 500", ex.Message);
+    }
+
+    [Fact]
+    public async Task OAuthMissingAccessTokenThrows()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, "{}");
+        var ex = await Assert.ThrowsAsync<BootstrapException>(() =>
+            SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("k",
+                new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) }));
+        Assert.Contains("no access_token", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("explicit", new[] { "SST_STAGE", "ignored" }, "explicit")]
+    [InlineData(null, new[] { "SST_STAGE", "brentrager" }, "brentrager")]
+    [InlineData(null, new[] { "NEXT_PUBLIC_SST_STAGE", "dev-stage" }, "dev-stage")]
+    [InlineData(null, new[] { "SST_RESOURCE_App", "{\"stage\":\"sst-resource-stage\"}" }, "sst-resource-stage")]
+    [InlineData(null, new[] { "SST_STAGE", "production" }, "production")]
+    [InlineData(null, new[] { "SMOOAI_CONFIG_ENV", "qa" }, "qa")]
+    [InlineData(null, new string[0], "development")]
+    [InlineData(null, new[] { "SST_RESOURCE_App", "{not json", "SMOOAI_CONFIG_ENV", "qa" }, "qa")]
+    public void ResolveEnv_Variants(string? explicitEnv, string[] envPairs, string expected)
+    {
+        var pairs = new List<(string, string)>();
+        for (var i = 0; i + 1 < envPairs.Length; i += 2)
+        {
+            pairs.Add((envPairs[i], envPairs[i + 1]));
+        }
+        var resolved = SmooAI.Config.Bootstrap.Bootstrap.ResolveEnv(Env(pairs.ToArray()), explicitEnv);
+        Assert.Equal(expected, resolved);
+    }
+
+    [Fact]
+    public async Task StringifiesNonStringValues()
+    {
+        var (http, handler) = CreateHttp();
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T"}""");
+        handler.Enqueue(HttpStatusCode.OK, """{"values":{"count":42,"flag":true,"pi":3.5}}""");
+
+        var options = new BootstrapOptions { HttpClient = http, GetEnv = Env(BaseEnv()) };
+        Assert.Equal("42", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("count", options));
+        Assert.Equal("true", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("flag", options));
+        Assert.Equal("3.5", await SmooAI.Config.Bootstrap.Bootstrap.FetchAsync("pi", options));
+    }
+}
+
+[CollectionDefinition("BootstrapCache", DisableParallelization = true)]
+public class BootstrapCacheCollection { }

--- a/go/config/bootstrap/bootstrap.go
+++ b/go/config/bootstrap/bootstrap.go
@@ -1,0 +1,286 @@
+// Package bootstrap provides a lightweight cold-start config fetcher
+// for the Smoo AI config platform.
+//
+// Unlike the main config client, this package has *zero* imports from
+// other parts of the smooai-config module and depends only on the Go
+// standard library (net/http, encoding/json, etc.). It exists for
+// deploy scripts, container entry-points, and other cold-start
+// contexts where the full SDK is too heavy or pulls in a transitive
+// dependency that breaks the host runtime.
+//
+// It performs a single OAuth client_credentials exchange, then a
+// single GET against /organizations/{orgId}/config/values, caching the
+// values map per-process per-env so repeated reads in the same process
+// avoid the round-trip.
+//
+// Inputs (from os.Getenv):
+//
+//	SMOOAI_CONFIG_API_URL       base URL (default https://api.smoo.ai)
+//	SMOOAI_CONFIG_AUTH_URL      OAuth base URL (default https://auth.smoo.ai;
+//	                            legacy SMOOAI_AUTH_URL also accepted)
+//	SMOOAI_CONFIG_CLIENT_ID     OAuth M2M client id
+//	SMOOAI_CONFIG_CLIENT_SECRET OAuth M2M client secret
+//	                            (legacy SMOOAI_CONFIG_API_KEY accepted)
+//	SMOOAI_CONFIG_ORG_ID        target org id
+//	SMOOAI_CONFIG_ENV           default env name (fallback when no SST stage)
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Option configures a Fetch call.
+type Option func(*options)
+
+type options struct {
+	environment string
+	httpClient  *http.Client
+	getEnv      func(string) string
+}
+
+// WithEnvironment overrides the auto-detected environment name.
+func WithEnvironment(env string) Option {
+	return func(o *options) { o.environment = env }
+}
+
+// WithHTTPClient overrides the default *http.Client. Mainly for testing.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) { o.httpClient = c }
+}
+
+// withGetEnv overrides the env lookup. Test-only; not exported.
+func withGetEnv(fn func(string) string) Option {
+	return func(o *options) { o.getEnv = fn }
+}
+
+type creds struct {
+	apiURL       string
+	authURL      string
+	clientID     string
+	clientSecret string
+	orgID        string
+}
+
+func readCreds(getEnv func(string) string) (creds, error) {
+	c := creds{
+		apiURL:       firstNonEmpty(getEnv("SMOOAI_CONFIG_API_URL"), "https://api.smoo.ai"),
+		authURL:      firstNonEmpty(getEnv("SMOOAI_CONFIG_AUTH_URL"), getEnv("SMOOAI_AUTH_URL"), "https://auth.smoo.ai"),
+		clientID:     getEnv("SMOOAI_CONFIG_CLIENT_ID"),
+		clientSecret: firstNonEmpty(getEnv("SMOOAI_CONFIG_CLIENT_SECRET"), getEnv("SMOOAI_CONFIG_API_KEY")),
+		orgID:        getEnv("SMOOAI_CONFIG_ORG_ID"),
+	}
+	if c.clientID == "" || c.clientSecret == "" || c.orgID == "" {
+		return creds{}, errors.New(
+			"[smooai-config/bootstrap] missing SMOOAI_CONFIG_{CLIENT_ID,CLIENT_SECRET,ORG_ID} in env. " +
+				"Set these (e.g. via `pnpm sst shell --stage <stage>`) before calling Fetch.",
+		)
+	}
+	return c, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func resolveEnv(getEnv func(string) string, explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	stage := getEnv("SST_STAGE")
+	if stage == "" {
+		stage = getEnv("NEXT_PUBLIC_SST_STAGE")
+	}
+	if stage == "" {
+		raw := getEnv("SST_RESOURCE_App")
+		if raw != "" {
+			var parsed struct {
+				Stage string `json:"stage"`
+			}
+			if err := json.Unmarshal([]byte(raw), &parsed); err == nil && parsed.Stage != "" {
+				stage = parsed.Stage
+			}
+		}
+	}
+	if stage == "" {
+		if v := getEnv("SMOOAI_CONFIG_ENV"); v != "" {
+			return v
+		}
+		return "development"
+	}
+	if stage == "production" {
+		return "production"
+	}
+	return stage
+}
+
+// Package-level cache: one values map per env name.
+var (
+	cacheMu     sync.Mutex
+	cachedEnv   string
+	cachedVals  map[string]any
+	cacheLoaded bool
+)
+
+// resetCache clears the cache. Test-only.
+func resetCache() {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	cachedEnv = ""
+	cachedVals = nil
+	cacheLoaded = false
+}
+
+// Fetch reads a single config value by camelCase key.
+//
+// Returns ("", nil) if the key is not present in the values map; does
+// NOT return an error in that case. Only env, auth, and network
+// failures produce errors.
+//
+// The full values map is cached per-process per-env after the first
+// call so repeated reads inside the same process don't re-do the
+// OAuth + GET round-trip.
+func Fetch(ctx context.Context, key string, opts ...Option) (string, error) {
+	o := &options{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		getEnv:     os.Getenv,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	env := resolveEnv(o.getEnv, o.environment)
+
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	if !cacheLoaded || cachedEnv != env {
+		c, err := readCreds(o.getEnv)
+		if err != nil {
+			return "", err
+		}
+		token, err := mintAccessToken(ctx, o.httpClient, c)
+		if err != nil {
+			return "", err
+		}
+		vals, err := fetchValues(ctx, o.httpClient, c, token, env)
+		if err != nil {
+			return "", err
+		}
+		cachedVals = vals
+		cachedEnv = env
+		cacheLoaded = true
+	}
+
+	v, ok := cachedVals[key]
+	if !ok || v == nil {
+		return "", nil
+	}
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	case bool:
+		if t {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		// json.Unmarshal decodes numbers as float64 by default. Render
+		// integers without trailing ".0" to match the other SDKs.
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t)), nil
+		}
+		return fmt.Sprintf("%g", t), nil
+	default:
+		return fmt.Sprintf("%v", t), nil
+	}
+}
+
+func mintAccessToken(ctx context.Context, client *http.Client, c creds) (string, error) {
+	authURL := strings.TrimRight(c.authURL, "/") + "/token"
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("provider", "client_credentials")
+	form.Set("client_id", c.clientID)
+	form.Set("client_secret", c.clientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("[smooai-config/bootstrap] build OAuth request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("[smooai-config/bootstrap] OAuth token exchange: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf(
+			"[smooai-config/bootstrap] OAuth token exchange failed: HTTP %d %s",
+			resp.StatusCode, string(body),
+		)
+	}
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("[smooai-config/bootstrap] OAuth response not JSON: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", errors.New("[smooai-config/bootstrap] OAuth token endpoint returned no access_token")
+	}
+	return parsed.AccessToken, nil
+}
+
+func fetchValues(ctx context.Context, client *http.Client, c creds, token, env string) (map[string]any, error) {
+	apiURL := strings.TrimRight(c.apiURL, "/")
+	u := fmt.Sprintf(
+		"%s/organizations/%s/config/values?environment=%s",
+		apiURL, url.PathEscape(c.orgID), url.QueryEscape(env),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[smooai-config/bootstrap] build values request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("[smooai-config/bootstrap] GET /config/values: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf(
+			"[smooai-config/bootstrap] GET /config/values failed: HTTP %d %s",
+			resp.StatusCode, string(body),
+		)
+	}
+	var parsed struct {
+		Values map[string]any `json:"values"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("[smooai-config/bootstrap] values response not JSON: %w", err)
+	}
+	if parsed.Values == nil {
+		return map[string]any{}, nil
+	}
+	return parsed.Values, nil
+}

--- a/go/config/bootstrap/bootstrap_test.go
+++ b/go/config/bootstrap/bootstrap_test.go
@@ -1,0 +1,363 @@
+package bootstrap
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type capturedReq struct {
+	method string
+	url    string
+	header http.Header
+	body   string
+}
+
+type recorder struct {
+	t         *testing.T
+	responses []func(w http.ResponseWriter, r *http.Request)
+	calls     []capturedReq
+}
+
+func (r *recorder) handle(w http.ResponseWriter, req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	r.calls = append(r.calls, capturedReq{
+		method: req.Method,
+		url:    req.URL.String(),
+		header: req.Header.Clone(),
+		body:   string(body),
+	})
+	if len(r.responses) == 0 {
+		r.t.Fatalf("recorder ran out of queued responses")
+	}
+	fn := r.responses[0]
+	r.responses = r.responses[1:]
+	fn(w, req)
+}
+
+func ok(body string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+func fail(status int, body string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+func newEnvMap(pairs ...string) map[string]string {
+	m := map[string]string{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		m[pairs[i]] = pairs[i+1]
+	}
+	return m
+}
+
+func envFn(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func newRecorderServer(t *testing.T, responses ...func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, *recorder) {
+	rec := &recorder{t: t, responses: responses}
+	srv := httptest.NewServer(http.HandlerFunc(rec.handle))
+	return srv, rec
+}
+
+func baseEnv(serverURL string) map[string]string {
+	return newEnvMap(
+		"SMOOAI_CONFIG_API_URL", serverURL,
+		"SMOOAI_CONFIG_AUTH_URL", serverURL,
+		"SMOOAI_CONFIG_CLIENT_ID", "client-id-123",
+		"SMOOAI_CONFIG_CLIENT_SECRET", "client-secret-456",
+		"SMOOAI_CONFIG_ORG_ID", "org-789",
+	)
+}
+
+func TestFetch_ReturnsValueForKnownKey(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"TOKEN"}`),
+		ok(`{"values":{"databaseUrl":"postgres://x"}}`),
+	)
+	defer srv.Close()
+
+	v, err := Fetch(context.Background(), "databaseUrl",
+		withGetEnv(envFn(baseEnv(srv.URL))),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "postgres://x" {
+		t.Fatalf("got %q, want postgres://x", v)
+	}
+	if len(rec.calls) != 2 {
+		t.Fatalf("got %d HTTP calls, want 2", len(rec.calls))
+	}
+}
+
+func TestFetch_ReturnsEmptyForMissingKey(t *testing.T) {
+	resetCache()
+	srv, _ := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		ok(`{"values":{"other":"x"}}`),
+	)
+	defer srv.Close()
+
+	v, err := Fetch(context.Background(), "databaseUrl",
+		withGetEnv(envFn(baseEnv(srv.URL))),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "" {
+		t.Fatalf("got %q, want empty string", v)
+	}
+}
+
+func TestFetch_CachesValuesPerEnv(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		ok(`{"values":{"a":"1","b":"2"}}`),
+	)
+	defer srv.Close()
+
+	ctx := context.Background()
+	env := envFn(baseEnv(srv.URL))
+
+	v1, err := Fetch(ctx, "a", withGetEnv(env))
+	if err != nil || v1 != "1" {
+		t.Fatalf("a: %q err=%v", v1, err)
+	}
+	v2, err := Fetch(ctx, "b", withGetEnv(env))
+	if err != nil || v2 != "2" {
+		t.Fatalf("b: %q err=%v", v2, err)
+	}
+	if len(rec.calls) != 2 {
+		t.Fatalf("expected 2 HTTP calls (cached), got %d", len(rec.calls))
+	}
+}
+
+func TestFetch_RefetchesOnEnvChange(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"T1"}`),
+		ok(`{"values":{"a":"dev"}}`),
+		ok(`{"access_token":"T2"}`),
+		ok(`{"values":{"a":"prod"}}`),
+	)
+	defer srv.Close()
+	env := envFn(baseEnv(srv.URL))
+
+	v1, err := Fetch(context.Background(), "a", withGetEnv(env), WithEnvironment("development"))
+	if err != nil || v1 != "dev" {
+		t.Fatalf("v1: %q err=%v", v1, err)
+	}
+	v2, err := Fetch(context.Background(), "a", withGetEnv(env), WithEnvironment("production"))
+	if err != nil || v2 != "prod" {
+		t.Fatalf("v2: %q err=%v", v2, err)
+	}
+	if len(rec.calls) != 4 {
+		t.Fatalf("expected 4 HTTP calls, got %d", len(rec.calls))
+	}
+}
+
+func TestFetch_OAuthRequestShape(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"TOKEN"}`),
+		ok(`{"values":{"k":"v"}}`),
+	)
+	defer srv.Close()
+
+	_, err := Fetch(context.Background(), "k", withGetEnv(envFn(baseEnv(srv.URL))))
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	auth := rec.calls[0]
+	if auth.method != "POST" {
+		t.Fatalf("auth method = %s, want POST", auth.method)
+	}
+	if auth.url != "/token" {
+		t.Fatalf("auth url = %s, want /token", auth.url)
+	}
+	if !strings.Contains(auth.body, "grant_type=client_credentials") ||
+		!strings.Contains(auth.body, "client_id=client-id-123") ||
+		!strings.Contains(auth.body, "client_secret=client-secret-456") ||
+		!strings.Contains(auth.body, "provider=client_credentials") {
+		t.Fatalf("auth body missing required fields: %s", auth.body)
+	}
+}
+
+func TestFetch_ValuesRequestShape(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"TOKEN"}`),
+		ok(`{"values":{"k":"v"}}`),
+	)
+	defer srv.Close()
+
+	_, err := Fetch(context.Background(), "k",
+		withGetEnv(envFn(baseEnv(srv.URL))),
+		WithEnvironment("staging env"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	values := rec.calls[1]
+	if values.method != "GET" {
+		t.Fatalf("values method = %s, want GET", values.method)
+	}
+	wantPath := "/organizations/org-789/config/values?environment=staging+env"
+	// QueryEscape encodes spaces as +; both + and %20 are valid. Accept either.
+	if values.url != wantPath && values.url != "/organizations/org-789/config/values?environment=staging%20env" {
+		t.Fatalf("values url = %s, want %s", values.url, wantPath)
+	}
+	if got := values.header.Get("Authorization"); got != "Bearer TOKEN" {
+		t.Fatalf("Authorization = %q, want Bearer TOKEN", got)
+	}
+}
+
+func TestFetch_MissingCredsErrors(t *testing.T) {
+	resetCache()
+	env := baseEnv("http://example.test")
+	delete(env, "SMOOAI_CONFIG_CLIENT_ID")
+
+	_, err := Fetch(context.Background(), "k", withGetEnv(envFn(env)))
+	if err == nil || !strings.Contains(err.Error(), "CLIENT_ID,CLIENT_SECRET,ORG_ID") {
+		t.Fatalf("got err=%v, want missing-creds error", err)
+	}
+}
+
+func TestFetch_AcceptsLegacyApiKey(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		ok(`{"values":{"k":"v"}}`),
+	)
+	defer srv.Close()
+
+	env := baseEnv(srv.URL)
+	delete(env, "SMOOAI_CONFIG_CLIENT_SECRET")
+	env["SMOOAI_CONFIG_API_KEY"] = "legacy-secret"
+
+	v, err := Fetch(context.Background(), "k", withGetEnv(envFn(env)))
+	if err != nil || v != "v" {
+		t.Fatalf("v=%q err=%v", v, err)
+	}
+	if !strings.Contains(rec.calls[0].body, "client_secret=legacy-secret") {
+		t.Fatalf("body did not include legacy client_secret: %s", rec.calls[0].body)
+	}
+}
+
+func TestFetch_AcceptsLegacyAuthUrl(t *testing.T) {
+	resetCache()
+	srv, rec := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		ok(`{"values":{"k":"v"}}`),
+	)
+	defer srv.Close()
+
+	env := baseEnv(srv.URL)
+	delete(env, "SMOOAI_CONFIG_AUTH_URL")
+	env["SMOOAI_AUTH_URL"] = srv.URL
+
+	if _, err := Fetch(context.Background(), "k", withGetEnv(envFn(env))); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if rec.calls[0].url != "/token" {
+		t.Fatalf("legacy SMOOAI_AUTH_URL not used; first call URL = %s", rec.calls[0].url)
+	}
+}
+
+func TestFetch_OAuthFailureErrors(t *testing.T) {
+	resetCache()
+	srv, _ := newRecorderServer(t, fail(401, "invalid_client"))
+	defer srv.Close()
+
+	_, err := Fetch(context.Background(), "k", withGetEnv(envFn(baseEnv(srv.URL))))
+	if err == nil || !strings.Contains(err.Error(), "OAuth token exchange failed: HTTP 401") {
+		t.Fatalf("got err=%v, want OAuth 401 error", err)
+	}
+}
+
+func TestFetch_ValuesFailureErrors(t *testing.T) {
+	resetCache()
+	srv, _ := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		fail(500, "boom"),
+	)
+	defer srv.Close()
+
+	_, err := Fetch(context.Background(), "k", withGetEnv(envFn(baseEnv(srv.URL))))
+	if err == nil || !strings.Contains(err.Error(), "GET /config/values failed: HTTP 500") {
+		t.Fatalf("got err=%v, want values 500 error", err)
+	}
+}
+
+func TestFetch_OAuthMissingAccessToken(t *testing.T) {
+	resetCache()
+	srv, _ := newRecorderServer(t, ok(`{}`))
+	defer srv.Close()
+
+	_, err := Fetch(context.Background(), "k", withGetEnv(envFn(baseEnv(srv.URL))))
+	if err == nil || !strings.Contains(err.Error(), "no access_token") {
+		t.Fatalf("got err=%v, want no-access-token error", err)
+	}
+}
+
+func TestResolveEnv_Variants(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit string
+		env      map[string]string
+		want     string
+	}{
+		{"explicit wins", "explicit", newEnvMap("SST_STAGE", "ignored"), "explicit"},
+		{"SST_STAGE", "", newEnvMap("SST_STAGE", "brentrager"), "brentrager"},
+		{"NEXT_PUBLIC_SST_STAGE", "", newEnvMap("NEXT_PUBLIC_SST_STAGE", "dev-stage"), "dev-stage"},
+		{"SST_RESOURCE_App", "", newEnvMap("SST_RESOURCE_App", `{"stage":"sst-resource-stage"}`), "sst-resource-stage"},
+		{"production stays production", "", newEnvMap("SST_STAGE", "production"), "production"},
+		{"SMOOAI_CONFIG_ENV fallback", "", newEnvMap("SMOOAI_CONFIG_ENV", "qa"), "qa"},
+		{"development default", "", newEnvMap(), "development"},
+		{"malformed SST_RESOURCE_App falls through", "", newEnvMap("SST_RESOURCE_App", "{not json", "SMOOAI_CONFIG_ENV", "qa"), "qa"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEnv(envFn(tc.env), tc.explicit)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetch_StringifiesNonStringValues(t *testing.T) {
+	resetCache()
+	srv, _ := newRecorderServer(t,
+		ok(`{"access_token":"T"}`),
+		ok(`{"values":{"count":42,"flag":true,"pi":3.5}}`),
+	)
+	defer srv.Close()
+	env := envFn(baseEnv(srv.URL))
+
+	c, _ := Fetch(context.Background(), "count", withGetEnv(env))
+	if c != "42" {
+		t.Fatalf("count = %q, want 42", c)
+	}
+	f, _ := Fetch(context.Background(), "flag", withGetEnv(env))
+	if f != "true" {
+		t.Fatalf("flag = %q, want true", f)
+	}
+	p, _ := Fetch(context.Background(), "pi", withGetEnv(env))
+	if p != "3.5" {
+		t.Fatalf("pi = %q, want 3.5", p)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
             "require": "./dist/index.js",
             "default": "./dist/index.js"
         },
+        "./bootstrap": {
+            "types": "./dist/bootstrap/index.d.ts",
+            "import": "./dist/bootstrap/index.mjs",
+            "require": "./dist/bootstrap/index.js"
+        },
         "./nextjs": {
             "types": "./dist/nextjs/index.d.ts",
             "browser": {

--- a/python/src/smooai_config/bootstrap.py
+++ b/python/src/smooai_config/bootstrap.py
@@ -1,0 +1,202 @@
+"""smooai_config.bootstrap — lightweight cold-start config fetcher.
+
+This module is designed to be importable in environments where the full
+``smooai_config`` SDK is too heavy or pulls in a problematic transitive
+dependency. It uses only the Python standard library (``urllib``,
+``json``, ``os``) and has **zero** imports from anywhere else in this
+package.
+
+Use ``bootstrap_fetch(key, environment=...)`` from a deploy script,
+container entry-point, or any cold-start context to read a single config
+value via plain HTTP.
+
+It performs a single OAuth ``client_credentials`` exchange, then a
+single GET against
+``/organizations/{orgId}/config/values?environment={env}`` and caches
+the resulting values map per-process per-env so repeated reads in the
+same process avoid the round-trip.
+
+Inputs (read from ``os.environ``):
+    SMOOAI_CONFIG_API_URL       base URL (default https://api.smoo.ai)
+    SMOOAI_CONFIG_AUTH_URL      OAuth base URL
+                                (default https://auth.smoo.ai;
+                                legacy SMOOAI_AUTH_URL also accepted)
+    SMOOAI_CONFIG_CLIENT_ID     OAuth M2M client id
+    SMOOAI_CONFIG_CLIENT_SECRET OAuth M2M client secret
+                                (legacy SMOOAI_CONFIG_API_KEY accepted)
+    SMOOAI_CONFIG_ORG_ID        target org id
+    SMOOAI_CONFIG_ENV           default env name (used when ``environment``
+                                arg is omitted and no SST stage is detected)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+class BootstrapError(RuntimeError):
+    """Raised when bootstrap_fetch cannot complete (env, auth, or network)."""
+
+
+@dataclass(frozen=True)
+class _Creds:
+    api_url: str
+    auth_url: str
+    client_id: str
+    client_secret: str
+    org_id: str
+
+
+def _read_creds() -> _Creds:
+    api_url = os.environ.get("SMOOAI_CONFIG_API_URL", "https://api.smoo.ai")
+    auth_url = os.environ.get("SMOOAI_CONFIG_AUTH_URL") or os.environ.get("SMOOAI_AUTH_URL") or "https://auth.smoo.ai"
+    client_id = os.environ.get("SMOOAI_CONFIG_CLIENT_ID")
+    client_secret = os.environ.get("SMOOAI_CONFIG_CLIENT_SECRET") or os.environ.get("SMOOAI_CONFIG_API_KEY")
+    org_id = os.environ.get("SMOOAI_CONFIG_ORG_ID")
+    if not client_id or not client_secret or not org_id:
+        raise BootstrapError(
+            "[smooai_config.bootstrap] missing "
+            "SMOOAI_CONFIG_{CLIENT_ID,CLIENT_SECRET,ORG_ID} in env. "
+            "Set these (e.g. via `pnpm sst shell --stage <stage>`) before "
+            "calling bootstrap_fetch."
+        )
+    return _Creds(
+        api_url=api_url,
+        auth_url=auth_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        org_id=org_id,
+    )
+
+
+def _resolve_env(environment: str | None) -> str:
+    if environment:
+        return environment
+    stage = os.environ.get("SST_STAGE") or os.environ.get("NEXT_PUBLIC_SST_STAGE")
+    if not stage:
+        raw = os.environ.get("SST_RESOURCE_App")
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict) and isinstance(parsed.get("stage"), str):
+                    stage = parsed["stage"]
+            except (json.JSONDecodeError, ValueError):
+                pass
+    if not stage:
+        return os.environ.get("SMOOAI_CONFIG_ENV", "development")
+    if stage == "production":
+        return "production"
+    return stage
+
+
+def _http_post(url: str, data: bytes, headers: dict[str, str]) -> tuple[int, bytes]:
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310 - plain HTTPS to known hosts
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _http_get(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310 - plain HTTPS to known hosts
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _mint_access_token(creds: _Creds) -> str:
+    auth_url = creds.auth_url.rstrip("/")
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "provider": "client_credentials",
+            "client_id": creds.client_id,
+            "client_secret": creds.client_secret,
+        }
+    ).encode("utf-8")
+    status, raw = _http_post(
+        f"{auth_url}/token",
+        body,
+        {"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    if status < 200 or status >= 300:
+        raise BootstrapError(
+            f"[smooai_config.bootstrap] OAuth token exchange failed: HTTP {status} "
+            f"{raw.decode('utf-8', errors='replace')}"
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise BootstrapError(f"[smooai_config.bootstrap] OAuth token response was not valid JSON: {e}") from e
+    token = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token:
+        raise BootstrapError("[smooai_config.bootstrap] OAuth token endpoint returned no access_token")
+    return token
+
+
+_cached_values: dict[str, Any] | None = None
+_cached_env: str | None = None
+
+
+def _reset_cache() -> None:
+    """Test-only: clear the in-process cache. Not part of the public API."""
+    global _cached_values, _cached_env
+    _cached_values = None
+    _cached_env = None
+
+
+def bootstrap_fetch(key: str, environment: str | None = None) -> str | None:
+    """Fetch a single config value by camelCase key.
+
+    Returns ``None`` if the key is not present in the values map. Does
+    NOT raise on missing keys — only on env/auth/network errors.
+
+    The full values map is cached per-process per-env after the first
+    call so repeated reads inside the same process don't re-do the
+    OAuth + GET round-trip.
+    """
+    global _cached_values, _cached_env
+
+    env = _resolve_env(environment)
+    if _cached_values is None or _cached_env != env:
+        creds = _read_creds()
+        token = _mint_access_token(creds)
+        api_url = creds.api_url.rstrip("/")
+        url = (
+            f"{api_url}/organizations/{urllib.parse.quote(creds.org_id, safe='')}"
+            f"/config/values?environment={urllib.parse.quote(env, safe='')}"
+        )
+        status, raw = _http_get(
+            url,
+            {"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        )
+        if status < 200 or status >= 300:
+            raise BootstrapError(
+                f"[smooai_config.bootstrap] GET /config/values failed: HTTP {status} "
+                f"{raw.decode('utf-8', errors='replace')}"
+            )
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            raise BootstrapError(f"[smooai_config.bootstrap] values response was not valid JSON: {e}") from e
+        values = payload.get("values") if isinstance(payload, dict) else None
+        _cached_values = values if isinstance(values, dict) else {}
+        _cached_env = env
+
+    raw_value = _cached_values.get(key)
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        return raw_value
+    if isinstance(raw_value, bool):
+        return "true" if raw_value else "false"
+    return str(raw_value)

--- a/python/tests/test_bootstrap.py
+++ b/python/tests/test_bootstrap.py
@@ -1,0 +1,237 @@
+"""Tests for smooai_config.bootstrap — plain-HTTP cold-start config reader."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from smooai_config import bootstrap as bs
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # Clear bootstrap cache + all SMOOAI_/SST_ env vars before each test.
+    bs._reset_cache()
+    import os
+
+    for key in list(os.environ.keys()):
+        if key.startswith(("SMOOAI_", "SST_")) or key == "NEXT_PUBLIC_SST_STAGE":
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("SMOOAI_CONFIG_API_URL", "https://api.example.test")
+    monkeypatch.setenv("SMOOAI_CONFIG_AUTH_URL", "https://auth.example.test")
+    monkeypatch.setenv("SMOOAI_CONFIG_CLIENT_ID", "client-id-123")
+    monkeypatch.setenv("SMOOAI_CONFIG_CLIENT_SECRET", "client-secret-456")
+    monkeypatch.setenv("SMOOAI_CONFIG_ORG_ID", "org-789")
+    yield
+    bs._reset_cache()
+
+
+class _HttpRecorder:
+    def __init__(self, queue: list[tuple[int, dict[str, Any]]]) -> None:
+        self._queue = queue
+        self.calls: list[tuple[str, str, dict[str, str], bytes | None]] = []
+
+    def post(self, url: str, data: bytes, headers: dict[str, str]) -> tuple[int, bytes]:
+        status, body = self._queue.pop(0)
+        self.calls.append(("POST", url, headers, data))
+        return status, json.dumps(body).encode("utf-8")
+
+    def get(self, url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+        status, body = self._queue.pop(0)
+        self.calls.append(("GET", url, headers, None))
+        return status, json.dumps(body).encode("utf-8")
+
+
+def _patch_http(recorder: _HttpRecorder) -> Any:
+    return patch.multiple(
+        bs,
+        _http_post=recorder.post,
+        _http_get=recorder.get,
+    )
+
+
+def _ok_pair(token_body: dict[str, Any], values_body: dict[str, Any]) -> list[tuple[int, dict[str, Any]]]:
+    return [(200, token_body), (200, values_body)]
+
+
+def test_returns_value_for_known_key() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "TOKEN"}, {"values": {"databaseUrl": "postgres://x"}}))
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("databaseUrl") == "postgres://x"
+    assert len(rec.calls) == 2
+
+
+def test_returns_none_for_missing_key() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"other": "x"}}))
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("databaseUrl") is None
+
+
+def test_caches_values_per_env() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"a": "1", "b": "2"}}))
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("a") == "1"
+        assert bs.bootstrap_fetch("b") == "2"
+    # Only 2 HTTP round trips total, even though we read 2 keys.
+    assert len(rec.calls) == 2
+
+
+def test_refetches_on_env_change() -> None:
+    rec = _HttpRecorder(
+        [
+            (200, {"access_token": "T1"}),
+            (200, {"values": {"a": "dev"}}),
+            (200, {"access_token": "T2"}),
+            (200, {"values": {"a": "prod"}}),
+        ]
+    )
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("a", environment="development") == "dev"
+        assert bs.bootstrap_fetch("a", environment="production") == "prod"
+    assert len(rec.calls) == 4
+
+
+def test_oauth_body_shape() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"k": "v"}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    auth_call = rec.calls[0]
+    assert auth_call[0] == "POST"
+    assert auth_call[1] == "https://auth.example.test/token"
+    assert auth_call[2]["Content-Type"] == "application/x-www-form-urlencoded"
+    body = (auth_call[3] or b"").decode("utf-8")
+    assert "grant_type=client_credentials" in body
+    assert "client_id=client-id-123" in body
+    assert "client_secret=client-secret-456" in body
+    assert "provider=client_credentials" in body
+
+
+def test_values_url_and_bearer() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "TOKEN"}, {"values": {"k": "v"}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k", environment="staging env")
+    values_call = rec.calls[1]
+    assert values_call[0] == "GET"
+    assert values_call[1] == ("https://api.example.test/organizations/org-789/config/values?environment=staging%20env")
+    assert values_call[2]["Authorization"] == "Bearer TOKEN"
+
+
+def test_throws_when_creds_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOOAI_CONFIG_CLIENT_ID")
+    with pytest.raises(bs.BootstrapError, match=r"CLIENT_ID,CLIENT_SECRET,ORG_ID"):
+        bs.bootstrap_fetch("k")
+
+
+def test_accepts_legacy_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOOAI_CONFIG_CLIENT_SECRET")
+    monkeypatch.setenv("SMOOAI_CONFIG_API_KEY", "legacy-secret")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"k": "v"}}))
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("k") == "v"
+    body = (rec.calls[0][3] or b"").decode("utf-8")
+    assert "client_secret=legacy-secret" in body
+
+
+def test_accepts_legacy_auth_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOOAI_CONFIG_AUTH_URL")
+    monkeypatch.setenv("SMOOAI_AUTH_URL", "https://legacy-auth.example.test")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"k": "v"}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert rec.calls[0][1] == "https://legacy-auth.example.test/token"
+
+
+def test_oauth_failure_raises() -> None:
+    rec = _HttpRecorder([(401, {"error": "invalid_client"})])
+    with _patch_http(rec):
+        with pytest.raises(bs.BootstrapError, match=r"OAuth token exchange failed: HTTP 401"):
+            bs.bootstrap_fetch("k")
+
+
+def test_values_failure_raises() -> None:
+    rec = _HttpRecorder([(200, {"access_token": "T"}), (500, {"error": "boom"})])
+    with _patch_http(rec):
+        with pytest.raises(bs.BootstrapError, match=r"GET /config/values failed: HTTP 500"):
+            bs.bootstrap_fetch("k")
+
+
+def test_oauth_missing_access_token_raises() -> None:
+    rec = _HttpRecorder([(200, {})])
+    with _patch_http(rec):
+        with pytest.raises(bs.BootstrapError, match=r"no access_token"):
+            bs.bootstrap_fetch("k")
+
+
+def test_env_resolution_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SST_STAGE", "ignored")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k", environment="explicit")
+    assert "environment=explicit" in rec.calls[1][1]
+
+
+def test_env_resolution_sst_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SST_STAGE", "brentrager")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=brentrager" in rec.calls[1][1]
+
+
+def test_env_resolution_next_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXT_PUBLIC_SST_STAGE", "dev-stage")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=dev-stage" in rec.calls[1][1]
+
+
+def test_env_resolution_sst_resource_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SST_RESOURCE_App", json.dumps({"stage": "sst-resource-stage"}))
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=sst-resource-stage" in rec.calls[1][1]
+
+
+def test_env_resolution_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SST_STAGE", "production")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=production" in rec.calls[1][1]
+
+
+def test_env_resolution_smooai_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOOAI_CONFIG_ENV", "qa")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=qa" in rec.calls[1][1]
+
+
+def test_env_resolution_development_default() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=development" in rec.calls[1][1]
+
+
+def test_malformed_sst_resource_app_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SST_RESOURCE_App", "{not json")
+    monkeypatch.setenv("SMOOAI_CONFIG_ENV", "qa")
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {}}))
+    with _patch_http(rec):
+        bs.bootstrap_fetch("k")
+    assert "environment=qa" in rec.calls[1][1]
+
+
+def test_non_string_values_are_stringified() -> None:
+    rec = _HttpRecorder(_ok_pair({"access_token": "T"}, {"values": {"count": 42, "flag": True}}))
+    with _patch_http(rec):
+        assert bs.bootstrap_fetch("count") == "42"
+        assert bs.bootstrap_fetch("flag") == "true"

--- a/rust/config/src/bootstrap.rs
+++ b/rust/config/src/bootstrap.rs
@@ -1,0 +1,593 @@
+//! Lightweight cold-start config fetcher.
+//!
+//! This module exists for callers that need to read a single config
+//! value from a deploy script, container entry-point, or other
+//! cold-start context where the full SDK is too heavy or pulls in a
+//! problematic transitive dependency.
+//!
+//! It has **zero** imports from other modules in this crate and uses
+//! only `reqwest` + `serde_json` (which are already crate deps).
+//!
+//! It performs a single OAuth `client_credentials` exchange, then a
+//! single GET against `/organizations/{org_id}/config/values` and
+//! caches the values map per-process per-env so repeated reads inside
+//! the same process avoid the round-trip.
+//!
+//! Inputs (read from `std::env`):
+//!
+//! - `SMOOAI_CONFIG_API_URL` — base URL (default `https://api.smoo.ai`)
+//! - `SMOOAI_CONFIG_AUTH_URL` — OAuth base URL (default `https://auth.smoo.ai`;
+//!   legacy `SMOOAI_AUTH_URL` also accepted)
+//! - `SMOOAI_CONFIG_CLIENT_ID` — OAuth M2M client id
+//! - `SMOOAI_CONFIG_CLIENT_SECRET` — OAuth M2M client secret
+//!   (legacy `SMOOAI_CONFIG_API_KEY` accepted)
+//! - `SMOOAI_CONFIG_ORG_ID` — target org id
+//! - `SMOOAI_CONFIG_ENV` — default env name (fallback when no SST stage)
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use serde_json::Value;
+use thiserror::Error;
+
+/// URL-encode characters: anything not in unreserved set per RFC 3986.
+/// (alphanumeric, `-`, `_`, `.`, `~` are left alone — same as JS encodeURIComponent.)
+const URL_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+/// Errors returned by [`bootstrap_fetch`].
+#[derive(Debug, Error)]
+pub enum BootstrapError {
+    #[error("[smooai-config/bootstrap] missing SMOOAI_CONFIG_{{CLIENT_ID,CLIENT_SECRET,ORG_ID}} in env. Set these (e.g. via `pnpm sst shell --stage <stage>`) before calling bootstrap_fetch.")]
+    MissingCredentials,
+    #[error("[smooai-config/bootstrap] OAuth token exchange failed: HTTP {status} {body}")]
+    OAuthFailed { status: u16, body: String },
+    #[error("[smooai-config/bootstrap] OAuth token endpoint returned no access_token")]
+    MissingAccessToken,
+    #[error("[smooai-config/bootstrap] GET /config/values failed: HTTP {status} {body}")]
+    ValuesFailed { status: u16, body: String },
+    #[error("[smooai-config/bootstrap] HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("[smooai-config/bootstrap] response not JSON: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone)]
+struct BootstrapCreds {
+    api_url: String,
+    auth_url: String,
+    client_id: String,
+    client_secret: String,
+    org_id: String,
+}
+
+fn first_non_empty(values: &[Option<String>]) -> Option<String> {
+    values
+        .iter()
+        .find_map(|v| v.as_ref().filter(|s| !s.is_empty()).cloned())
+}
+
+fn read_creds(env: &HashMap<String, String>) -> Result<BootstrapCreds, BootstrapError> {
+    let api_url = env
+        .get("SMOOAI_CONFIG_API_URL")
+        .cloned()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "https://api.smoo.ai".to_string());
+    let auth_url = first_non_empty(&[
+        env.get("SMOOAI_CONFIG_AUTH_URL").cloned(),
+        env.get("SMOOAI_AUTH_URL").cloned(),
+    ])
+    .unwrap_or_else(|| "https://auth.smoo.ai".to_string());
+    let client_id = env.get("SMOOAI_CONFIG_CLIENT_ID").cloned().unwrap_or_default();
+    let client_secret = first_non_empty(&[
+        env.get("SMOOAI_CONFIG_CLIENT_SECRET").cloned(),
+        env.get("SMOOAI_CONFIG_API_KEY").cloned(),
+    ])
+    .unwrap_or_default();
+    let org_id = env.get("SMOOAI_CONFIG_ORG_ID").cloned().unwrap_or_default();
+
+    if client_id.is_empty() || client_secret.is_empty() || org_id.is_empty() {
+        return Err(BootstrapError::MissingCredentials);
+    }
+    Ok(BootstrapCreds {
+        api_url,
+        auth_url,
+        client_id,
+        client_secret,
+        org_id,
+    })
+}
+
+fn resolve_env(env: &HashMap<String, String>, explicit: Option<&str>) -> String {
+    if let Some(e) = explicit {
+        if !e.is_empty() {
+            return e.to_string();
+        }
+    }
+    let mut stage = env.get("SST_STAGE").cloned().filter(|s| !s.is_empty());
+    if stage.is_none() {
+        stage = env.get("NEXT_PUBLIC_SST_STAGE").cloned().filter(|s| !s.is_empty());
+    }
+    if stage.is_none() {
+        if let Some(raw) = env.get("SST_RESOURCE_App").filter(|s| !s.is_empty()) {
+            if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
+                if let Some(s) = parsed.get("stage").and_then(|v| v.as_str()) {
+                    if !s.is_empty() {
+                        stage = Some(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    match stage {
+        Some(s) if s == "production" => "production".to_string(),
+        Some(s) => s,
+        None => env
+            .get("SMOOAI_CONFIG_ENV")
+            .cloned()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "development".to_string()),
+    }
+}
+
+/// In-process cache of fetched values, keyed by env name.
+static CACHE: Mutex<Option<(String, HashMap<String, Value>)>> = Mutex::new(None);
+
+/// Test-only: clear the in-process cache.
+#[doc(hidden)]
+pub fn __reset_bootstrap_cache() {
+    let mut guard = CACHE.lock().unwrap();
+    *guard = None;
+}
+
+fn env_map() -> HashMap<String, String> {
+    std::env::vars().collect()
+}
+
+/// Fetch a single config value by camelCase key.
+///
+/// Returns `Ok(None)` if the key is not present in the values map. Only
+/// env, auth, and network failures produce errors.
+///
+/// The full values map is cached per-process per-env after the first
+/// call.
+pub async fn bootstrap_fetch(key: &str, environment: Option<&str>) -> Result<Option<String>, BootstrapError> {
+    bootstrap_fetch_with_env(key, environment, &env_map(), &reqwest::Client::new()).await
+}
+
+/// Same as [`bootstrap_fetch`] but with an explicit env map and client.
+/// Useful for tests; not part of the stable public API.
+#[doc(hidden)]
+pub async fn bootstrap_fetch_with_env(
+    key: &str,
+    environment: Option<&str>,
+    env: &HashMap<String, String>,
+    client: &reqwest::Client,
+) -> Result<Option<String>, BootstrapError> {
+    let env_name = resolve_env(env, environment);
+
+    let need_fetch = {
+        let guard = CACHE.lock().unwrap();
+        match guard.as_ref() {
+            Some((cached_env, _)) => cached_env != &env_name,
+            None => true,
+        }
+    };
+
+    if need_fetch {
+        let creds = read_creds(env)?;
+        let token = mint_access_token(client, &creds).await?;
+        let values = fetch_values(client, &creds, &token, &env_name).await?;
+        let mut guard = CACHE.lock().unwrap();
+        *guard = Some((env_name.clone(), values));
+    }
+
+    let guard = CACHE.lock().unwrap();
+    let values = &guard.as_ref().expect("cache populated above").1;
+    Ok(values.get(key).and_then(value_to_string))
+}
+
+fn value_to_string(v: &Value) -> Option<String> {
+    match v {
+        Value::Null => None,
+        Value::String(s) => Some(s.clone()),
+        Value::Bool(b) => Some(if *b { "true".to_string() } else { "false".to_string() }),
+        Value::Number(n) => Some(n.to_string()),
+        other => Some(other.to_string()),
+    }
+}
+
+async fn mint_access_token(client: &reqwest::Client, creds: &BootstrapCreds) -> Result<String, BootstrapError> {
+    let auth_base = creds.auth_url.trim_end_matches('/');
+    let url = format!("{}/token", auth_base);
+    let form = [
+        ("grant_type", "client_credentials"),
+        ("provider", "client_credentials"),
+        ("client_id", creds.client_id.as_str()),
+        ("client_secret", creds.client_secret.as_str()),
+    ];
+
+    let resp = client.post(&url).form(&form).send().await?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(BootstrapError::OAuthFailed {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    let parsed: Value = serde_json::from_str(&body)?;
+    let token = parsed
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    token
+        .filter(|t| !t.is_empty())
+        .ok_or(BootstrapError::MissingAccessToken)
+}
+
+async fn fetch_values(
+    client: &reqwest::Client,
+    creds: &BootstrapCreds,
+    token: &str,
+    env: &str,
+) -> Result<HashMap<String, Value>, BootstrapError> {
+    let api_base = creds.api_url.trim_end_matches('/');
+    let org = utf8_percent_encode(&creds.org_id, URL_ENCODE_SET).to_string();
+    let env_enc = utf8_percent_encode(env, URL_ENCODE_SET).to_string();
+    let url = format!(
+        "{}/organizations/{}/config/values?environment={}",
+        api_base, org, env_enc
+    );
+    let resp = client
+        .get(&url)
+        .bearer_auth(token)
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(BootstrapError::ValuesFailed {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    let parsed: Value = serde_json::from_str(&body)?;
+    let values = parsed
+        .get("values")
+        .and_then(|v| v.as_object())
+        .map(|m| {
+            m.iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<HashMap<String, Value>>()
+        })
+        .unwrap_or_default();
+    Ok(values)
+}
+
+#[cfg(test)]
+#[allow(clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex as StdMutex;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // All bootstrap_fetch_with_env tests share the process-wide CACHE,
+    // so we serialize them with a dedicated mutex.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn lock_and_reset() -> std::sync::MutexGuard<'static, ()> {
+        // Recover from any prior poisoned panic so a single failing
+        // test doesn't break the rest of the suite.
+        let g = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        super::__reset_bootstrap_cache();
+        g
+    }
+
+    fn base_env(server_url: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("SMOOAI_CONFIG_API_URL".into(), server_url.into());
+        m.insert("SMOOAI_CONFIG_AUTH_URL".into(), server_url.into());
+        m.insert("SMOOAI_CONFIG_CLIENT_ID".into(), "client-id-123".into());
+        m.insert("SMOOAI_CONFIG_CLIENT_SECRET".into(), "client-secret-456".into());
+        m.insert("SMOOAI_CONFIG_ORG_ID".into(), "org-789".into());
+        m
+    }
+
+    async fn mount_oauth_ok(server: &MockServer, token: &str) {
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"access_token": token})))
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_values(server: &MockServer, env: &str, values: serde_json::Value) {
+        Mock::given(method("GET"))
+            .and(path("/organizations/org-789/config/values"))
+            .and(query_param("environment", env))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"values": values})))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn returns_value_for_known_key() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        mount_oauth_ok(&server, "TOKEN").await;
+        mount_values(&server, "development", json!({"databaseUrl": "postgres://x"})).await;
+        let env = base_env(&server.uri());
+        let v = bootstrap_fetch_with_env("databaseUrl", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap();
+        assert_eq!(v, Some("postgres://x".to_string()));
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_missing_key() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        mount_oauth_ok(&server, "T").await;
+        mount_values(&server, "development", json!({"other": "x"})).await;
+        let env = base_env(&server.uri());
+        let v = bootstrap_fetch_with_env("databaseUrl", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap();
+        assert_eq!(v, None);
+    }
+
+    #[tokio::test]
+    async fn caches_values_per_env() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        // Each mount with `expect(1)` would fail if called more than once.
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"access_token": "T"})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/organizations/org-789/config/values"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"values": {"a": "1", "b": "2"}})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let env = base_env(&server.uri());
+        let c = reqwest::Client::new();
+        assert_eq!(
+            bootstrap_fetch_with_env("a", None, &env, &c).await.unwrap(),
+            Some("1".into())
+        );
+        assert_eq!(
+            bootstrap_fetch_with_env("b", None, &env, &c).await.unwrap(),
+            Some("2".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn refetches_on_env_change() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"access_token": "T"})))
+            .expect(2)
+            .mount(&server)
+            .await;
+        mount_values(&server, "development", json!({"a": "dev"})).await;
+        mount_values(&server, "production", json!({"a": "prod"})).await;
+        let env = base_env(&server.uri());
+        let c = reqwest::Client::new();
+        assert_eq!(
+            bootstrap_fetch_with_env("a", Some("development"), &env, &c)
+                .await
+                .unwrap(),
+            Some("dev".into())
+        );
+        assert_eq!(
+            bootstrap_fetch_with_env("a", Some("production"), &env, &c)
+                .await
+                .unwrap(),
+            Some("prod".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_creds_errors() {
+        let _g = lock_and_reset();
+        let mut env = base_env("http://example.test");
+        env.remove("SMOOAI_CONFIG_CLIENT_ID");
+        let err = bootstrap_fetch_with_env("k", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap_err();
+        matches!(err, BootstrapError::MissingCredentials);
+    }
+
+    #[tokio::test]
+    async fn accepts_legacy_api_key() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(wiremock::matchers::body_string_contains("client_secret=legacy-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"access_token": "T"})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        mount_values(&server, "development", json!({"k": "v"})).await;
+        let mut env = base_env(&server.uri());
+        env.remove("SMOOAI_CONFIG_CLIENT_SECRET");
+        env.insert("SMOOAI_CONFIG_API_KEY".into(), "legacy-secret".into());
+        let v = bootstrap_fetch_with_env("k", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap();
+        assert_eq!(v, Some("v".into()));
+    }
+
+    #[tokio::test]
+    async fn oauth_failure_returns_error() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid_client"))
+            .mount(&server)
+            .await;
+        let env = base_env(&server.uri());
+        let err = bootstrap_fetch_with_env("k", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap_err();
+        match err {
+            BootstrapError::OAuthFailed { status, .. } => assert_eq!(status, 401),
+            _ => panic!("expected OAuthFailed, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn values_failure_returns_error() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        mount_oauth_ok(&server, "T").await;
+        Mock::given(method("GET"))
+            .and(path("/organizations/org-789/config/values"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let env = base_env(&server.uri());
+        let err = bootstrap_fetch_with_env("k", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap_err();
+        match err {
+            BootstrapError::ValuesFailed { status, .. } => assert_eq!(status, 500),
+            _ => panic!("expected ValuesFailed, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn oauth_missing_access_token_errors() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+        let env = base_env(&server.uri());
+        let err = bootstrap_fetch_with_env("k", None, &env, &reqwest::Client::new())
+            .await
+            .unwrap_err();
+        matches!(err, BootstrapError::MissingAccessToken);
+    }
+
+    #[test]
+    fn resolve_env_explicit_wins() {
+        let mut env = HashMap::new();
+        env.insert("SST_STAGE".into(), "ignored".into());
+        assert_eq!(resolve_env(&env, Some("explicit")), "explicit");
+    }
+
+    #[test]
+    fn resolve_env_sst_stage() {
+        let mut env = HashMap::new();
+        env.insert("SST_STAGE".into(), "brentrager".into());
+        assert_eq!(resolve_env(&env, None), "brentrager");
+    }
+
+    #[test]
+    fn resolve_env_next_public_stage() {
+        let mut env = HashMap::new();
+        env.insert("NEXT_PUBLIC_SST_STAGE".into(), "dev-stage".into());
+        assert_eq!(resolve_env(&env, None), "dev-stage");
+    }
+
+    #[test]
+    fn resolve_env_sst_resource_app() {
+        let mut env = HashMap::new();
+        env.insert("SST_RESOURCE_App".into(), r#"{"stage":"sst-resource-stage"}"#.into());
+        assert_eq!(resolve_env(&env, None), "sst-resource-stage");
+    }
+
+    #[test]
+    fn resolve_env_production() {
+        let mut env = HashMap::new();
+        env.insert("SST_STAGE".into(), "production".into());
+        assert_eq!(resolve_env(&env, None), "production");
+    }
+
+    #[test]
+    fn resolve_env_smooai_env_fallback() {
+        let mut env = HashMap::new();
+        env.insert("SMOOAI_CONFIG_ENV".into(), "qa".into());
+        assert_eq!(resolve_env(&env, None), "qa");
+    }
+
+    #[test]
+    fn resolve_env_development_default() {
+        let env = HashMap::new();
+        assert_eq!(resolve_env(&env, None), "development");
+    }
+
+    #[test]
+    fn resolve_env_malformed_sst_resource_app_falls_through() {
+        let mut env = HashMap::new();
+        env.insert("SST_RESOURCE_App".into(), "{not json".into());
+        env.insert("SMOOAI_CONFIG_ENV".into(), "qa".into());
+        assert_eq!(resolve_env(&env, None), "qa");
+    }
+
+    #[tokio::test]
+    async fn stringifies_non_string_values() {
+        let _g = lock_and_reset();
+        let server = MockServer::start().await;
+        mount_oauth_ok(&server, "T").await;
+        mount_values(&server, "development", json!({"count": 42, "flag": true, "pi": 3.5})).await;
+        let env = base_env(&server.uri());
+        let c = reqwest::Client::new();
+        assert_eq!(
+            bootstrap_fetch_with_env("count", None, &env, &c).await.unwrap(),
+            Some("42".into())
+        );
+        assert_eq!(
+            bootstrap_fetch_with_env("flag", None, &env, &c).await.unwrap(),
+            Some("true".into())
+        );
+        assert_eq!(
+            bootstrap_fetch_with_env("pi", None, &env, &c).await.unwrap(),
+            Some("3.5".into())
+        );
+    }
+}

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides schema definition, JSON Schema generation, runtime config client,
 //! and local file/env-based configuration with caching.
 
+pub mod bootstrap;
 pub mod build;
 pub mod client;
 pub mod cloud_region;
@@ -17,6 +18,7 @@ pub mod schema;
 pub mod schema_validator;
 pub mod utils;
 
+pub use bootstrap::{bootstrap_fetch, BootstrapError};
 pub use build::{build_bundle, BuildBundleOptions, BuildBundleResult, BuildError, Classification, Classifier};
 pub use client::{ConfigClient, EvaluateFeatureFlagResponse, FeatureFlagEvaluationError};
 pub use cloud_region::{get_cloud_region, get_cloud_region_from_env, CloudRegionResult};

--- a/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/src/bootstrap/__tests__/bootstrap.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetBootstrapCacheForTests, bootstrapFetch } from '../index';
+
+// Snapshot + restore process.env for full test isolation.
+const originalEnv = { ...process.env };
+
+function clearSmooEnv() {
+    for (const key of Object.keys(process.env)) {
+        if (key.startsWith('SMOOAI_') || key.startsWith('SST_') || key === 'NEXT_PUBLIC_SST_STAGE') {
+            delete process.env[key];
+        }
+    }
+}
+
+function setBaseEnv() {
+    process.env.SMOOAI_CONFIG_API_URL = 'https://api.example.test';
+    process.env.SMOOAI_CONFIG_AUTH_URL = 'https://auth.example.test';
+    process.env.SMOOAI_CONFIG_CLIENT_ID = 'client-id-123';
+    process.env.SMOOAI_CONFIG_CLIENT_SECRET = 'client-secret-456';
+    process.env.SMOOAI_CONFIG_ORG_ID = 'org-789';
+}
+
+type FetchArgs = [input: string | URL, init?: RequestInit];
+
+function mockFetchResponses(responses: Array<{ ok?: boolean; status?: number; body: unknown; text?: string }>) {
+    const fetchMock = vi.fn(async (..._args: FetchArgs) => {
+        const next = responses.shift();
+        if (!next) throw new Error('mock fetch ran out of queued responses');
+        const ok = next.ok ?? true;
+        const status = next.status ?? (ok ? 200 : 500);
+        return {
+            ok,
+            status,
+            json: async () => next.body,
+            text: async () => next.text ?? JSON.stringify(next.body),
+        } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+describe('bootstrapFetch', () => {
+    beforeEach(() => {
+        clearSmooEnv();
+        resetBootstrapCacheForTests();
+        setBaseEnv();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        // restore env
+        for (const key of Object.keys(process.env)) {
+            if (!(key in originalEnv)) delete process.env[key];
+        }
+        for (const [k, v] of Object.entries(originalEnv)) {
+            process.env[k] = v;
+        }
+    });
+
+    it('returns the value for a known key', async () => {
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { databaseUrl: 'postgres://example' } } }]);
+
+        const value = await bootstrapFetch('databaseUrl');
+        expect(value).toBe('postgres://example');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns undefined for a missing key without throwing', async () => {
+        mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { otherKey: 'x' } } }]);
+
+        const value = await bootstrapFetch('databaseUrl');
+        expect(value).toBeUndefined();
+    });
+
+    it('caches the values map per env across calls', async () => {
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { a: '1', b: '2' } } }]);
+
+        const a = await bootstrapFetch('a');
+        const b = await bootstrapFetch('b');
+        expect(a).toBe('1');
+        expect(b).toBe('2');
+        // Only 2 HTTP calls total (token + values), not 4.
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-fetches when the resolved env changes', async () => {
+        const fetchMock = mockFetchResponses([
+            { body: { access_token: 'T1' } },
+            { body: { values: { a: 'dev' } } },
+            { body: { access_token: 'T2' } },
+            { body: { values: { a: 'prod' } } },
+        ]);
+
+        const a1 = await bootstrapFetch('a', { environment: 'development' });
+        const a2 = await bootstrapFetch('a', { environment: 'production' });
+        expect(a1).toBe('dev');
+        expect(a2).toBe('prod');
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('sends OAuth client_credentials with the expected body', async () => {
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { k: 'v' } } }]);
+        await bootstrapFetch('k');
+
+        const [authUrl, authInit] = fetchMock.mock.calls[0]!;
+        expect(authUrl).toBe('https://auth.example.test/token');
+        expect(authInit!.method).toBe('POST');
+        const body = String(authInit!.body);
+        expect(body).toContain('grant_type=client_credentials');
+        expect(body).toContain('client_id=client-id-123');
+        expect(body).toContain('client_secret=client-secret-456');
+        expect(body).toContain('provider=client_credentials');
+    });
+
+    it('sends the values GET with bearer token and url-encoded environment', async () => {
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { k: 'v' } } }]);
+        await bootstrapFetch('k', { environment: 'staging env' });
+
+        const [valuesUrl, valuesInit] = fetchMock.mock.calls[1]!;
+        expect(valuesUrl).toBe('https://api.example.test/organizations/org-789/config/values?environment=staging%20env');
+        const headers = valuesInit!.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer TOKEN');
+    });
+
+    it('throws when required env vars are missing', async () => {
+        delete process.env.SMOOAI_CONFIG_CLIENT_ID;
+        await expect(bootstrapFetch('k')).rejects.toThrow(/SMOOAI_CONFIG_\{CLIENT_ID,CLIENT_SECRET,ORG_ID\}/);
+    });
+
+    it('accepts legacy SMOOAI_CONFIG_API_KEY as client secret', async () => {
+        delete process.env.SMOOAI_CONFIG_CLIENT_SECRET;
+        process.env.SMOOAI_CONFIG_API_KEY = 'legacy-secret';
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { k: 'v' } } }]);
+        const value = await bootstrapFetch('k');
+        expect(value).toBe('v');
+        const body = String(fetchMock.mock.calls[0]![1]!.body);
+        expect(body).toContain('client_secret=legacy-secret');
+    });
+
+    it('accepts legacy SMOOAI_AUTH_URL when SMOOAI_CONFIG_AUTH_URL absent', async () => {
+        delete process.env.SMOOAI_CONFIG_AUTH_URL;
+        process.env.SMOOAI_AUTH_URL = 'https://legacy-auth.example.test';
+        const fetchMock = mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { body: { values: { k: 'v' } } }]);
+        await bootstrapFetch('k');
+        expect(fetchMock.mock.calls[0]![0]).toBe('https://legacy-auth.example.test/token');
+    });
+
+    it('throws a clear error when the OAuth call fails', async () => {
+        mockFetchResponses([{ ok: false, status: 401, body: {}, text: 'invalid_client' }]);
+        await expect(bootstrapFetch('k')).rejects.toThrow(/OAuth token exchange failed: HTTP 401 invalid_client/);
+    });
+
+    it('throws a clear error when the values call fails', async () => {
+        mockFetchResponses([{ body: { access_token: 'TOKEN' } }, { ok: false, status: 500, body: {}, text: 'boom' }]);
+        await expect(bootstrapFetch('k')).rejects.toThrow(/GET \/config\/values failed: HTTP 500 boom/);
+    });
+
+    it('throws when the OAuth response is missing access_token', async () => {
+        mockFetchResponses([{ body: {} }]);
+        await expect(bootstrapFetch('k')).rejects.toThrow(/no access_token/);
+    });
+
+    describe('environment resolution', () => {
+        it('uses explicit options.environment first', async () => {
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            process.env.SST_STAGE = 'should-be-ignored';
+            await bootstrapFetch('k', { environment: 'explicit-env' });
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=explicit-env');
+        });
+
+        it('uses SST_STAGE when no explicit env', async () => {
+            process.env.SST_STAGE = 'brentrager';
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=brentrager');
+        });
+
+        it('uses NEXT_PUBLIC_SST_STAGE as a fallback for stage', async () => {
+            process.env.NEXT_PUBLIC_SST_STAGE = 'dev-stage';
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=dev-stage');
+        });
+
+        it('parses SST_RESOURCE_App JSON for stage', async () => {
+            process.env.SST_RESOURCE_App = JSON.stringify({ stage: 'sst-resource-stage' });
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=sst-resource-stage');
+        });
+
+        it('maps stage=production to environment=production', async () => {
+            process.env.SST_STAGE = 'production';
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=production');
+        });
+
+        it('uses SMOOAI_CONFIG_ENV when no stage env vars are set', async () => {
+            process.env.SMOOAI_CONFIG_ENV = 'qa';
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=qa');
+        });
+
+        it('falls back to development as the last resort', async () => {
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=development');
+        });
+
+        it('survives malformed SST_RESOURCE_App JSON', async () => {
+            process.env.SST_RESOURCE_App = '{not json';
+            process.env.SMOOAI_CONFIG_ENV = 'qa';
+            const fetchMock = mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: {} } }]);
+            await bootstrapFetch('k');
+            expect(fetchMock.mock.calls[1]![0]).toContain('environment=qa');
+        });
+    });
+
+    it('stringifies non-string values', async () => {
+        mockFetchResponses([{ body: { access_token: 'T' } }, { body: { values: { count: 42, flag: true } } }]);
+        expect(await bootstrapFetch('count')).toBe('42');
+        // cache hit, no new mocks needed
+        expect(await bootstrapFetch('flag')).toBe('true');
+    });
+});

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,0 +1,153 @@
+/**
+ * @smooai/config/bootstrap — lightweight cold-start config fetcher.
+ *
+ * This entry point exists for callers that need to read a single config
+ * value from a script, build step, or other cold-start context where
+ * importing the full @smooai/config SDK is too expensive or pulls in a
+ * transitive dependency (e.g. `@smooai/logger`'s top-level
+ * `import.meta.url` use) that breaks the host runtime (tsx, edge, etc.).
+ *
+ * It deliberately has **zero** imports from the rest of @smooai/config
+ * and zero third-party dependencies. Only Node built-ins (`process`,
+ * native `fetch`) are used.
+ *
+ * It performs a single OAuth `client_credentials` exchange, then a single
+ * GET against `/organizations/{orgId}/config/values?environment={env}`.
+ * The resulting values map is cached per-process per-env so repeated
+ * reads inside the same script avoid the round-trip.
+ *
+ * Inputs (read from `process.env`):
+ *   SMOOAI_CONFIG_API_URL       base URL (default https://api.smoo.ai)
+ *   SMOOAI_CONFIG_AUTH_URL      OAuth base URL (default https://auth.smoo.ai;
+ *                               legacy SMOOAI_AUTH_URL also accepted)
+ *   SMOOAI_CONFIG_CLIENT_ID     OAuth M2M client id
+ *   SMOOAI_CONFIG_CLIENT_SECRET OAuth M2M client secret
+ *                               (legacy SMOOAI_CONFIG_API_KEY accepted)
+ *   SMOOAI_CONFIG_ORG_ID        target org id
+ *   SMOOAI_CONFIG_ENV           default env name (used when `options.environment`
+ *                               is omitted and no SST stage is detected)
+ *
+ * Environment resolution order (when `options.environment` is omitted):
+ *   1. SST_STAGE
+ *   2. NEXT_PUBLIC_SST_STAGE
+ *   3. SST_RESOURCE_App (JSON, `.stage` field — `sst shell` exports this
+ *      even when SST_STAGE itself isn't set)
+ *   4. SMOOAI_CONFIG_ENV
+ *   5. 'development'
+ *
+ * Stage-to-env follows the platform convention: `production` stays
+ * `production`, anything else uses the stage value directly (or the
+ * SMOOAI_CONFIG_ENV fallback when no stage is detected).
+ */
+
+export interface BootstrapOptions {
+    /** Explicit environment name. Bypasses auto-detection. */
+    environment?: string;
+}
+
+interface BootstrapCreds {
+    apiUrl: string;
+    authUrl: string;
+    clientId: string;
+    clientSecret: string;
+    orgId: string;
+}
+
+function readCreds(): BootstrapCreds {
+    const apiUrl = process.env.SMOOAI_CONFIG_API_URL ?? 'https://api.smoo.ai';
+    const authUrl = process.env.SMOOAI_CONFIG_AUTH_URL ?? process.env.SMOOAI_AUTH_URL ?? 'https://auth.smoo.ai';
+    const clientId = process.env.SMOOAI_CONFIG_CLIENT_ID;
+    const clientSecret = process.env.SMOOAI_CONFIG_CLIENT_SECRET || process.env.SMOOAI_CONFIG_API_KEY;
+    const orgId = process.env.SMOOAI_CONFIG_ORG_ID;
+    if (!clientId || !clientSecret || !orgId) {
+        throw new Error(
+            '[@smooai/config/bootstrap] missing SMOOAI_CONFIG_{CLIENT_ID,CLIENT_SECRET,ORG_ID} in env. ' +
+                'Set these (e.g. via `pnpm sst shell --stage <stage>`) before calling bootstrapFetch.',
+        );
+    }
+    return { apiUrl, authUrl, clientId, clientSecret, orgId };
+}
+
+async function mintAccessToken(creds: BootstrapCreds): Promise<string> {
+    const trimmedAuth = creds.authUrl.replace(/\/+$/, '');
+    const res = await fetch(`${trimmedAuth}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            provider: 'client_credentials',
+            client_id: creds.clientId,
+            client_secret: creds.clientSecret,
+        }).toString(),
+    });
+    if (!res.ok) {
+        const body = await res.text().catch(() => '<unreadable>');
+        throw new Error(`[@smooai/config/bootstrap] OAuth token exchange failed: HTTP ${res.status} ${body}`);
+    }
+    const body = (await res.json()) as { access_token?: string };
+    if (!body.access_token) {
+        throw new Error('[@smooai/config/bootstrap] OAuth token endpoint returned no access_token');
+    }
+    return body.access_token;
+}
+
+function resolveEnv(environment?: string): string {
+    if (environment) return environment;
+    let stage = process.env.SST_STAGE ?? process.env.NEXT_PUBLIC_SST_STAGE;
+    if (!stage) {
+        try {
+            const raw = process.env.SST_RESOURCE_App;
+            if (raw) {
+                const parsed = JSON.parse(raw) as { stage?: string };
+                if (parsed.stage) stage = parsed.stage;
+            }
+        } catch {
+            // fall through
+        }
+    }
+    if (!stage) {
+        return process.env.SMOOAI_CONFIG_ENV ?? 'development';
+    }
+    if (stage === 'production') return 'production';
+    return stage;
+}
+
+let cached: Record<string, unknown> | undefined;
+let cachedEnv: string | undefined;
+
+/** Test-only: clear the in-process values cache. Not part of the public API. */
+export function resetBootstrapCacheForTests(): void {
+    cached = undefined;
+    cachedEnv = undefined;
+}
+
+/**
+ * Fetch a single config value by camelCase key. The full values map is
+ * cached per-process per-env after the first call so repeated reads in
+ * the same script process don't re-do the OAuth + GET round-trip.
+ *
+ * Returns `undefined` if the key is not present in the values map. Does
+ * NOT throw on missing keys — only on env/auth/network errors.
+ */
+export async function bootstrapFetch(key: string, options?: BootstrapOptions): Promise<string | undefined> {
+    const env = resolveEnv(options?.environment);
+    if (cached === undefined || cachedEnv !== env) {
+        const creds = readCreds();
+        const token = await mintAccessToken(creds);
+        const trimmedApi = creds.apiUrl.replace(/\/+$/, '');
+        const url = `${trimmedApi}/organizations/${encodeURIComponent(creds.orgId)}/config/values?environment=${encodeURIComponent(env)}`;
+        const res = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+        });
+        if (!res.ok) {
+            const body = await res.text().catch(() => '<unreadable>');
+            throw new Error(`[@smooai/config/bootstrap] GET /config/values failed: HTTP ${res.status} ${body}`);
+        }
+        const body = (await res.json()) as { values?: Record<string, unknown> };
+        cached = body.values ?? {};
+        cachedEnv = env;
+    }
+    const v = cached[key];
+    if (v === undefined || v === null) return undefined;
+    return typeof v === 'string' ? v : String(v);
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const serverEntry = [
     'src/index.ts',
+    'src/bootstrap/index.ts',
     'src/vite/preloadConfig.ts',
     'src/vite/index.ts',
     'src/utils/mergeReplaceArrays.ts',


### PR DESCRIPTION
## Summary
New \`@smooai/config/bootstrap\` lightweight cold-start fetch helper in TS, Python, Go, Rust, and .NET. Zero deps on the rest of the SDK (no logger, no fetch wrapper, no schema validation, no DI). Each does plain OAuth client_credentials exchange + GET \`/organizations/{orgId}/config/values?environment={env}\` with process-wide caching per env.

## Why
Cold-start scenarios where importing the full SDK is problematic. In TS specifically: \`@smooai/backend-utils/config\` transitively pulls in \`@smooai/logger\` whose \`AwsServerLogger.ts:30\` uses \`import.meta.url\` at module top level → tsx's CJS loader crashes with \`Cannot access '__filename' before initialization\`. The smooai monorepo had to ship an ad-hoc shim in PR https://github.com/SmooAI/smooai/pull/599 to unblock prod migration scripts. This SDK addition lets that shim delete.

## API surface (identical wire behavior across all 5 languages)
- \`bootstrapFetch(key, options?)\` returns the value as a string (idiomatic absent in each language: undefined/None/""/Ok(None)/null).
- Inputs from env: \`SMOOAI_CONFIG_API_URL\`, \`SMOOAI_CONFIG_AUTH_URL\`, \`SMOOAI_CONFIG_CLIENT_ID\`, \`SMOOAI_CONFIG_CLIENT_SECRET\` (or legacy \`SMOOAI_CONFIG_API_KEY\`), \`SMOOAI_CONFIG_ORG_ID\`.
- Env resolution chain: explicit → \`SST_STAGE\` → \`NEXT_PUBLIC_SST_STAGE\` → \`SST_RESOURCE_App\` JSON \`.stage\` → \`SMOOAI_CONFIG_ENV\` → \`'development'\`. \`stage === 'production'\` → environment=production.

## Per-language
- **TS** — \`src/bootstrap/index.ts\`, export at \`@smooai/config/bootstrap\`, 21 tests, server-only (uses \`process.env\`).
- **Python** — \`python/src/smooai_config/bootstrap.py\`, sync API, stdlib only, 20 tests.
- **Go** — new \`go/config/bootstrap\` subpackage, options-pattern, 22 tests via \`httptest\`.
- **Rust** — \`rust/config/src/bootstrap.rs\` via \`lib.rs\`, async, 18 tests with serializing mutex.
- **.NET** — \`SmooAI.Config/Bootstrap/BootstrapFetch.cs\`, async, 21 tests in \`[DisableParallelization]\` collection.

## Verification
All green: typecheck/format/lint/test across all 5 languages (206 TS, 308 Python, 22 Go, 18+ Rust, 21 .NET). \`dist/bootstrap/\` artifacts verified.

## Follow-up
Once this publishes, smooai monorepo deletes \`scripts/lib/fetch-smoo-config.ts\` and migrate scripts import directly from \`@smooai/config/bootstrap\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)