### PR TITLE
SMOODEV-974: ConfigClient (TS) — exchange client_credentials for JWT

### DIFF
--- a/.changeset/smoodev-974-ts-oauth-exchange.md
+++ b/.changeset/smoodev-974-ts-oauth-exchange.md
@@ -1,0 +1,24 @@
+---
+'@smooai/config': major
+---
+
+SMOODEV-974: `ConfigClient` (TypeScript runtime) now exchanges OAuth `client_credentials` for a JWT and uses **that** JWT as the Bearer token on `/config/values` calls, matching the .NET `SmooConfigClient`, the in-package `bootstrap`, and the CLI.
+
+**Breaking — all four broken language clients in this package previously sent the raw API key as the Bearer token, which the backend rejects with 401 because it expects a JWT.** Live feature flag fetches and runtime config reads were therefore silent failures across TypeScript, Python, Go, and Rust. This release fixes TypeScript; Python / Go / Rust ship in follow-up tickets (SMOODEV-9xx).
+
+**TypeScript migration**:
+
+- Set both `SMOOAI_CONFIG_CLIENT_ID` **and** `SMOOAI_CONFIG_CLIENT_SECRET` (or the legacy `SMOOAI_CONFIG_API_KEY`) on every consumer Lambda / process. The runtime SDK now requires both.
+- `new ConfigClient({...})` now requires `clientId` in addition to `clientSecret` (or `apiKey`). Constructing without `clientId` throws.
+- `apiKey` is preserved as a deprecated alias for `clientSecret`. Source-level code that passes `apiKey` continues to compile, but the value is now treated as the OAuth client secret (which is what it always was in the AuthDynamoTable).
+- New exported class `TokenProvider` in `@smooai/config/platform` — mirrors `SmooAI.Config.OAuth.TokenProvider` (mint, cache, 60s refresh window). Pass `new TokenProvider({...})` via the `tokenProvider` option to override caching or for testing.
+
+**No-change consumers**:
+
+- `bootstrap` (`@smooai/config/bootstrap`) and the CLI were already doing the OAuth exchange — their behavior is unchanged.
+- `.NET` `SmooConfigClient` was already correct — unchanged.
+- Schema/build/manage tooling is unchanged.
+
+**Behavior change to be aware of**:
+
+- The TS runtime now makes an additional `POST /token` request on cold start (and after token expiry / 401). The JWT is cached in-memory for the lifetime of the `ConfigClient` instance, refreshed 60s before expiry. On a 401 response from `/config/values` or `/evaluate`, the cached token is invalidated and the call is retried once.

--- a/README.md
+++ b/README.md
@@ -452,25 +452,33 @@ All language implementations include a runtime client for fetching configuration
 
 ### Environment Variables
 
