### PR TITLE
SMOODEV-959: Segment-aware feature-flag evaluator for .NET SDK

### DIFF
--- a/.changeset/smoodev-959-dotnet-ff-evaluator.md
+++ b/.changeset/smoodev-959-dotnet-ff-evaluator.md
@@ -1,0 +1,7 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-959: Port the segment-aware feature-flag evaluator to the .NET SDK so it reaches parity with TS / Python / Rust / Go. `SmooConfigClient.EvaluateFeatureFlagAsync(key, context, environment)` POSTs to `/organizations/{orgId}/config/feature-flags/{key}/evaluate` and returns an `EvaluateFeatureFlagResponse` carrying the resolved value plus `matchedRuleId`, `rolloutBucket`, and `source` (`raw` / `rule` / `rollout` / `default`). HTTP 404 / 400 / 5xx surface as a typed `FeatureFlagEvaluationException` with a `Kind` enum so callers can branch without parsing messages.
+
+Also wires the existing typed `ConfigKey<T>` handle: feature-flag-tier keys get `EvaluateAsync(client, context)` (returns the deserialized value) and `EvaluateRawAsync(client, context)` (returns the full envelope). Calling either on a non-FeatureFlag key throws `InvalidOperationException`.

--- a/dotnet/src/SmooAI.Config/Models/FeatureFlagEvaluation.cs
+++ b/dotnet/src/SmooAI.Config/Models/FeatureFlagEvaluation.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SmooAI.Config.Models;
+
+/// <summary>
+/// Wire contract for <c>POST /config/feature-flags/{key}/evaluate</c>.
+/// Mirrors the TypeScript <c>EvaluateFeatureFlagResponse</c> and the schema in
+/// <c>@smooai/schemas/config/feature-flag</c>. SMOODEV-959 — .NET port of the
+/// segment-aware evaluator that already shipped in TS / Python / Rust / Go.
+/// </summary>
+public sealed class EvaluateFeatureFlagResponse
+{
+    /// <summary>The resolved flag value (post rules + rollout).</summary>
+    [JsonPropertyName("value")]
+    public JsonElement Value { get; init; }
+
+    /// <summary>Id of the rule that fired, if any.</summary>
+    [JsonPropertyName("matchedRuleId")]
+    public string? MatchedRuleId { get; init; }
+
+    /// <summary>0–99 bucket the context was assigned to, if a rollout ran.</summary>
+    [JsonPropertyName("rolloutBucket")]
+    public int? RolloutBucket { get; init; }
+
+    /// <summary>Which branch the evaluator returned from: <c>raw</c> / <c>rule</c> / <c>rollout</c> / <c>default</c>.</summary>
+    [JsonPropertyName("source")]
+    public string Source { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Categorizes errors from <see cref="SmooConfigClient.EvaluateFeatureFlagAsync"/>
+/// so callers can branch on 404 / 400 / 5xx without parsing the message.
+/// </summary>
+public enum FeatureFlagErrorKind
+{
+    /// <summary>5xx, network, or any non-404 / non-400 failure.</summary>
+    Server,
+
+    /// <summary>404 — the flag key is not defined in the org's schema.</summary>
+    NotFound,
+
+    /// <summary>400 — invalid context or missing environment.</summary>
+    Context,
+}
+
+/// <summary>
+/// Thrown by <see cref="SmooConfigClient.EvaluateFeatureFlagAsync"/> when the
+/// server rejects the request or returns a non-2xx status. Use
+/// <see cref="Kind"/> to branch on 404 / 400 / 5xx without parsing the
+/// message. Mirrors <c>FeatureFlagEvaluationError</c> in the other SDKs.
+/// </summary>
+public sealed class FeatureFlagEvaluationException : Exception
+{
+    /// <summary>The feature-flag key the caller asked to evaluate.</summary>
+    public string Key { get; }
+
+    /// <summary>HTTP status code returned by the server.</summary>
+    public int StatusCode { get; }
+
+    /// <summary>Categorization (not-found / context / server).</summary>
+    public FeatureFlagErrorKind Kind { get; }
+
+    /// <summary>Raw response body text, if any.</summary>
+    public string? ServerMessage { get; }
+
+    public FeatureFlagEvaluationException(string key, int statusCode, FeatureFlagErrorKind kind, string? serverMessage)
+        : base(BuildMessage(key, statusCode, serverMessage))
+    {
+        Key = key;
+        StatusCode = statusCode;
+        Kind = kind;
+        ServerMessage = serverMessage;
+    }
+
+    private static string BuildMessage(string key, int statusCode, string? serverMessage)
+    {
+        return string.IsNullOrEmpty(serverMessage)
+            ? $"Feature flag \"{key}\" evaluation failed: HTTP {statusCode}"
+            : $"Feature flag \"{key}\" evaluation failed: HTTP {statusCode} — {serverMessage}";
+    }
+}

--- a/dotnet/src/SmooAI.Config/SmooConfigClient.cs
+++ b/dotnet/src/SmooAI.Config/SmooConfigClient.cs
@@ -151,6 +151,84 @@ public sealed class SmooConfigClient : IDisposable
         return SendWithRetryAsync<JsonElement>(HttpMethod.Put, url, body, cancellationToken);
     }
 
+    /// <summary>
+    /// Evaluate a segment-aware feature flag against the server. SMOODEV-959 —
+    /// brings the .NET SDK to parity with TS / Python / Rust / Go.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetValueAsync"/>, this is always a network call:
+    /// segment rules (percentage rollout, attribute matching, bucketing) live
+    /// server-side and the response depends on the <paramref name="context"/>
+    /// you pass. Callers that don't need segment evaluation should keep using
+    /// <see cref="GetValueAsync"/> for the static flag value.
+    /// </remarks>
+    /// <param name="key">Feature-flag key.</param>
+    /// <param name="context">Attributes the server's segment rules may reference
+    /// (e.g. <c>{ userId, tenantId, plan, country }</c>). Unreferenced keys are
+    /// ignored by the server. Keep values JSON-serializable — the server hashes
+    /// <c>bucketBy</c> values by their string representation, so numbers and
+    /// booleans bucket stably across client rebuilds. A null map is sent as <c>{}</c>.</param>
+    /// <param name="environment">Environment name; falls back to <c>DefaultEnvironment</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="FeatureFlagEvaluationException">Thrown on any non-2xx response. Inspect <see cref="FeatureFlagEvaluationException.Kind"/> for 404 / 400 / 5xx.</exception>
+    public async Task<EvaluateFeatureFlagResponse> EvaluateFeatureFlagAsync(
+        string key,
+        IReadOnlyDictionary<string, object?>? context = null,
+        string? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException(
+                "@smooai/config: EvaluateFeatureFlag called with null/empty key. " +
+                "Most common cause: reading a typed-keys constant for a key that's not declared in your schema. " +
+                "Add it to .smooai-config/config.ts and run `smooai-config push`.",
+                nameof(key));
+        }
+
+        var env = ResolveEnv(environment);
+        var body = new EvaluateFeatureFlagRequest
+        {
+            Environment = env,
+            Context = context ?? new Dictionary<string, object?>(),
+        };
+
+        var url = $"{_baseUrl}/organizations/{_orgId}/config/feature-flags/{Uri.EscapeDataString(key)}/evaluate";
+
+        // We can't reuse SendWithRetryAsync because we need to map status
+        // codes to the typed FeatureFlagEvaluationException categories before
+        // it converts everything to SmooConfigApiException.
+        var response = await SendOnceAsync(HttpMethod.Post, url, body, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                response.Dispose();
+                _tokenProvider.Invalidate();
+                response = await SendOnceAsync(HttpMethod.Post, url, body, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var text = await SafeReadAsync(response, cancellationToken).ConfigureAwait(false);
+                var kind = response.StatusCode switch
+                {
+                    HttpStatusCode.NotFound => FeatureFlagErrorKind.NotFound,
+                    HttpStatusCode.BadRequest => FeatureFlagErrorKind.Context,
+                    _ => FeatureFlagErrorKind.Server,
+                };
+                throw new FeatureFlagEvaluationException(key, (int)response.StatusCode, kind, string.IsNullOrWhiteSpace(text) ? null : text.Trim());
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<EvaluateFeatureFlagResponse>(JsonOptions, cancellationToken).ConfigureAwait(false);
+            return result ?? new EvaluateFeatureFlagResponse();
+        }
+        finally
+        {
+            response.Dispose();
+        }
+    }
+
     private string ResolveEnv(string? environment)
         => string.IsNullOrWhiteSpace(environment) ? _defaultEnvironment : environment!;
 
@@ -205,6 +283,15 @@ public sealed class SmooConfigClient : IDisposable
     public void Dispose()
     {
         if (_disposeHttpClient) _httpClient.Dispose();
+    }
+
+    private sealed class EvaluateFeatureFlagRequest
+    {
+        [JsonPropertyName("environment")]
+        public string Environment { get; init; } = string.Empty;
+
+        [JsonPropertyName("context")]
+        public IReadOnlyDictionary<string, object?> Context { get; init; } = new Dictionary<string, object?>();
     }
 
     private sealed class SetValueRequest

--- a/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
+++ b/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
@@ -68,6 +68,51 @@ public sealed class ConfigKey<T>
         return await GetAsync(client, environment, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Evaluate a segment-aware feature flag against the server (SMOODEV-959).
+    /// Only valid when <see cref="Tier"/> is <see cref="ConfigTier.FeatureFlag"/>;
+    /// throws <see cref="InvalidOperationException"/> otherwise. The resolved
+    /// value is deserialized into <typeparamref name="T"/>; the full response
+    /// envelope (including <c>matchedRuleId</c>, <c>rolloutBucket</c>, and
+    /// <c>source</c>) is available via <see cref="EvaluateRawAsync"/>.
+    /// </summary>
+    public async Task<T?> EvaluateAsync(
+        SmooConfigClient client,
+        IReadOnlyDictionary<string, object?>? context = null,
+        string? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (Tier != ConfigTier.FeatureFlag)
+        {
+            throw new InvalidOperationException(
+                $"ConfigKey<{typeof(T).Name}>({Key}) has tier {Tier}; only FeatureFlag-tier keys support EvaluateAsync.");
+        }
+
+        var response = await client.EvaluateFeatureFlagAsync(Key, context, environment, cancellationToken).ConfigureAwait(false);
+        return Deserialize(response.Value);
+    }
+
+    /// <summary>
+    /// Same as <see cref="EvaluateAsync"/> but returns the full
+    /// <see cref="EvaluateFeatureFlagResponse"/> so callers can inspect
+    /// <c>matchedRuleId</c>, <c>rolloutBucket</c>, and <c>source</c>.
+    /// </summary>
+    public Task<EvaluateFeatureFlagResponse> EvaluateRawAsync(
+        SmooConfigClient client,
+        IReadOnlyDictionary<string, object?>? context = null,
+        string? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (Tier != ConfigTier.FeatureFlag)
+        {
+            throw new InvalidOperationException(
+                $"ConfigKey<{typeof(T).Name}>({Key}) has tier {Tier}; only FeatureFlag-tier keys support EvaluateRawAsync.");
+        }
+        return client.EvaluateFeatureFlagAsync(Key, context, environment, cancellationToken);
+    }
+
     private static T? Deserialize(JsonElement element)
     {
         if (element.ValueKind == JsonValueKind.Undefined || element.ValueKind == JsonValueKind.Null)

--- a/dotnet/tests/SmooAI.Config.Tests/FeatureFlagEvaluatorTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/FeatureFlagEvaluatorTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Text.Json;
+using SmooAI.Config.Models;
+using SmooAI.Config.OAuth;
+using SmooAI.Config.Typed;
+
+namespace SmooAI.Config.Tests;
+
+/// <summary>
+/// SMOODEV-959 — segment-aware feature-flag evaluator parity with TS / Python /
+/// Rust / Go. Fixtures mirror the existing Go (<c>feature_flag_evaluate_test.go</c>)
+/// and Python (<c>test_client.py</c>) suites.
+/// </summary>
+public class FeatureFlagEvaluatorTests
+{
+    private static SmooConfigClientOptions Options() => new()
+    {
+        ClientId = "cid",
+        ClientSecret = "csec",
+        OrgId = "org-uuid",
+        BaseUrl = "https://api.smoo.ai",
+        AuthUrl = "https://auth.smoo.ai",
+        DefaultEnvironment = "production",
+    };
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler) CreateClient()
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        // Seed an OAuth token exchange so the first real request gets through.
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+        var options = Options();
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_posts_expected_body_and_headers()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":true,"source":"rule","matchedRuleId":"r-1"}""");
+
+        var context = new Dictionary<string, object?>
+        {
+            ["userId"] = "u-42",
+            ["plan"] = "pro",
+        };
+        var resp = await client.EvaluateFeatureFlagAsync("newCheckout", context);
+
+        Assert.Equal("rule", resp.Source);
+        Assert.Equal("r-1", resp.MatchedRuleId);
+        Assert.Equal(JsonValueKind.True, resp.Value.ValueKind);
+
+        // token + POST
+        Assert.Equal(2, handler.Requests.Count);
+        var post = handler.Requests[1];
+        Assert.Equal(HttpMethod.Post, post.Method);
+        Assert.Equal(
+            "https://api.smoo.ai/organizations/org-uuid/config/feature-flags/newCheckout/evaluate",
+            post.RequestUri!.ToString());
+        Assert.Equal("Bearer", post.Headers.Authorization!.Scheme);
+        Assert.Equal("tok-1", post.Headers.Authorization!.Parameter);
+
+        using var parsed = JsonDocument.Parse(handler.RequestBodies[1]);
+        Assert.Equal("production", parsed.RootElement.GetProperty("environment").GetString());
+        var ctx = parsed.RootElement.GetProperty("context");
+        Assert.Equal("u-42", ctx.GetProperty("userId").GetString());
+        Assert.Equal("pro", ctx.GetProperty("plan").GetString());
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_null_context_serializes_as_empty_object()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":false,"source":"default"}""");
+
+        await client.EvaluateFeatureFlagAsync("flag");
+
+        using var parsed = JsonDocument.Parse(handler.RequestBodies[1]);
+        var ctx = parsed.RootElement.GetProperty("context");
+        Assert.Equal(JsonValueKind.Object, ctx.ValueKind);
+        Assert.Empty(ctx.EnumerateObject());
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_override_environment_wins()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":1,"source":"raw"}""");
+
+        await client.EvaluateFeatureFlagAsync("flag", null, "staging");
+
+        using var parsed = JsonDocument.Parse(handler.RequestBodies[1]);
+        Assert.Equal("staging", parsed.RootElement.GetProperty("environment").GetString());
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_url_encodes_key()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":true,"source":"raw"}""");
+
+        await client.EvaluateFeatureFlagAsync("weird/key");
+
+        var post = handler.Requests[1];
+        // Slash must be escaped so the path segment is preserved as a single
+        // value rather than being interpreted as a sub-route.
+        Assert.Contains("feature-flags/weird%2Fkey/evaluate", post.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_decodes_full_response_shape()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":{"variant":"B"},"source":"rollout","matchedRuleId":"r-2","rolloutBucket":42}""");
+
+        var resp = await client.EvaluateFeatureFlagAsync("flag");
+
+        Assert.Equal("rollout", resp.Source);
+        Assert.Equal("r-2", resp.MatchedRuleId);
+        Assert.Equal(42, resp.RolloutBucket);
+        Assert.Equal("B", resp.Value.GetProperty("variant").GetString());
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_404_throws_not_found()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.NotFound, "flag not defined in schema");
+
+        var ex = await Assert.ThrowsAsync<FeatureFlagEvaluationException>(() =>
+            client.EvaluateFeatureFlagAsync("missing"));
+
+        Assert.Equal("missing", ex.Key);
+        Assert.Equal(404, ex.StatusCode);
+        Assert.Equal(FeatureFlagErrorKind.NotFound, ex.Kind);
+        Assert.Equal("flag not defined in schema", ex.ServerMessage);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_400_throws_context()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.BadRequest, "missing environment");
+
+        var ex = await Assert.ThrowsAsync<FeatureFlagEvaluationException>(() =>
+            client.EvaluateFeatureFlagAsync("flag"));
+        Assert.Equal(FeatureFlagErrorKind.Context, ex.Kind);
+        Assert.Equal(400, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_500_throws_server()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.InternalServerError, "boom");
+
+        var ex = await Assert.ThrowsAsync<FeatureFlagEvaluationException>(() =>
+            client.EvaluateFeatureFlagAsync("flag"));
+        Assert.Equal(FeatureFlagErrorKind.Server, ex.Kind);
+        Assert.Equal(500, ex.StatusCode);
+        Assert.Contains("boom", ex.Message);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureFlagAsync_throws_on_empty_key()
+    {
+        var (client, _) = CreateClient();
+        await Assert.ThrowsAsync<ArgumentException>(() => client.EvaluateFeatureFlagAsync(""));
+    }
+
+    // --- ConfigKey<T>.EvaluateAsync wiring ---
+
+    [Fact]
+    public async Task ConfigKey_EvaluateAsync_returns_typed_value_for_feature_flag_tier()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":true,"source":"rule"}""");
+
+        var key = new ConfigKey<bool>("newCheckout", ConfigTier.FeatureFlag);
+        var value = await key.EvaluateAsync(client, new Dictionary<string, object?> { ["userId"] = "u-1" });
+        Assert.True(value);
+    }
+
+    [Fact]
+    public async Task ConfigKey_EvaluateAsync_throws_for_non_feature_flag_tier()
+    {
+        var (client, _) = CreateClient();
+        var key = new ConfigKey<string>("apiUrl", ConfigTier.Public);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => key.EvaluateAsync(client));
+    }
+
+    [Fact]
+    public async Task ConfigKey_EvaluateRawAsync_exposes_full_envelope()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":"variantA","source":"rollout","matchedRuleId":"r-7","rolloutBucket":3}""");
+
+        var key = new ConfigKey<string>("checkoutVariant", ConfigTier.FeatureFlag);
+        var resp = await key.EvaluateRawAsync(client);
+        Assert.Equal("rollout", resp.Source);
+        Assert.Equal("r-7", resp.MatchedRuleId);
+        Assert.Equal(3, resp.RolloutBucket);
+        Assert.Equal("variantA", resp.Value.GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- TS / Python / Rust / Go all ship a segment-aware feature-flag evaluator (`evaluateFeatureFlag`); .NET was the only port missing it. Callers had to fall back to `GetValueAsync` which returns the raw flag value without segment rules or rollout.
- Adds `SmooConfigClient.EvaluateFeatureFlagAsync(key, context, environment)`, `EvaluateFeatureFlagResponse` model, and a typed `FeatureFlagEvaluationException` with a `FeatureFlagErrorKind` enum (`Server` / `NotFound` / `Context`) so callers branch on status without parsing messages.
- Wires the generated `ConfigKey<T>` typed handles: feature-flag-tier keys get `EvaluateAsync(...)` (deserialized value) and `EvaluateRawAsync(...)` (full envelope with `matchedRuleId`, `rolloutBucket`, `source`). Non-FF tiers throw `InvalidOperationException`.

## Test plan
- [x] `cd dotnet && dotnet build && dotnet test` — 81 passed (12 new SMOODEV-959 cases mirroring the Go / Python fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)