### PR TITLE
SMOODEV-957: Env-var + file-tier fallback in .NET ConfigKey.ResolveAsync

### DIFF
--- a/.changeset/smoodev-957-dotnet-env-file-fallback.md
+++ b/.changeset/smoodev-957-dotnet-env-file-fallback.md
@@ -1,0 +1,10 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-957: Extend `ConfigKey<T>.ResolveAsync` in the .NET SDK to the full SMOODEV-857 priority chain — **baked runtime → `SMOOAI_CONFIG_<KEY>` env var → live HTTP → local `.smooai-config/<env>.json`**. Previously the .NET port only did `baked → HTTP`, so deployments that needed a single key overridden without a re-bake had no env-var path, and dev laptops without network connectivity had no file-tier fallback.
+
+- Env-var names follow the existing convention (`moonshotApiKey` → `SMOOAI_CONFIG_MOONSHOT_API_KEY`). JSON-shaped values are parsed; primitives become JSON strings so the typed deserializer round-trips correctly.
+- File-tier reads from `$SMOOAI_CONFIG_FILE_DIR/<env>.json` (or `./.smooai-config/<env>.json`). Malformed or missing files are silent — same posture as TS / Python / Rust / Go.
+- HTTP failures (`HttpRequestException`, `SmooConfigApiException`, request timeouts) fall through to the file tier so an offline laptop can still resolve from local defaults. Caller cancellation still propagates.
+- `SmooConfigClient.DefaultEnvironment` is now exposed internally so the file-tier lookup aligns with whatever env name the HTTP tier would have used.

--- a/dotnet/src/SmooAI.Config/SmooConfigClient.cs
+++ b/dotnet/src/SmooAI.Config/SmooConfigClient.cs
@@ -26,6 +26,13 @@ public sealed class SmooConfigClient : IDisposable
     private readonly string _orgId;
     private readonly string _defaultEnvironment;
 
+    /// <summary>
+    /// Default environment the client falls back to when callers don't pass
+    /// an explicit one. Exposed so <see cref="Typed.ConfigKey{T}.ResolveAsync"/>
+    /// can use the same value for its file-tier fallback (SMOODEV-957).
+    /// </summary>
+    internal string DefaultEnvironment => _defaultEnvironment;
+
     /// <summary>JSON options used for both request and response bodies.</summary>
     public static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
+++ b/dotnet/src/SmooAI.Config/Typed/ConfigKey.cs
@@ -46,11 +46,21 @@ public sealed class ConfigKey<T>
     }
 
     /// <summary>
