### PR TITLE
SMOODEV-928: Bump @smooai/logger ^4.1.4 + /utils ^1.3.3 + /fetch ^3.3.5

### DIFF
--- a/.changeset/bump-logger-fetch-utils.md
+++ b/.changeset/bump-logger-fetch-utils.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-928: Bump `@smooai/logger` to `^4.1.4`, `@smooai/utils` to `^1.3.3`, and `@smooai/fetch` to `^3.3.5`. Picks up the ESM `__filename` TDZ fix from logger 4.1.4 across the runtime dep graph (utils 1.3.2 and fetch 3.3.4 both still pulled logger 3.x as their own runtime deps).

--- a/package.json
+++ b/package.json
@@ -244,9 +244,9 @@
     },
     "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@smooai/fetch": "^3.1.0",
-        "@smooai/logger": "^3.1.1",
-        "@smooai/utils": "^1.3.1",
+        "@smooai/fetch": "^3.3.5",
+        "@smooai/logger": "^4.1.4",
+        "@smooai/utils": "^1.3.3",
         "@standard-schema/spec": "^1.0.0",
         "@valibot/to-json-schema": "^1.2.0",
         "ajv": "^8.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,14 +13,14 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       '@smooai/fetch':
-        specifier: ^3.1.0
-        version: 3.1.0(@types/node@22.13.10)(typescript@5.8.2)
+        specifier: ^3.3.5
+        version: 3.3.5(@types/node@22.13.10)(typescript@5.8.2)
       '@smooai/logger':
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^4.1.4
+        version: 4.1.4
       '@smooai/utils':
-        specifier: ^1.3.1
-        version: 1.3.1(@types/node@22.13.10)(typescript@5.8.2)
+        specifier: ^1.3.3
+        version: 1.3.3(@types/node@22.13.10)(typescript@5.8.2)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1328,25 +1328,16 @@ packages:
     peerDependencies:
       typescript: ^5.8.2
 
