### PR TITLE
SMOODEV-960: Document CLI is TS-only in each per-language README

### DIFF
--- a/.changeset/smoodev-960-cli-ts-only-docs.md
+++ b/.changeset/smoodev-960-cli-ts-only-docs.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-960: Add a "CLI is TS-only — install via Node" note to each per-language README (Python, Rust, Go, .NET). The `smooai-config` CLI (push / pull / list / set / diff / login) is TypeScript-only by design because the schema is authored in TS, but a Python/Rust/Go/.NET-only team installing the SDK had no docs hint that they still needed Node for the CLI. Pure docs change.

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -5,6 +5,8 @@
 
 **Type-safe config, secrets, and feature flags for .NET — same schema, same encrypted bundle, same source of truth as the TypeScript, Python, Rust, and Go clients.**
 
+> **Note:** the `smooai-config` **CLI** (push / pull / list / set / diff / login) is TypeScript-only. The schema is authored in TS and pushed via the CLI; this .NET SDK only **reads** values at runtime. If you're on a .NET-only team and need the CLI, install it via Node: `pnpm add -g @smooai/config` (or `npm i -g @smooai/config`).
+
 ## Install
 
 ```sh

--- a/go/config/README.md
+++ b/go/config/README.md
@@ -34,6 +34,8 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 Go port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Define your config with Go structs and tags — the same schema your TypeScript frontend or Rust service reads.
 
+> **Note:** the `smooai-config` **CLI** (push / pull / list / set / diff / login) is TypeScript-only. The schema is authored in TS and pushed via the CLI; this Go module only **reads** values at runtime. If you're on a Go-only team and need the CLI, install it via Node: `pnpm add -g @smooai/config` (or `npm i -g @smooai/config`).
+
 ### What you get
 
 - **Three tiers, one schema** - public config, secrets, and feature flags as three Go structs with struct tags.

--- a/python/README.md
+++ b/python/README.md
@@ -38,6 +38,8 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 The Python port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Define your schema with Pydantic `BaseModel` classes once and every Python service in your stack reads the same typed values as your TypeScript frontend or Go backend.
 
+> **Note:** the `smooai-config` **CLI** (push / pull / list / set / diff / login) is TypeScript-only. The schema is authored in TS and pushed via the CLI; this Python client only **reads** values at runtime. If you're on a Python-only team and need the CLI, install it via Node: `pnpm add -g @smooai/config` (or `npm i -g @smooai/config`).
+
 ### What you get
 
 - **Three tiers, one schema** - public config, secrets, and feature flags separated cleanly as three Pydantic `BaseModel` classes.

--- a/rust/config/README.md
+++ b/rust/config/README.md
@@ -38,6 +38,8 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 Rust port of [@smooai/config](https://www.npmjs.com/package/@smooai/config). Derive `JsonSchema` on your own Rust structs, generate the exact schema every other service in your stack reads, and resolve values through a cached async client.
 
+> **Note:** the `smooai-config` **CLI** (push / pull / list / set / diff / login) is TypeScript-only. The schema is authored in TS and pushed via the CLI; this Rust crate only **reads** values at runtime. If you're on a Rust-only team and need the CLI, install it via Node: `pnpm add -g @smooai/config` (or `npm i -g @smooai/config`).
+
 ### What you get
 
 - **Three tiers, one schema** - public config, secrets, and feature flags as three Rust structs with `#[derive(JsonSchema)]`.


### PR DESCRIPTION
Docs fix. CLI is TS-only by design (schema authored in TS); add a note to Python/Rust/Go/.NET READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)