-    /// Resolve from a runtime when baked, else fall back to the HTTP client.
-    /// This is the typical production pattern: public + secret come from the
-    /// baked blob synchronously; everything else (feature flags, missing keys)
-    /// falls through to the network.
+    /// Resolve in priority order: baked runtime → <c>SMOOAI_CONFIG_&lt;KEY&gt;</c> env var →
+    /// live HTTP API → <c>.smooai-config/&lt;env&gt;.json</c> file defaults. Mirrors the
+    /// SMOODEV-857 chain that already ships in TS / Python / Rust / Go.
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item>Bake wins so AOT-deployed apps don't pay a network cost at cold start.</item>
+    ///   <item>Env-var sits next so operators can override a single key without re-baking.</item>
+    ///   <item>HTTP is the authoritative source for anything not baked / env-overridden.</item>
+    ///   <item>File-tier defaults are the last-resort fallback when the network is unavailable (dev laptops, offline tests).</item>
+    /// </list>
+    /// File-tier directory: <c>$SMOOAI_CONFIG_FILE_DIR</c> if set, otherwise
+    /// <c>./.smooai-config</c> relative to the working directory. The file is
+    /// <c>&lt;environment&gt;.json</c>, a flat key→value map.
+    /// </remarks>
     public async Task<T?> ResolveAsync(
         SmooConfigRuntime? runtime,
         SmooConfigClient client,
@@ -59,13 +69,52 @@ public sealed class ConfigKey<T>
     {
         ArgumentNullException.ThrowIfNull(client);
 
+        // 1. Baked runtime (cold-start friendly, AES-decrypted in-process).
         if (runtime is not null)
         {
-            var el = runtime.GetValue(Key);
-            if (el.HasValue) return Deserialize(el.Value);
+            var fromBlob = runtime.GetValue(Key);
+            if (fromBlob.HasValue) return Deserialize(fromBlob.Value);
         }
 
-        return await GetAsync(client, environment, cancellationToken).ConfigureAwait(false);
+        // 2. Env-var override.
+        var fromEnv = EnvFileFallback.ReadFromEnv(Key);
+        if (fromEnv.HasValue) return Deserialize(fromEnv.Value);
+
+        // 3. Live HTTP API.
+        try
+        {
+            var fromHttp = await GetAsync(client, environment, cancellationToken).ConfigureAwait(false);
+            // GetAsync returns default(T) both when the key is missing and
+            // when the value really is the type default. To avoid masking
+            // legitimate defaults, only treat it as "missing" for reference
+            // types / nullable structs.
+            if (fromHttp is not null) return fromHttp;
+        }
+        catch (HttpRequestException)
+        {
+            // Network unreachable / DNS failure / transient — fall through
+            // to the file tier so dev laptops and offline tests still work.
+        }
+        catch (SmooConfigApiException)
+        {
+            // Non-2xx from the server. Same posture as the HttpRequest
+            // failure above: prefer a stale file-tier default over a hard
+            // failure.
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Request timeout (not caller cancellation) — fall through.
+        }
+
+        // 4. Local file defaults (./.smooai-config/<env>.json). Use the
+        // client's configured default environment when the caller didn't
+        // pass one explicitly — keeps the file-tier env name aligned with
+        // the HTTP-tier env name.
+        var resolvedEnv = string.IsNullOrWhiteSpace(environment) ? client.DefaultEnvironment : environment!;
+        var fromFile = EnvFileFallback.ReadFromFile(Key, resolvedEnv);
+        if (fromFile.HasValue) return Deserialize(fromFile.Value);
+
+        return default;
     }
 
     /// <summary>

--- a/dotnet/src/SmooAI.Config/Typed/EnvFileFallback.cs
+++ b/dotnet/src/SmooAI.Config/Typed/EnvFileFallback.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+
+namespace SmooAI.Config.Typed;
+
+/// <summary>
+/// SMOODEV-957 — env-var + local-file fallback helpers for
+/// <see cref="ConfigKey{T}.ResolveAsync"/>. Mirrors the priority chain TS /
+/// Python / Rust / Go already ship (bake → env → http → file) so the .NET SDK
+/// reaches parity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Env-var names follow the same convention as the other ports: the config
+/// key in camelCase is rewritten to <c>SMOOAI_CONFIG_&lt;UPPER_SNAKE&gt;</c>.
+/// Example: <c>moonshotApiKey</c> → <c>SMOOAI_CONFIG_MOONSHOT_API_KEY</c>.
+/// </para>
+/// <para>
+/// File-tier defaults live in <c>.smooai-config/&lt;env&gt;.json</c> under the
+/// current working directory, or in the directory pointed at by
+/// <c>SMOOAI_CONFIG_FILE_DIR</c>. The file is treated as a flat JSON object;
+/// values are parsed as <see cref="JsonElement"/> and deserialized via the
+/// same path <see cref="SmooConfigClient.JsonOptions"/> uses.
+/// </para>
+/// </remarks>
+internal static class EnvFileFallback
+{
+    /// <summary>Environment variable prefix for the env-var fallback tier.</summary>
+    internal const string EnvVarPrefix = "SMOOAI_CONFIG_";
+
+    /// <summary>Optional override pointing at the file-defaults directory.</summary>
+    internal const string FileDirEnvVar = "SMOOAI_CONFIG_FILE_DIR";
+
+    private const string DefaultDir = ".smooai-config";
+
+    // File-defaults cache. Keyed by (resolved-dir, environment) so the same
+    // process can resolve multiple stages cheaply.
+    private static readonly Dictionary<string, JsonElement> s_fileCache =
+        new(StringComparer.Ordinal);
+    private static readonly object s_fileCacheLock = new();
+
+    /// <summary>
+    /// Convert camelCase to UPPER_SNAKE_CASE and prepend the env-var prefix.
+    /// Already-upper-snake keys are returned untouched (after prefix).
+    /// </summary>
+    internal static string EnvVarNameFor(string key)
+    {
+        // Fast path: already UPPER_SNAKE_CASE.
+        if (IsUpperSnake(key)) return EnvVarPrefix + key;
+
+        var sb = new System.Text.StringBuilder(key.Length + 8);
+        sb.Append(EnvVarPrefix);
+        for (int i = 0; i < key.Length; i++)
+        {
+            var c = key[i];
+            if (char.IsUpper(c) && i > 0) sb.Append('_');
+            sb.Append(char.ToUpperInvariant(c));
+        }
+        return sb.ToString();
+    }
+
+    private static bool IsUpperSnake(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return false;
+        foreach (var c in s)
+        {
+            if (!(char.IsUpper(c) || char.IsDigit(c) || c == '_')) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Read the env-var tier. Returns <c>null</c> when the var is unset or
+    /// empty. JSON-shaped values are parsed as JSON; anything else is wrapped
+    /// as a JSON string so callers get a uniform <see cref="JsonElement"/>.
+    /// </summary>
+    internal static JsonElement? ReadFromEnv(string key)
+    {
+        var raw = Environment.GetEnvironmentVariable(EnvVarNameFor(key));
+        if (string.IsNullOrEmpty(raw)) return null;
+
+        // Try JSON first so booleans / numbers / objects round-trip; fall
+        // back to a JSON string so the deserializer downstream can handle
+        // primitives without a separate coercion path.
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return JsonSerializer.SerializeToElement(raw);
+        }
+    }
+
+    /// <summary>
+    /// Read the file-tier defaults for <paramref name="environment"/>. Returns
+    /// <c>null</c> when no file exists, the env override points at a missing
+    /// directory, or the file is malformed.
+    /// </summary>
+    internal static JsonElement? ReadFromFile(string key, string environment)
+    {
+        var dir = Environment.GetEnvironmentVariable(FileDirEnvVar);
+        if (string.IsNullOrWhiteSpace(dir))
+        {
+            dir = Path.Combine(Directory.GetCurrentDirectory(), DefaultDir);
+        }
+
+        var path = Path.Combine(dir, $"{environment}.json");
+
+        JsonElement root;
+        var cacheKey = path; // resolved file path keys the cache
+        lock (s_fileCacheLock)
+        {
+            if (s_fileCache.TryGetValue(cacheKey, out var cached))
+            {
+                root = cached;
+            }
+            else
+            {
+                if (!File.Exists(path)) return null;
+
+                try
+                {
+                    var bytes = File.ReadAllBytes(path);
+                    using var doc = JsonDocument.Parse(bytes);
+                    root = doc.RootElement.Clone();
+                    s_fileCache[cacheKey] = root;
+                }
+                catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+                {
+                    // File-tier is best-effort — a malformed defaults file
+                    // shouldn't crash an otherwise-working app. The other
+                    // language ports follow the same posture (graceful
+                    // fall-through).
+                    return null;
+                }
+            }
+        }
+
+        if (root.ValueKind != JsonValueKind.Object) return null;
+        return root.TryGetProperty(key, out var value) ? value : null;
+    }
+
+    /// <summary>Test seam — clear the in-process file cache.</summary>
+    internal static void ResetFileCacheForTests()
+    {
+        lock (s_fileCacheLock)
+        {
+            s_fileCache.Clear();
+        }
+    }
+}

--- a/dotnet/tests/SmooAI.Config.Tests/ResolveAsyncFallbackTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/ResolveAsyncFallbackTests.cs
@@ -1,0 +1,290 @@
+using System.Net;
+using System.Text.Json;
+using SmooAI.Config.Models;
+using SmooAI.Config.OAuth;
+using SmooAI.Config.Runtime;
+using SmooAI.Config.Typed;
+
+namespace SmooAI.Config.Tests;
+
+/// <summary>
+/// SMOODEV-957 — verifies the bake → env → HTTP → file priority chain in
+/// <see cref="ConfigKey{T}.ResolveAsync"/>. Mirrors the priority-chain
+/// integration tests in the other SDKs (Go: <c>priority_chain_integration_test.go</c>;
+/// Python: <c>test_priority_chain_integration.py</c>; Rust:
+/// <c>priority_chain_integration.rs</c>).
+/// </summary>
+[Collection("EnvSerial")]
+public class ResolveAsyncFallbackTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly List<string> _envVarsToReset = new();
+    private readonly Dictionary<string, string?> _originalEnv = new();
+
+    public ResolveAsyncFallbackTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"smooai-config-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        EnvFileFallback.ResetFileCacheForTests();
+    }
+
+    public void Dispose()
+    {
+        // Restore env vars
+        foreach (var (name, original) in _originalEnv)
+        {
+            Environment.SetEnvironmentVariable(name, original);
+        }
+        EnvFileFallback.ResetFileCacheForTests();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private void SetEnv(string name, string? value)
+    {
+        if (!_originalEnv.ContainsKey(name))
+        {
+            _originalEnv[name] = Environment.GetEnvironmentVariable(name);
+        }
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    private static SmooConfigClientOptions Options() => new()
+    {
+        ClientId = "cid",
+        ClientSecret = "csec",
+        OrgId = "org-uuid",
+        BaseUrl = "https://api.smoo.ai",
+        AuthUrl = "https://auth.smoo.ai",
+        DefaultEnvironment = "production",
+    };
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler) CreateClient(bool seedToken = true)
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        if (seedToken)
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+        }
+        var options = Options();
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+        return (client, handler);
+    }
+
+    private void WriteFileDefault(string environment, object payload)
+    {
+        SetEnv(EnvFileFallback.FileDirEnvVar, _tempDir);
+        var path = Path.Combine(_tempDir, $"{environment}.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(payload));
+        EnvFileFallback.ResetFileCacheForTests();
+    }
+
+    // --- 1. Env-var fallback ---
+
+    [Fact]
+    public async Task EnvVar_overrides_http_when_runtime_absent()
+    {
+        var (client, handler) = CreateClient();
+        // HTTP would return "from-http" but env-var beats it.
+        handler.Enqueue(HttpStatusCode.OK, """{"value":"from-http"}""");
+
+        SetEnv("SMOOAI_CONFIG_MOONSHOT_API_KEY", "from-env");
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.ResolveAsync(runtime: null, client);
+
+        Assert.Equal("from-env", value);
+        // The env-var tier short-circuits before the HTTP client is touched,
+        // so no requests (not even the token exchange) should fire.
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task EnvVar_camelCase_key_maps_to_upper_snake_var()
+    {
+        var (client, _) = CreateClient(seedToken: false);
+        SetEnv("SMOOAI_CONFIG_API_URL", "\"https://override.example\"");
+
+        var key = new ConfigKey<string>("apiUrl", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("https://override.example", value);
+    }
+
+    [Fact]
+    public async Task EnvVar_parses_json_payload_for_typed_round_trip()
+    {
+        var (client, _) = CreateClient(seedToken: false);
+        SetEnv("SMOOAI_CONFIG_MAX_RETRIES", "7");
+
+        var key = new ConfigKey<int>("maxRetries", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal(7, value);
+    }
+
+    // --- 2. File-tier fallback ---
+
+    [Fact]
+    public async Task File_used_when_http_fails()
+    {
+        var (client, handler) = CreateClient();
+        // HTTP returns 500 → ResolveAsync should fall through to the file.
+        handler.Enqueue(HttpStatusCode.InternalServerError, "boom");
+
+        WriteFileDefault("production", new { moonshotApiKey = "from-file" });
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("from-file", value);
+    }
+
+    [Fact]
+    public async Task File_used_when_http_returns_missing()
+    {
+        var (client, handler) = CreateClient();
+        // HTTP returns an empty value envelope (key not in remote schema).
+        handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");
+
+        WriteFileDefault("production", new { localOnlyKey = "from-file" });
+
+        var key = new ConfigKey<string>("localOnlyKey", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("from-file", value);
+    }
+
+    [Fact]
+    public async Task File_honors_environment_override()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");
+
+        WriteFileDefault("staging", new { stageKey = "staging-value" });
+
+        var key = new ConfigKey<string>("stageKey", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client, environment: "staging");
+
+        Assert.Equal("staging-value", value);
+    }
+
+    [Fact]
+    public async Task File_defaults_to_development_when_environment_unspecified()
+    {
+        // Override client default environment to something the file doesn't
+        // exist for, to force the dev path. Easier: rebuild with default env.
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");
+        var options = new SmooConfigClientOptions
+        {
+            ClientId = "cid",
+            ClientSecret = "csec",
+            OrgId = "org-uuid",
+            BaseUrl = "https://api.smoo.ai",
+            AuthUrl = "https://auth.smoo.ai",
+            DefaultEnvironment = "development",
+        };
+        var tokenProvider = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tokenProvider);
+
+        handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");
+
+        WriteFileDefault("development", new { localKey = "dev-default" });
+
+        var key = new ConfigKey<string>("localKey", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("dev-default", value);
+    }
+
+    // --- 3. Bake still wins ---
+
+    [Fact]
+    public async Task Bake_wins_over_env_and_file()
+    {
+        var (client, _) = CreateClient(seedToken: false);
+
+        // Both env + file would resolve to other values — bake must beat them.
+        SetEnv("SMOOAI_CONFIG_MOONSHOT_API_KEY", "from-env");
+        WriteFileDefault("production", new { moonshotApiKey = "from-file" });
+
+        // Build a synthetic baked runtime.
+        var baked = new BakedConfig(
+            publicValues: new Dictionary<string, JsonElement>(),
+            secretValues: new Dictionary<string, JsonElement>
+            {
+                ["moonshotApiKey"] = JsonSerializer.SerializeToElement("from-bake"),
+            });
+        var runtime = SmooConfigRuntimeTestAccess.NewFromBaked(baked);
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.ResolveAsync(runtime, client);
+
+        Assert.Equal("from-bake", value);
+    }
+
+    [Fact]
+    public async Task Env_wins_over_http_and_file()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":"from-http"}""");
+        SetEnv("SMOOAI_CONFIG_MOONSHOT_API_KEY", "from-env");
+        WriteFileDefault("production", new { moonshotApiKey = "from-file" });
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("from-env", value);
+    }
+
+    [Fact]
+    public async Task Http_wins_over_file_when_present()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":"from-http"}""");
+        WriteFileDefault("production", new { moonshotApiKey = "from-file" });
+
+        var key = new ConfigKey<string>("moonshotApiKey", ConfigTier.Secret);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Equal("from-http", value);
+    }
+
+    [Fact]
+    public async Task Missing_everywhere_returns_default()
+    {
+        var (client, handler) = CreateClient();
+        handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");
+        // No env var, no file written (FileDirEnvVar unset → default dir,
+        // which the test fixture doesn't populate).
+
+        var key = new ConfigKey<string>("nonExistent", ConfigTier.Public);
+        var value = await key.ResolveAsync(null, client);
+
+        Assert.Null(value);
+    }
+}
+
+/// <summary>
+/// Backdoor for building a <see cref="SmooConfigRuntime"/> from an in-memory
+/// <see cref="BakedConfig"/> — the public API only loads from an encrypted
+/// blob on disk.
+/// </summary>
+internal static class SmooConfigRuntimeTestAccess
+{
+    public static SmooConfigRuntime NewFromBaked(BakedConfig baked)
+    {
+        // Use reflection to call the private ctor; this lives in the same
+        // assembly thanks to InternalsVisibleTo (test project).
+        var ctor = typeof(SmooConfigRuntime).GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(BakedConfig) },
+            modifiers: null);
+        if (ctor is null) throw new InvalidOperationException("SmooConfigRuntime private ctor not found");
+        return (SmooConfigRuntime)ctor.Invoke(new object[] { baked });
+    }
+}


### PR DESCRIPTION
## Summary
- SMOODEV-857 extended the resolution chain to `bake → env → http → file` across TS / Python / Rust / Go. .NET was left at `bake → http`, so a single-key override couldn't ride on an env var without rebuilding the baked blob, and offline dev laptops had no file-tier fallback either.
- `ConfigKey<T>.ResolveAsync` now walks all four tiers in order. Env-var names follow the existing convention (camelCase → `SMOOAI_CONFIG_UPPER_SNAKE`); JSON-shaped values are parsed so numbers / bools / objects round-trip into the typed return. File-tier reads `$SMOOAI_CONFIG_FILE_DIR/<env>.json` (or `./.smooai-config/<env>.json`); malformed / missing files are silent — same posture as the other ports.
- HTTP failures (`HttpRequestException`, `SmooConfigApiException`, request-timeout `TaskCanceledException`) fall through to the file tier so offline resolution still works. Caller cancellation still propagates.

## Test plan
- [x] `cd dotnet && dotnet build && dotnet test` — 92 passed (11 new SMOODEV-957 cases covering env-wins-over-http, file-when-http-fails / -returns-null, file-honors-environment, bake-still-wins, and missing-everywhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)