-| Variable                | Description                                            | Required |
-| ----------------------- | ------------------------------------------------------ | -------- |
-| `SMOOAI_CONFIG_API_URL` | Base URL of the config API                             | Yes      |
-| `SMOOAI_CONFIG_API_KEY` | Bearer token for authentication                        | Yes      |
-| `SMOOAI_CONFIG_ORG_ID`  | Organization ID                                        | Yes      |
-| `SMOOAI_CONFIG_ENV`     | Default environment name (defaults to `"development"`) | No       |
+Authentication is OAuth2 `client_credentials` against `{authUrl}/token` — the client exchanges `(CLIENT_ID, CLIENT_SECRET)` for a JWT and uses that JWT as the Bearer token on every config call. `TokenProvider` caches the JWT in memory and refreshes 60s before expiry.
+
+| Variable                      | Description                                                                    | Required |
+| ----------------------------- | ------------------------------------------------------------------------------ | -------- |
+| `SMOOAI_CONFIG_API_URL`       | Base URL of the config API                                                     | Yes      |
+| `SMOOAI_CONFIG_AUTH_URL`      | OAuth issuer base URL (defaults to `https://auth.smoo.ai`)                     | No       |
+| `SMOOAI_CONFIG_CLIENT_ID`     | OAuth client ID                                                                | Yes      |
+| `SMOOAI_CONFIG_CLIENT_SECRET` | OAuth client secret (legacy `SMOOAI_CONFIG_API_KEY` is accepted as a fallback) | Yes      |
+| `SMOOAI_CONFIG_ORG_ID`        | Organization ID                                                                | Yes      |
+| `SMOOAI_CONFIG_ENV`           | Default environment name (defaults to `"development"`)                         | No       |
+
+> **Migration note (v5 / SMOODEV-974):** the TypeScript `ConfigClient` previously sent `SMOOAI_CONFIG_API_KEY` directly as the Bearer token, which the backend rejected with 401 because it expects a JWT. The SDK now mints a JWT via the OAuth `client_credentials` grant before each call — matching the .NET client, the in-package `bootstrap`, and the CLI. **You must set `SMOOAI_CONFIG_CLIENT_ID` in addition to `SMOOAI_CONFIG_API_KEY` / `SMOOAI_CONFIG_CLIENT_SECRET`** for the runtime SDK to work. The legacy `SMOOAI_CONFIG_API_KEY` env var continues to function as the OAuth client secret.
 
 ### TypeScript Client
 
 ```typescript
 import { ConfigClient } from '@smooai/config/platform/client';
 
-// Zero-config (reads from env vars)
+// Zero-config (reads from env vars — needs CLIENT_ID + CLIENT_SECRET/API_KEY + ORG_ID)
 const client = new ConfigClient();
 
 // Or explicit
 const client = new ConfigClient({
     baseUrl: 'https://config.smooai.dev',
-    apiKey: 'your-api-key',
+    authUrl: 'https://auth.smooai.dev',
+    clientId: 'your-client-id',
+    clientSecret: 'your-client-secret',
     orgId: 'your-org-id',
     environment: 'production',
 });

--- a/src/nextjs/getConfig.test.ts
+++ b/src/nextjs/getConfig.test.ts
@@ -8,13 +8,25 @@ vi.mock('@smooai/fetch', () => ({
     default: mockFetch,
 }));
 
+import { TokenProvider } from '../platform/TokenProvider';
 import { getConfig } from './getConfig';
+
+// SMOODEV-974: stub TokenProvider so these tests focus on getConfig behavior,
+// not the OAuth handshake (covered by TokenProvider.test.ts).
+class StubTokenProvider extends TokenProvider {
+    constructor() {
+        super({ authUrl: 'https://stub.invalid', clientId: 'stub', clientSecret: 'stub' });
+    }
+    async getAccessToken(): Promise<string> {
+        return 'stub-jwt';
+    }
+}
 
 const BASE_OPTIONS = {
     baseUrl: 'https://api.smooai.dev',
-    apiKey: 'test-key',
     orgId: 'org-123',
     environment: 'production',
+    tokenProvider: new StubTokenProvider(),
 };
 
 describe('getConfig', () => {

--- a/src/platform/TokenProvider.test.ts
+++ b/src/platform/TokenProvider.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TokenProvider } from './TokenProvider';
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+vi.mock('@smooai/fetch', () => ({ default: mockFetch }));
+
+const BASE = {
+    authUrl: 'https://auth.example.com',
+    clientId: 'client-abc',
+    clientSecret: 'secret-xyz',
+};
+
+function mockTokenResponse(opts: { token?: string; expiresIn?: number; ok?: boolean; status?: number; body?: string } = {}): void {
+    mockFetch.mockResolvedValueOnce({
+        ok: opts.ok ?? true,
+        status: opts.status ?? 200,
+        json: () => Promise.resolve({ access_token: opts.token ?? 'jwt-1', expires_in: opts.expiresIn ?? 3600 }),
+        text: () => Promise.resolve(opts.body ?? ''),
+    });
+}
+
+describe('TokenProvider', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('throws when authUrl is missing', () => {
+            expect(() => new TokenProvider({ ...BASE, authUrl: '' })).toThrow(/authUrl/);
+        });
+        it('throws when clientId is missing', () => {
+            expect(() => new TokenProvider({ ...BASE, clientId: '' })).toThrow(/clientId/);
+        });
+        it('throws when clientSecret is missing', () => {
+            expect(() => new TokenProvider({ ...BASE, clientSecret: '' })).toThrow(/clientSecret/);
+        });
+        it('trims trailing slashes from authUrl', async () => {
+            const p = new TokenProvider({ ...BASE, authUrl: 'https://auth.example.com///' });
+            mockTokenResponse();
+            await p.getAccessToken();
+            expect(mockFetch).toHaveBeenCalledWith('https://auth.example.com/token', expect.any(Object));
+        });
+    });
+
+    describe('getAccessToken', () => {
+        it('POSTs to /token with client_credentials grant + provider param', async () => {
+            const p = new TokenProvider(BASE);
+            mockTokenResponse({ token: 'jwt-fresh' });
+            const token = await p.getAccessToken();
+            expect(token).toBe('jwt-fresh');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const [url, init] = mockFetch.mock.calls[0];
+            expect(url).toBe('https://auth.example.com/token');
+            expect(init.method).toBe('POST');
+            expect(init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+            const body = new URLSearchParams(init.body);
+            expect(body.get('grant_type')).toBe('client_credentials');
+            expect(body.get('provider')).toBe('client_credentials');
+            expect(body.get('client_id')).toBe('client-abc');
+            expect(body.get('client_secret')).toBe('secret-xyz');
+        });
+
+        it('caches the token and reuses it across calls', async () => {
+            const p = new TokenProvider(BASE);
+            mockTokenResponse({ token: 'jwt-1', expiresIn: 3600 });
+            const t1 = await p.getAccessToken();
+            const t2 = await p.getAccessToken();
+            expect(t1).toBe('jwt-1');
+            expect(t2).toBe('jwt-1');
+            expect(mockFetch).toHaveBeenCalledTimes(1); // cached
+        });
+
+        it('refreshes when within the refresh window of expiry', async () => {
+            const p = new TokenProvider({ ...BASE, refreshWindowSec: 60 });
+            // Time t=0, token expires in 100s. Should be valid for first 40s, then refresh.
+            let nowMs = 0;
+            p._setNowForTests(() => nowMs);
+            mockTokenResponse({ token: 'jwt-1', expiresIn: 100 });
+            expect(await p.getAccessToken()).toBe('jwt-1');
+            // Advance 30s — still valid (refresh window is 60s before expiry; t=30 < 40 threshold)
+            nowMs = 30_000;
+            expect(await p.getAccessToken()).toBe('jwt-1');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            // Advance to 45s — within refresh window (refresh threshold is t=40, since expiry=100s and window=60s)
+            nowMs = 45_000;
+            mockTokenResponse({ token: 'jwt-2', expiresIn: 100 });
+            expect(await p.getAccessToken()).toBe('jwt-2');
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('dedupes concurrent refresh calls (single-flight)', async () => {
+            const p = new TokenProvider(BASE);
+            let resolveFetch!: (v: unknown) => void;
+            mockFetch.mockReturnValueOnce(
+                new Promise((res) => {
+                    resolveFetch = res;
+                }),
+            );
+            const t1 = p.getAccessToken();
+            const t2 = p.getAccessToken();
+            const t3 = p.getAccessToken();
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            resolveFetch({
+                ok: true,
+                json: () => Promise.resolve({ access_token: 'jwt-shared', expires_in: 3600 }),
+                text: () => Promise.resolve(''),
+            });
+            expect(await t1).toBe('jwt-shared');
+            expect(await t2).toBe('jwt-shared');
+            expect(await t3).toBe('jwt-shared');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when the token endpoint returns a non-2xx response', async () => {
+            const p = new TokenProvider(BASE);
+            mockTokenResponse({ ok: false, status: 401, body: 'invalid_client' });
+            await expect(p.getAccessToken()).rejects.toThrow(/OAuth token exchange failed: HTTP 401/);
+        });
+
+        it('throws when the token endpoint returns no access_token', async () => {
+            const p = new TokenProvider(BASE);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({}),
+                text: () => Promise.resolve(''),
+            });
+            await expect(p.getAccessToken()).rejects.toThrow(/no access_token/);
+        });
+
+        it('defaults expires_in to 3600 when missing from the response', async () => {
+            const p = new TokenProvider(BASE);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ access_token: 'jwt-no-expiry' }),
+                text: () => Promise.resolve(''),
+            });
+            expect(await p.getAccessToken()).toBe('jwt-no-expiry');
+            // Second call uses cache (would have failed if expires_in defaulted to 0)
+            expect(await p.getAccessToken()).toBe('jwt-no-expiry');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('invalidate', () => {
+        it('forces a fresh exchange on the next call', async () => {
+            const p = new TokenProvider(BASE);
+            mockTokenResponse({ token: 'jwt-1' });
+            await p.getAccessToken();
+            p.invalidate();
+            mockTokenResponse({ token: 'jwt-2' });
+            expect(await p.getAccessToken()).toBe('jwt-2');
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/src/platform/TokenProvider.ts
+++ b/src/platform/TokenProvider.ts
@@ -1,0 +1,127 @@
+/**
+ * OAuth2 client_credentials token provider for @smooai/config runtime clients.
+ *
+ * Exchanges (clientId, clientSecret) for an access token against `{authUrl}/token`
+ * and caches the JWT in memory until it's within `refreshWindowSec` of expiry.
+ *
+ * Parity with the .NET `TokenProvider` (dotnet/src/SmooAI.Config/OAuth/TokenProvider.cs)
+ * and the bootstrap `mintAccessToken` (src/bootstrap/index.ts). Extracted from
+ * ConfigClient so the same logic can be shared, mocked in tests, and reused by
+ * other in-package callers.
+ *
+ * Server contract:
+ *
+ *     POST {authUrl}/token
+ *     Content-Type: application/x-www-form-urlencoded
+ *
+ *     grant_type=client_credentials
+ *     provider=client_credentials
+ *     client_id=<uuid>
+ *     client_secret=sk_...
+ */
+
+import fetch from '@smooai/fetch';
+
+export interface TokenProviderOptions {
+    /** OAuth issuer base URL (no trailing slash required). E.g. `https://auth.smoo.ai`. */
+    authUrl: string;
+    /** OAuth client ID. */
+    clientId: string;
+    /** OAuth client secret. */
+    clientSecret: string;
+    /**
+     * How many seconds before expiry to proactively refresh the token. Defaults to 60s.
+     * Matches the .NET TokenProvider default.
+     */
+    refreshWindowSec?: number;
+}
+
+interface CachedToken {
+    accessToken: string;
+    /** Unix seconds. */
+    expiresAt: number;
+}
+
+export class TokenProvider {
+    private readonly authUrl: string;
+    private readonly clientId: string;
+    private readonly clientSecret: string;
+    private readonly refreshWindowSec: number;
+    private cached?: CachedToken;
+    private inflight?: Promise<string>;
+    // Test seam — overridden in unit tests.
+    private nowMs: () => number = () => Date.now();
+
+    constructor(options: TokenProviderOptions) {
+        if (!options.authUrl) throw new Error('@smooai/config: TokenProvider requires authUrl');
+        if (!options.clientId) throw new Error('@smooai/config: TokenProvider requires clientId');
+        if (!options.clientSecret) throw new Error('@smooai/config: TokenProvider requires clientSecret');
+        this.authUrl = options.authUrl.replace(/\/+$/, '');
+        this.clientId = options.clientId;
+        this.clientSecret = options.clientSecret;
+        this.refreshWindowSec = options.refreshWindowSec ?? 60;
+    }
+
+    /**
+     * Returns a valid OAuth access token, refreshing from the server if cached
+     * value is missing, expired, or within the refresh window.
+     *
+     * Concurrent callers during a refresh share a single in-flight request to
+     * avoid duplicate token exchanges.
+     */
+    async getAccessToken(): Promise<string> {
+        if (!this.shouldRefresh()) return this.cached!.accessToken;
+        if (this.inflight) return this.inflight;
+        this.inflight = this.refresh().finally(() => {
+            this.inflight = undefined;
+        });
+        return this.inflight;
+    }
+
+    /**
+     * Invalidate the cached token so the next call re-exchanges.
+     * Used by callers that observe a 401 to retry once with a fresh token.
+     */
+    invalidate(): void {
+        this.cached = undefined;
+    }
+
+    private shouldRefresh(): boolean {
+        if (!this.cached) return true;
+        const nowSec = Math.floor(this.nowMs() / 1000);
+        return nowSec >= this.cached.expiresAt - this.refreshWindowSec;
+    }
+
+    private async refresh(): Promise<string> {
+        const res = await fetch(`${this.authUrl}/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'client_credentials',
+                provider: 'client_credentials',
+                client_id: this.clientId,
+                client_secret: this.clientSecret,
+            }).toString(),
+        });
+        if (!res.ok) {
+            const body = await res.text().catch(() => '<unreadable>');
+            throw new Error(`@smooai/config: OAuth token exchange failed: HTTP ${res.status} ${body}`);
+        }
+        const body = (await res.json()) as { access_token?: string; expires_in?: number };
+        if (!body.access_token) {
+            throw new Error('@smooai/config: OAuth token endpoint returned no access_token');
+        }
+        const expiresIn = typeof body.expires_in === 'number' ? body.expires_in : 3600;
+        const nowSec = Math.floor(this.nowMs() / 1000);
+        this.cached = {
+            accessToken: body.access_token,
+            expiresAt: nowSec + expiresIn,
+        };
+        return body.access_token;
+    }
+
+    /** @internal test seam — overrides the time source. */
+    _setNowForTests(now: () => number): void {
+        this.nowMs = now;
+    }
+}

--- a/src/platform/client.integration.test.ts
+++ b/src/platform/client.integration.test.ts
@@ -14,7 +14,10 @@ import { ConfigClient, type ConfigClientOptions } from './client';
 // Test constants
 // ---------------------------------------------------------------------------
 const BASE_URL = 'https://config.smooai.test';
+const AUTH_URL = 'https://auth.smooai.test';
+const CLIENT_ID = 'test-client-id-001';
 const API_KEY = 'test-api-key-12345';
+const ACCESS_TOKEN = 'fake-jwt-access-token';
 const ORG_ID = '550e8400-e29b-41d4-a716-446655440000';
 
 // ---------------------------------------------------------------------------
@@ -59,14 +62,32 @@ function getRequestCount(pathPattern?: string): number {
 // ---------------------------------------------------------------------------
 // MSW Handlers
 // ---------------------------------------------------------------------------
+// SMOODEV-974: The auth model is now OAuth2 client_credentials. Clients POST
+// (CLIENT_ID, API_KEY) to AUTH_URL/token, get back a JWT, then send that JWT
+// as the Bearer on /config/values calls. Handlers below mimic that contract.
 const handlers = [
+    // OAuth token endpoint: POST /token
+    http.post(`${AUTH_URL}/token`, async ({ request }) => {
+        logRequest('POST', request.url);
+        const body = new URLSearchParams(await request.text());
+        if (
+            body.get('grant_type') !== 'client_credentials' ||
+            body.get('provider') !== 'client_credentials' ||
+            body.get('client_id') !== CLIENT_ID ||
+            body.get('client_secret') !== API_KEY
+        ) {
+            return HttpResponse.json({ error: 'invalid_client' }, { status: 401 });
+        }
+        return HttpResponse.json({ access_token: ACCESS_TOKEN, token_type: 'Bearer', expires_in: 3600 });
+    }),
+
     // Single value endpoint: GET /organizations/:orgId/config/values/:key
     http.get(`${BASE_URL}/organizations/:orgId/config/values/:key`, ({ request, params }) => {
         logRequest('GET', request.url);
 
-        // Auth check
+        // Auth check — backend requires the JWT issued by /token, not the raw API key.
         const auth = request.headers.get('Authorization');
-        if (auth !== `Bearer ${API_KEY}`) {
+        if (auth !== `Bearer ${ACCESS_TOKEN}`) {
             return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
 
@@ -92,7 +113,7 @@ const handlers = [
         logRequest('GET', request.url);
 
         const auth = request.headers.get('Authorization');
-        if (auth !== `Bearer ${API_KEY}`) {
+        if (auth !== `Bearer ${ACCESS_TOKEN}`) {
             return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
 
@@ -127,7 +148,9 @@ afterEach(() => server.resetHandlers());
 function createClient(overrides: Partial<ConfigClientOptions> = {}) {
     return new ConfigClient({
         baseUrl: overrides.baseUrl ?? BASE_URL,
-        apiKey: overrides.apiKey ?? API_KEY,
+        authUrl: overrides.authUrl ?? AUTH_URL,
+        clientId: overrides.clientId ?? CLIENT_ID,
+        clientSecret: overrides.clientSecret ?? overrides.apiKey ?? API_KEY,
         orgId: overrides.orgId ?? ORG_ID,
         environment: overrides.environment,
         cacheTtlMs: overrides.cacheTtlMs,
@@ -193,8 +216,10 @@ describe('ConfigClient Integration Tests', () => {
         it('sends the correct Authorization header', async () => {
             const client = createClient();
             await client.getValue('API_URL', 'production');
-            expect(requestLog).toHaveLength(1);
-            // If auth were wrong, we'd get a 401 error
+            // 1 OAuth token exchange + 1 config-values call
+            expect(getRequestCount('/token')).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
+            // If auth were wrong, the MSW handler would have returned 401 and the call would have thrown.
         });
 
         it('URL-encodes keys with special characters', async () => {
@@ -204,7 +229,7 @@ describe('ConfigClient Integration Tests', () => {
                 http.get(`${BASE_URL}/organizations/:orgId/config/values/:key`, ({ request, params }) => {
                     logRequest('GET', request.url);
                     const auth = request.headers.get('Authorization');
-                    if (auth !== `Bearer ${API_KEY}`) {
+                    if (auth !== `Bearer ${ACCESS_TOKEN}`) {
                         return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
                     }
                     // Verify the raw URL contains the encoded form
@@ -219,19 +244,47 @@ describe('ConfigClient Integration Tests', () => {
             expect(value).toBe('found-my/special key');
         });
 
-        it('throws on 401 Unauthorized', async () => {
-            const client = createClient({ apiKey: 'bad-key' });
-            await expect(client.getValue('API_URL', 'production')).rejects.toThrow('Config API error: HTTP 401');
+        it('throws on OAuth token-exchange failure (bad client_secret)', async () => {
+            // Bad secret → /token returns 401 → exchange throws synchronously, never reaches /config/values.
+            // @smooai/fetch wraps the error with the response body, so we just check for 401.
+            const client = createClient({ clientSecret: 'bad-secret' });
+            await expect(client.getValue('API_URL', 'production')).rejects.toThrow(/401/);
+        });
+
+        it('retries once after a downstream 401 (token revoked / rotated)', async () => {
+            // First /config/values call returns 401 even with a valid JWT — simulates
+            // server-side token revocation. Client should invalidate + re-exchange + retry.
+            let downstreamHits = 0;
+            server.use(
+                http.get(`${BASE_URL}/organizations/:orgId/config/values/:key`, ({ request, params }) => {
+                    logRequest('GET', request.url);
+                    downstreamHits++;
+                    if (downstreamHits === 1) {
+                        return HttpResponse.json({ error: 'token revoked' }, { status: 401 });
+                    }
+                    const key = params.key as string;
+                    const url = new URL(request.url);
+                    const env = url.searchParams.get('environment') || 'development';
+                    return HttpResponse.json({ value: MOCK_VALUES[env]?.[key] });
+                }),
+            );
+
+            const client = createClient();
+            const value = await client.getValue('API_URL', 'production');
+            expect(value).toBe('https://api.smooai.com');
+            expect(downstreamHits).toBe(2);
+            // Two /token POSTs (initial + post-401 refresh) + two /config/values GETs
+            expect(getRequestCount('/token')).toBe(2);
         });
 
         it('throws on 403 Forbidden (wrong org)', async () => {
             const client = createClient({ orgId: 'wrong-org-id' });
-            await expect(client.getValue('API_URL', 'production')).rejects.toThrow('Config API error: HTTP 403');
+            await expect(client.getValue('API_URL', 'production')).rejects.toThrow(/403/);
         });
 
         it('throws on 404 Not Found (unknown key)', async () => {
             const client = createClient();
-            await expect(client.getValue('NONEXISTENT_KEY', 'production')).rejects.toThrow('Config API error: HTTP 404');
+            await expect(client.getValue('NONEXISTENT_KEY', 'production')).rejects.toThrow(/404/);
         });
     });
 
@@ -271,20 +324,31 @@ describe('ConfigClient Integration Tests', () => {
             expect(values).toEqual({});
         });
 
-        it('throws on 401 Unauthorized', async () => {
-            const client = createClient({ apiKey: 'wrong-key' });
-            await expect(client.getAllValues('production')).rejects.toThrow('Config API error: HTTP 401');
+        it('throws on OAuth failure (bad client_secret)', async () => {
+            const client = createClient({ clientSecret: 'wrong-secret' });
+            await expect(client.getAllValues('production')).rejects.toThrow(/401/);
         });
 
         it('throws on 403 Forbidden (wrong org)', async () => {
             const client = createClient({ orgId: 'wrong-org' });
-            await expect(client.getAllValues('production')).rejects.toThrow('Config API error: HTTP 403');
+            await expect(client.getAllValues('production')).rejects.toThrow(/403/);
         });
 
-        it('sends exactly one request', async () => {
+        it('sends exactly one /config/values request (plus one /token)', async () => {
             const client = createClient();
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(1);
+            // 1 /token + 1 /config/values
+            expect(getRequestCount('/config/values')).toBe(1);
+            expect(getRequestCount('/token')).toBe(1);
+        });
+
+        it('reuses the cached OAuth token across multiple config calls', async () => {
+            const client = createClient();
+            await client.getValue('API_URL', 'production');
+            await client.getValue('MAX_RETRIES', 'production');
+            await client.getAllValues('production');
+            // OAuth handshake only once
+            expect(getRequestCount('/token')).toBe(1);
         });
     });
 
@@ -296,10 +360,10 @@ describe('ConfigClient Integration Tests', () => {
             const client = createClient();
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1); // No additional request
+            expect(getRequestCount('/config/values')).toBe(1); // No additional request
         });
 
         it('caches different keys independently', async () => {
@@ -307,12 +371,12 @@ describe('ConfigClient Integration Tests', () => {
 
             await client.getValue('API_URL', 'production');
             await client.getValue('MAX_RETRIES', 'production');
-            expect(getRequestCount()).toBe(2); // Two separate fetches
+            expect(getRequestCount('/config/values')).toBe(2); // Two separate fetches
 
             // Both should be cached now
             await client.getValue('API_URL', 'production');
             await client.getValue('MAX_RETRIES', 'production');
-            expect(getRequestCount()).toBe(2); // No additional fetches
+            expect(getRequestCount('/config/values')).toBe(2); // No additional fetches
         });
 
         it('caches per-environment (same key, different env = separate cache entries)', async () => {
@@ -320,12 +384,12 @@ describe('ConfigClient Integration Tests', () => {
 
             await client.getValue('API_URL', 'production');
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(2);
+            expect(getRequestCount('/config/values')).toBe(2);
 
             // Both should be independently cached
             const prod = await client.getValue('API_URL', 'production');
             const staging = await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(2); // Still 2 — both from cache
+            expect(getRequestCount('/config/values')).toBe(2); // Still 2 — both from cache
 
             expect(prod).toBe('https://api.smooai.com');
             expect(staging).toBe('https://api.staging.smooai.com');
@@ -335,13 +399,13 @@ describe('ConfigClient Integration Tests', () => {
             const client = createClient();
 
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             // These should all come from cache
             const apiUrl = await client.getValue('API_URL', 'production');
             const retries = await client.getValue('MAX_RETRIES', 'production');
             const debug = await client.getValue('DEBUG', 'production');
-            expect(getRequestCount()).toBe(1); // No additional requests
+            expect(getRequestCount('/config/values')).toBe(1); // No additional requests
 
             expect(apiUrl).toBe('https://api.smooai.com');
             expect(retries).toBe(3);
@@ -352,12 +416,12 @@ describe('ConfigClient Integration Tests', () => {
             const client = createClient();
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             client.invalidateCache();
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(2); // Had to fetch again
+            expect(getRequestCount('/config/values')).toBe(2); // Had to fetch again
         });
 
         it('invalidateCache clears all environments', async () => {
@@ -365,40 +429,40 @@ describe('ConfigClient Integration Tests', () => {
 
             await client.getValue('API_URL', 'production');
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(2);
+            expect(getRequestCount('/config/values')).toBe(2);
 
             client.invalidateCache();
 
             await client.getValue('API_URL', 'production');
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(4); // Both re-fetched
+            expect(getRequestCount('/config/values')).toBe(4); // Both re-fetched
         });
 
         it('getAllValues for one env does not cache another env', async () => {
             const client = createClient();
 
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             // Staging values are NOT cached
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(2); // Had to fetch
+            expect(getRequestCount('/config/values')).toBe(2); // Had to fetch
         });
 
         it('invalidateCache followed by getAllValues re-populates cache', async () => {
             const client = createClient();
 
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             client.invalidateCache();
 
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(2); // Re-fetched
+            expect(getRequestCount('/config/values')).toBe(2); // Re-fetched
 
             // Should be cached again
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(2); // From cache
+            expect(getRequestCount('/config/values')).toBe(2); // From cache
         });
     });
 
@@ -406,16 +470,58 @@ describe('ConfigClient Integration Tests', () => {
     // Constructor / Configuration
     // -----------------------------------------------------------------------
     describe('constructor', () => {
-        it('throws when baseUrl is missing', () => {
-            expect(() => new ConfigClient({ apiKey: API_KEY, orgId: ORG_ID })).toThrow('baseUrl is required');
+        // SMOODEV-974: stash + clear env vars that ConfigClient defaults from, so
+        // these "required-field-missing" tests don't accidentally pick up a real
+        // SMOOAI_CONFIG_* value from the developer's shell or CI runner.
+        const SAVED_ENV: Record<string, string | undefined> = {};
+        beforeAll(() => {
+            for (const k of [
+                'SMOOAI_CONFIG_API_URL',
+                'SMOOAI_CONFIG_AUTH_URL',
+                'SMOOAI_AUTH_URL',
+                'SMOOAI_CONFIG_CLIENT_ID',
+                'SMOOAI_CONFIG_CLIENT_SECRET',
+                'SMOOAI_CONFIG_API_KEY',
+                'SMOOAI_CONFIG_ORG_ID',
+            ]) {
+                SAVED_ENV[k] = process.env[k];
+                delete process.env[k];
+            }
+        });
+        afterAll(() => {
+            for (const [k, v] of Object.entries(SAVED_ENV)) {
+                if (v === undefined) delete process.env[k];
+                else process.env[k] = v;
+            }
         });
 
-        it('throws when apiKey is missing', () => {
-            expect(() => new ConfigClient({ baseUrl: BASE_URL, orgId: ORG_ID })).toThrow('apiKey is required');
+        it('throws when baseUrl is missing', () => {
+            expect(() => new ConfigClient({ clientId: CLIENT_ID, clientSecret: API_KEY, orgId: ORG_ID })).toThrow('baseUrl is required');
+        });
+
+        it('throws when clientId is missing', () => {
+            expect(() => new ConfigClient({ baseUrl: BASE_URL, clientSecret: API_KEY, orgId: ORG_ID })).toThrow('clientId is required');
+        });
+
+        it('throws when clientSecret is missing', () => {
+            expect(() => new ConfigClient({ baseUrl: BASE_URL, clientId: CLIENT_ID, orgId: ORG_ID })).toThrow('clientSecret is required');
+        });
+
+        it('accepts apiKey as a deprecated alias for clientSecret', async () => {
+            const client = new ConfigClient({
+                baseUrl: BASE_URL,
+                authUrl: AUTH_URL,
+                clientId: CLIENT_ID,
+                apiKey: API_KEY,
+                orgId: ORG_ID,
+                environment: 'production',
+            });
+            const value = await client.getValue('API_URL');
+            expect(value).toBe('https://api.smooai.com');
         });
 
         it('throws when orgId is missing', () => {
-            expect(() => new ConfigClient({ baseUrl: BASE_URL, apiKey: API_KEY })).toThrow('orgId is required');
+            expect(() => new ConfigClient({ baseUrl: BASE_URL, clientId: CLIENT_ID, clientSecret: API_KEY })).toThrow('orgId is required');
         });
 
         it('strips trailing slashes from baseUrl', async () => {
@@ -435,12 +541,12 @@ describe('ConfigClient Integration Tests', () => {
             // 1. Load all values
             const all = await client.getAllValues('production');
             expect(all.API_URL).toBe('https://api.smooai.com');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             // 2. Individual getValue should be cached
             const cached = await client.getValue('API_URL', 'production');
             expect(cached).toBe('https://api.smooai.com');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             // 3. Invalidate
             client.invalidateCache();
@@ -448,7 +554,7 @@ describe('ConfigClient Integration Tests', () => {
             // 4. Re-fetch
             const fresh = await client.getValue('API_URL', 'production');
             expect(fresh).toBe('https://api.smooai.com');
-            expect(getRequestCount()).toBe(2);
+            expect(getRequestCount('/config/values')).toBe(2);
         });
 
         it('works across multiple environments in sequence', async () => {
@@ -461,13 +567,13 @@ describe('ConfigClient Integration Tests', () => {
             expect(prodUrl).toBe('https://api.smooai.com');
             expect(stagingUrl).toBe('https://api.staging.smooai.com');
             expect(devUrl).toBe('http://localhost:3000');
-            expect(getRequestCount()).toBe(3);
+            expect(getRequestCount('/config/values')).toBe(3);
 
             // All should be cached
             await client.getValue('API_URL', 'production');
             await client.getValue('API_URL', 'staging');
             await client.getValue('API_URL', 'development');
-            expect(getRequestCount()).toBe(3); // No new requests
+            expect(getRequestCount('/config/values')).toBe(3); // No new requests
         });
     });
 
@@ -479,11 +585,11 @@ describe('ConfigClient Integration Tests', () => {
             const client = createClient({ cacheTtlMs: 60_000 }); // 60s TTL
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             // Should still be cached
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
         });
 
         it('re-fetches after TTL expires', async () => {
@@ -498,17 +604,17 @@ describe('ConfigClient Integration Tests', () => {
                 const client = createClient({ cacheTtlMs: 100 }); // 100ms TTL
 
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(1);
+                expect(getRequestCount('/config/values')).toBe(1);
 
                 // Still within TTL
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(1);
+                expect(getRequestCount('/config/values')).toBe(1);
 
                 // Advance time past TTL
                 fakeTime += 200;
 
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(2); // Cache expired, re-fetched
+                expect(getRequestCount('/config/values')).toBe(2); // Cache expired, re-fetched
             } finally {
                 Date.now = originalDateNow;
             }
@@ -523,17 +629,17 @@ describe('ConfigClient Integration Tests', () => {
                 const client = createClient({ cacheTtlMs: 100 });
 
                 await client.getAllValues('production');
-                expect(getRequestCount()).toBe(1);
+                expect(getRequestCount('/config/values')).toBe(1);
 
                 // Cached
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(1);
+                expect(getRequestCount('/config/values')).toBe(1);
 
                 // Expire
                 fakeTime += 200;
 
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(2); // Re-fetched
+                expect(getRequestCount('/config/values')).toBe(2); // Re-fetched
             } finally {
                 Date.now = originalDateNow;
             }
@@ -548,13 +654,13 @@ describe('ConfigClient Integration Tests', () => {
                 const client = createClient(); // No TTL
 
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(1);
+                expect(getRequestCount('/config/values')).toBe(1);
 
                 // Advance time significantly
                 fakeTime += 86_400_000; // 24 hours
 
                 await client.getValue('API_URL', 'production');
-                expect(getRequestCount()).toBe(1); // Still cached
+                expect(getRequestCount('/config/values')).toBe(1); // Still cached
             } finally {
                 Date.now = originalDateNow;
             }
@@ -570,42 +676,42 @@ describe('ConfigClient Integration Tests', () => {
 
             await client.getValue('API_URL', 'production');
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(2);
+            expect(getRequestCount('/config/values')).toBe(2);
 
             client.invalidateCacheForEnvironment('production');
 
             // Production re-fetched, staging still cached
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(3);
+            expect(getRequestCount('/config/values')).toBe(3);
 
             await client.getValue('API_URL', 'staging');
-            expect(getRequestCount()).toBe(3); // Still cached
+            expect(getRequestCount('/config/values')).toBe(3); // Still cached
         });
 
         it('clears all keys for the environment', async () => {
             const client = createClient();
 
             await client.getAllValues('production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             client.invalidateCacheForEnvironment('production');
 
             // All production keys need re-fetch
             await client.getValue('API_URL', 'production');
             await client.getValue('MAX_RETRIES', 'production');
-            expect(getRequestCount()).toBe(3);
+            expect(getRequestCount('/config/values')).toBe(3);
         });
 
         it('does nothing for non-existent environment', async () => {
             const client = createClient();
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1);
+            expect(getRequestCount('/config/values')).toBe(1);
 
             client.invalidateCacheForEnvironment('nonexistent');
 
             await client.getValue('API_URL', 'production');
-            expect(getRequestCount()).toBe(1); // Still cached
+            expect(getRequestCount('/config/values')).toBe(1); // Still cached
         });
     });
 });

--- a/src/platform/client.test.ts
+++ b/src/platform/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConfigClient, FeatureFlagContextError, FeatureFlagEvaluationError, FeatureFlagNotFoundError } from './client';
+import { TokenProvider } from './TokenProvider';
 
 // Mock @smooai/fetch module
 const { mockFetch } = vi.hoisted(() => ({
@@ -9,11 +10,29 @@ vi.mock('@smooai/fetch', () => ({
     default: mockFetch,
 }));
 
+/**
+ * SMOODEV-974: test seam — a TokenProvider that returns a fixed JWT without
+ * hitting the auth server. Keeps existing cache/fetch-behavior tests focused
+ * on ConfigClient logic instead of the OAuth handshake.
+ */
+class StubTokenProvider extends TokenProvider {
+    public invalidateCallCount = 0;
+    constructor(private readonly token: string = 'test-access-token') {
+        super({ authUrl: 'https://stub.invalid', clientId: 'stub', clientSecret: 'stub' });
+    }
+    async getAccessToken(): Promise<string> {
+        return this.token;
+    }
+    invalidate(): void {
+        this.invalidateCallCount++;
+    }
+}
+
 const BASE_OPTIONS = {
     baseUrl: 'https://api.smooai.dev',
-    apiKey: 'test-key',
     orgId: 'org-123',
     environment: 'production',
+    tokenProvider: new StubTokenProvider(),
 };
 
 describe('ConfigClient', () => {
@@ -99,7 +118,7 @@ describe('ConfigClient', () => {
                 expect.stringContaining('/config/values'),
                 expect.objectContaining({
                     next: { revalidate: 60 },
-                    headers: expect.objectContaining({ Authorization: 'Bearer test-key' }),
+                    headers: expect.objectContaining({ Authorization: 'Bearer test-access-token' }),
                 }),
             );
         });
@@ -119,7 +138,7 @@ describe('ConfigClient', () => {
                 expect.any(String),
                 expect.objectContaining({
                     headers: expect.objectContaining({
-                        Authorization: 'Bearer test-key',
+                        Authorization: 'Bearer test-access-token',
                         'X-Custom': 'value',
                     }),
                 }),
@@ -145,7 +164,7 @@ describe('ConfigClient', () => {
                     method: 'POST',
                     body: JSON.stringify({ environment: 'production', context: { userId: 'u-1', plan: 'pro' } }),
                     headers: expect.objectContaining({
-                        Authorization: 'Bearer test-key',
+                        Authorization: 'Bearer test-access-token',
                         'Content-Type': 'application/json',
                     }),
                 }),

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -1,23 +1,48 @@
 /**
  * Browser/universal HTTP client for fetching config values from the Smoo AI config server.
  *
- * Environment variables (optional — used as defaults when constructor args are omitted):
- *   SMOOAI_CONFIG_API_URL  — Base URL of the config API
- *   SMOOAI_CONFIG_API_KEY  — Bearer token for authentication
- *   SMOOAI_CONFIG_ORG_ID   — Organization ID
- *   SMOOAI_CONFIG_ENV      — Default environment name (e.g. "production")
+ * Authentication uses OAuth2 `client_credentials` against `{authUrl}/token`,
+ * mirroring the .NET `SmooConfigClient` and the in-package `bootstrap` /
+ * `cli` flows. The exchanged JWT is cached + auto-refreshed by `TokenProvider`.
+ *
+ * Environment variables (used as defaults when constructor args are omitted):
+ *   SMOOAI_CONFIG_API_URL        — Base URL of the config API
+ *   SMOOAI_CONFIG_AUTH_URL       — OAuth issuer base URL (defaults to https://auth.smoo.ai;
+ *                                  also accepts SMOOAI_AUTH_URL)
+ *   SMOOAI_CONFIG_CLIENT_ID      — OAuth client ID
+ *   SMOOAI_CONFIG_CLIENT_SECRET  — OAuth client secret (also accepts SMOOAI_CONFIG_API_KEY)
+ *   SMOOAI_CONFIG_ORG_ID         — Organization ID
+ *   SMOOAI_CONFIG_ENV            — Default environment name (e.g. "production")
  *
  * SMOODEV-602: HTTP calls route through `@smooai/fetch`, which drops in as a
  * replacement for the global `fetch` and adds retries, Retry-After honoring,
  * and clearer error surfaces. Works in both Node and browser bundles.
+ *
+ * SMOODEV-974: ConfigClient now exchanges client credentials for a JWT (parity
+ * with bootstrap/CLI/.NET). Previously it sent the raw API key as Bearer,
+ * which the smooai backend's authMiddleware rejects with 401.
  */
 
 import fetch from '@smooai/fetch';
+import { TokenProvider } from './TokenProvider';
 
 export interface ConfigClientOptions {
     /** Base URL of the config API server. Falls back to SMOOAI_CONFIG_API_URL env var. */
     baseUrl?: string;
-    /** API key (M2M / client credentials token). Falls back to SMOOAI_CONFIG_API_KEY env var. */
+    /**
+     * OAuth issuer base URL. Falls back to SMOOAI_CONFIG_AUTH_URL, then
+     * SMOOAI_AUTH_URL env vars, then `https://auth.smoo.ai`.
+     */
+    authUrl?: string;
+    /** OAuth client ID. Falls back to SMOOAI_CONFIG_CLIENT_ID env var. */
+    clientId?: string;
+    /**
+     * OAuth client secret. Falls back to SMOOAI_CONFIG_CLIENT_SECRET, then
+     * SMOOAI_CONFIG_API_KEY env vars. (The legacy `SMOOAI_CONFIG_API_KEY`
+     * env var holds the OAuth client secret — it is NOT a Bearer token.)
+     */
+    clientSecret?: string;
+    /** @deprecated Alias for `clientSecret`. Kept for source-level compatibility. */
     apiKey?: string;
     /** Organization ID. Falls back to SMOOAI_CONFIG_ORG_ID env var. */
     orgId?: string;
@@ -25,6 +50,11 @@ export interface ConfigClientOptions {
     environment?: string;
     /** Cache TTL in milliseconds. 0 or undefined means cache never expires (manual invalidation only). */
     cacheTtlMs?: number;
+    /**
+     * Test seam — inject a pre-built `TokenProvider` so callers can stub
+     * the OAuth exchange without hitting the auth server.
+     */
+    tokenProvider?: TokenProvider;
 }
 
 interface CacheEntry {
@@ -42,25 +72,36 @@ function getEnv(key: string): string | undefined {
 export class ConfigClient {
     private baseUrl: string;
     private orgId: string;
-    private apiKey: string;
     private defaultEnvironment: string;
     private cacheTtlMs: number;
     private cache: Map<string, CacheEntry> = new Map();
+    private tokenProvider: TokenProvider;
 
     constructor(options: ConfigClientOptions = {}) {
         const baseUrl = options.baseUrl ?? getEnv('SMOOAI_CONFIG_API_URL');
-        const apiKey = options.apiKey ?? getEnv('SMOOAI_CONFIG_API_KEY');
+        const authUrl = options.authUrl ?? getEnv('SMOOAI_CONFIG_AUTH_URL') ?? getEnv('SMOOAI_AUTH_URL') ?? 'https://auth.smoo.ai';
+        const clientId = options.clientId ?? getEnv('SMOOAI_CONFIG_CLIENT_ID');
+        const clientSecret = options.clientSecret ?? options.apiKey ?? getEnv('SMOOAI_CONFIG_CLIENT_SECRET') ?? getEnv('SMOOAI_CONFIG_API_KEY');
         const orgId = options.orgId ?? getEnv('SMOOAI_CONFIG_ORG_ID');
 
         if (!baseUrl) throw new Error('@smooai/config: baseUrl is required (or set SMOOAI_CONFIG_API_URL)');
-        if (!apiKey) throw new Error('@smooai/config: apiKey is required (or set SMOOAI_CONFIG_API_KEY)');
         if (!orgId) throw new Error('@smooai/config: orgId is required (or set SMOOAI_CONFIG_ORG_ID)');
+        if (!options.tokenProvider) {
+            if (!clientId) throw new Error('@smooai/config: clientId is required (or set SMOOAI_CONFIG_CLIENT_ID)');
+            if (!clientSecret) throw new Error('@smooai/config: clientSecret is required (or set SMOOAI_CONFIG_CLIENT_SECRET / SMOOAI_CONFIG_API_KEY)');
+        }
 
         this.baseUrl = baseUrl.replace(/\/+$/, '');
-        this.apiKey = apiKey;
         this.orgId = orgId;
         this.defaultEnvironment = options.environment ?? getEnv('SMOOAI_CONFIG_ENV') ?? 'development';
         this.cacheTtlMs = options.cacheTtlMs ?? 0;
+        this.tokenProvider =
+            options.tokenProvider ??
+            new TokenProvider({
+                authUrl,
+                clientId: clientId!,
+                clientSecret: clientSecret!,
+            });
     }
 
     private computeExpiresAt(): number {
@@ -77,15 +118,37 @@ export class ConfigClient {
         return entry.value;
     }
 
+    private async authHeader(): Promise<string> {
+        return `Bearer ${await this.tokenProvider.getAccessToken()}`;
+    }
+
     private async fetchJson<T>(path: string, fetchOptions?: RequestInit): Promise<T> {
-        const response = await fetch(`${this.baseUrl}${path}`, {
-            ...fetchOptions,
-            headers: { Authorization: `Bearer ${this.apiKey}`, ...fetchOptions?.headers },
-        });
-        if (!response.ok) {
-            throw new Error(`Config API error: HTTP ${response.status} ${response.statusText}`);
+        const send = async (): Promise<Response> =>
+            fetch(`${this.baseUrl}${path}`, {
+                ...fetchOptions,
+                headers: { Authorization: await this.authHeader(), ...fetchOptions?.headers },
+            });
+
+        try {
+            const response = await send();
+            if (!response.ok) {
+                throw new Error(`Config API error: HTTP ${response.status} ${response.statusText}`);
+            }
+            return response.json() as Promise<T>;
+        } catch (err) {
+            // @smooai/fetch throws HTTPResponseError on non-2xx, exposing the response on `.response`.
+            // If we got a 401, the cached OAuth token may have been revoked/rotated — drop it and retry once.
+            const status = (err as { response?: { status?: number } } | undefined)?.response?.status;
+            if (status === 401) {
+                this.tokenProvider.invalidate();
+                const response = await send();
+                if (!response.ok) {
+                    throw new Error(`Config API error: HTTP ${response.status} ${response.statusText}`);
+                }
+                return response.json() as Promise<T>;
+            }
+            throw err;
         }
-        return response.json() as Promise<T>;
     }
 
     /**
@@ -194,29 +257,62 @@ export class ConfigClient {
      */
     async evaluateFeatureFlag(key: string, context: Record<string, unknown> = {}, environment?: string): Promise<EvaluateFeatureFlagResponse> {
         const env = environment ?? this.defaultEnvironment;
-        const response = await fetch(`${this.baseUrl}/organizations/${this.orgId}/config/feature-flags/${encodeURIComponent(key)}/evaluate`, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ environment: env, context }),
-        });
+        const url = `${this.baseUrl}/organizations/${this.orgId}/config/feature-flags/${encodeURIComponent(key)}/evaluate`;
+        const send = async (): Promise<Response> =>
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    Authorization: await this.authHeader(),
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ environment: env, context }),
+            });
 
-        if (response.status === 404) {
-            throw new FeatureFlagNotFoundError(key);
-        }
-        if (response.status === 400) {
-            const text = await response.text().catch(() => '');
-            throw new FeatureFlagContextError(key, text);
-        }
-        if (!response.ok) {
-            const text = await response.text().catch(() => '');
-            throw new FeatureFlagEvaluationError(key, response.status, text);
-        }
+        const dispatchOrThrow = async (response: Response): Promise<EvaluateFeatureFlagResponse> => {
+            if (response.status === 404) {
+                throw new FeatureFlagNotFoundError(key);
+            }
+            if (response.status === 400) {
+                const text = await response.text().catch(() => '');
+                throw new FeatureFlagContextError(key, text);
+            }
+            if (!response.ok) {
+                const text = await response.text().catch(() => '');
+                throw new FeatureFlagEvaluationError(key, response.status, text);
+            }
+            return (await response.json()) as EvaluateFeatureFlagResponse;
+        };
 
-        return (await response.json()) as EvaluateFeatureFlagResponse;
+        try {
+            const response = await send();
+            return await dispatchOrThrow(response);
+        } catch (err) {
+            // @smooai/fetch wraps non-2xx as HTTPResponseError. Translate to the
+            // typed FeatureFlag* errors so callers can branch on subclass,
+            // and retry once on 401 with a fresh OAuth token.
+            const inner = err as { response?: Response & { status?: number; isJson?: boolean; data?: { message?: string }; dataString?: string } };
+            const status = inner?.response?.status;
+            if (status === undefined) throw err; // not an HTTPResponseError — propagate
+            if (status === 401) {
+                this.tokenProvider.invalidate();
+                const response = await send();
+                try {
+                    return await dispatchOrThrow(response);
+                } catch (innerErr) {
+                    const r = (innerErr as { response?: { status?: number; dataString?: string; data?: { message?: string } } }).response;
+                    if (r?.status === undefined) throw innerErr;
+                    return throwFlagError(key, r.status, r.dataString ?? r.data?.message);
+                }
+            }
+            return throwFlagError(key, status, inner.response?.dataString ?? inner.response?.data?.message);
+        }
     }
+}
+
+function throwFlagError(key: string, status: number, body?: string): never {
+    if (status === 404) throw new FeatureFlagNotFoundError(key);
+    if (status === 400) throw new FeatureFlagContextError(key, body);
+    throw new FeatureFlagEvaluationError(key, status, body);
 }
 
 /**

--- a/src/vite/preloadConfig.test.ts
+++ b/src/vite/preloadConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TokenProvider } from '../platform/TokenProvider';
 import { preloadConfig, getPreloadedConfig, resetPreload } from './preloadConfig';
 
 // Mock @smooai/fetch module
@@ -9,11 +10,22 @@ vi.mock('@smooai/fetch', () => ({
     default: mockFetch,
 }));
 
+// SMOODEV-974: stub TokenProvider so these tests focus on preload behavior,
+// not the OAuth handshake (covered by TokenProvider.test.ts).
+class StubTokenProvider extends TokenProvider {
+    constructor() {
+        super({ authUrl: 'https://stub.invalid', clientId: 'stub', clientSecret: 'stub' });
+    }
+    async getAccessToken(): Promise<string> {
+        return 'stub-jwt';
+    }
+}
+
 const BASE_OPTIONS = {
     baseUrl: 'https://api.smooai.dev',
-    apiKey: 'test-key',
     orgId: 'org-123',
     environment: 'production',
+    tokenProvider: new StubTokenProvider(),
 };
 
 describe('preloadConfig', () => {
@@ -53,9 +65,12 @@ describe('preloadConfig', () => {
         const promise2 = preloadConfig(BASE_OPTIONS);
 
         expect(promise1).toBe(promise2);
-        expect(mockFetch).toHaveBeenCalledTimes(1);
 
+        // SMOODEV-974: must await before the fetch count check — getAccessToken
+        // is now an async step (even with the stub provider) so the underlying
+        // fetch is scheduled in a microtask after preloadConfig returns.
         await promise1;
+        expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('getPreloadedConfig returns null before completion', () => {


### PR DESCRIPTION
## Summary
`ConfigClient` was sending the raw `SMOOAI_CONFIG_API_KEY` as the Bearer token on `/config/values` calls. The smooai backend's authMiddleware only accepts JWT bearer tokens, so every runtime call from the TS SDK 401'd — observed as ~168/day "Invalid access token" in prod CloudWatch from apps/web SSR. Live feature flag fetches silently fell through to in-memory cache / default values.

`bootstrap`, the CLI, and `.NET SmooConfigClient` already did the right thing. The TS runtime SDK was the outlier; Python, Go, Rust have the same bug and ship in follow-up tickets.

## What changed
- **New `TokenProvider` class** (`src/platform/TokenProvider.ts`) — mirrors `SmooAI.Config.OAuth.TokenProvider`. Mints `client_credentials` JWTs, caches with 60s refresh window, dedupes concurrent refreshes (single-flight).
- **`ConfigClient.constructor`** now requires `clientId` in addition to `clientSecret` (legacy `apiKey` accepted as deprecated alias). Throws if missing.
- **`ConfigClient.fetchJson` + `evaluateFeatureFlag`** use `await tokenProvider.getAccessToken()` for the Bearer header. On 401, invalidate cached token + retry once.
- **Tests**: 12 new TokenProvider tests + integration MSW `/token` handler + OAuth-failure + 401-retry coverage.
- **README** updated — removed misleading "Bearer token for authentication" copy, documented `CLIENT_ID`/`CLIENT_SECRET` env vars.
- **Changeset**: major version bump (breaking constructor signature).

## Test plan
- [x] `pnpm vitest run` — 218 tests pass (21 files)
- [x] `pnpm typecheck`
- [ ] Once published: bump `@smooai/config` in smooai monorepo + wire `SMOOAI_CONFIG_CLIENT_ID` env to apps/web Lambda
- [ ] Monitor prod CloudWatch — 168/day "Invalid access token" should drop to 0

## Follow-ups (separate PRs in this repo)
- Python `ConfigClient` parity (TBD ticket)
- Go `ConfigClient` parity (TBD ticket)
- Rust `ConfigClient` parity (TBD ticket — Rust tests currently hardcode the broken behavior and will need updating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)