-  '@smooai/fetch@3.1.0':
-    resolution: {integrity: sha512-0q4ZWvFWLlUWZEAQAeTHCrLGk4k2ew9/8bDLuUepqS2AyrJkDSynKzK5U5H0ZYAyEdidzh346MuE0Q//SgXUww==}
+  '@smooai/fetch@3.3.5':
+    resolution: {integrity: sha512-k54Kkokq3P50DIJEotT4Pq2j8xBUKpln58aF4GYsN3IoswKpb+qAO0WaeJcf2qvPdbLE4SWUpJIXuS1upQ7Wbw==}
 
-  '@smooai/logger@3.1.1':
-    resolution: {integrity: sha512-WGjgW7wqwZ2XqcrAOCf237FmR/0bT4Cfb61vhdsaQHX7rxQhSs88VD4SxrNT53KbIcIULuj6z2TaZDCY7TJtwQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@smooai/logger@3.3.0':
-    resolution: {integrity: sha512-yIuKxI6M+w/pgG23EhhXdO717EGJjGFESwIoq/KwXDJqEcjq07HlfmkOzBS+wAKj1WRRz17AbmN12oSmq+oJnQ==}
+  '@smooai/logger@4.1.4':
+    resolution: {integrity: sha512-ub+dYF38oE8Ke3BNz1FmpfjlCKBOGzf+KQPI4ZIvTu34gckEBG2D7ISxq0Lnp4hN/xMi0v/LRnxjgGiDUtmaZQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@smooai/utils@1.3.1':
-    resolution: {integrity: sha512-y1jbOW8llHJrCuayJliSEVDSvEaj/4aKF9UP81Qo5i2wN2omFhyBtto0hAPMC3RcygYOBUPfAHJIFkSw+l4g5A==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@smooai/utils@1.3.2':
-    resolution: {integrity: sha512-OvXXcrXNH61m3udK1G0rTkSjp2dTAfRMHdfLL1NuF/wT7ld4PvuLEN1GRd7n5M+OHhqpE9WSwNx+qdXhMCEiYQ==}
+  '@smooai/utils@1.3.3':
+    resolution: {integrity: sha512-oC+yXM37uZnJSD7Lk0sxW4cZjW+GIprdS/v8/63alavuPrUELK5c6WljZR1TRuzAan4afHkHRKDl8eK3xRHuKA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2788,11 +2779,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -3129,6 +3115,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4295,7 +4282,7 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.4
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.14
@@ -4316,7 +4303,7 @@ snapshots:
       npm-package-arg: 11.0.3
       npm-run-path: 5.3.0
       object-treeify: 4.0.1
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-name: 5.0.1
       which: 4.0.0
       yarn: 1.22.22
@@ -4784,11 +4771,11 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  '@smooai/fetch@3.1.0(@types/node@22.13.10)(typescript@5.8.2)':
+  '@smooai/fetch@3.3.5(@types/node@22.13.10)(typescript@5.8.2)':
     dependencies:
       '@faker-js/faker': 9.9.0
-      '@smooai/logger': 3.3.0
-      '@smooai/utils': 1.3.2(@types/node@22.13.10)(typescript@5.8.2)
+      '@smooai/logger': 4.1.4
+      '@smooai/utils': 1.3.3(@types/node@22.13.10)(typescript@5.8.2)
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
       lodash.merge: 4.6.2
@@ -4801,7 +4788,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@smooai/logger@3.1.1':
+  '@smooai/logger@4.1.4':
     dependencies:
       '@aws-sdk/client-sqs': 3.883.0
       browser-dtector: 4.1.0
@@ -4819,52 +4806,12 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@smooai/logger@3.3.0':
-    dependencies:
-      '@aws-sdk/client-sqs': 3.883.0
-      browser-dtector: 4.1.0
-      dayjs: 1.11.18
-      esbuild-plugin-alias: 0.2.1
-      esm-utils: 4.3.0
-      json-stable-stringify: 1.3.0
-      merge-anything: 6.0.6
-      picocolors: 1.1.1
-      rotating-file-stream: 3.2.7
-      serialize-error: 11.0.3
-      source-map-support: 0.5.21
-      uuid: 9.0.1
-      zod: 4.1.5
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@smooai/utils@1.3.1(@types/node@22.13.10)(typescript@5.8.2)':
+  '@smooai/utils@1.3.3(@types/node@22.13.10)(typescript@5.8.2)':
     dependencies:
       '@oclif/core': 2.16.0(@types/node@22.13.10)(typescript@5.8.2)
       '@oclif/plugin-help': 6.2.32
       '@oclif/plugin-plugins': 5.4.46
-      '@smooai/logger': 3.1.1
-      '@standard-schema/spec': 1.0.0
-      '@standard-schema/utils': 0.3.0
-      find-up: 7.0.0
-      hono: 4.9.6
-      http-status-codes: 2.3.0
-      libphonenumber-js: 1.12.15
-      zod: 4.1.5
-      zx: 8.8.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - aws-crt
-      - supports-color
-      - typescript
-
-  '@smooai/utils@1.3.2(@types/node@22.13.10)(typescript@5.8.2)':
-    dependencies:
-      '@oclif/core': 2.16.0(@types/node@22.13.10)(typescript@5.8.2)
-      '@oclif/plugin-help': 6.2.32
-      '@oclif/plugin-plugins': 5.4.46
-      '@smooai/logger': 3.3.0
+      '@smooai/logger': 4.1.4
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
       find-up: 7.0.0
@@ -5913,7 +5860,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-name: 5.0.1
 
   npm-run-path@5.3.0:
@@ -6194,10 +6141,7 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2: {}
-
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   serialize-error@11.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Bump runtime \`@smooai/logger\` to \`^4.1.4\`, \`@smooai/utils\` to \`^1.3.3\`, \`@smooai/fetch\` to \`^3.3.5\`.
- Closes the cascade so every package in the @smooai/* graph pulls logger 4.1.4 directly instead of relying on the smooai monorepo's \`pnpm.overrides\` hack.

## Test plan
- [x] \`tsc --noEmit --skipLibCheck\` clean
- [x] vitest 206 pass (20 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)