### PR TITLE
SMOODEV-974: Fix SmooConfigProvider test (follow-up to #82)

### DIFF
--- a/src/nextjs/SmooConfigProvider.test.tsx
+++ b/src/nextjs/SmooConfigProvider.test.tsx
@@ -1,17 +1,29 @@
 import { cleanup, render, screen } from '@testing-library/react';
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenProvider } from '../platform/TokenProvider';
 import { useConfigClient } from '../react/ConfigProvider';
 import { SmooConfigProvider } from './SmooConfigProvider';
 
 // Mock fetch to prevent actual API calls
 vi.stubGlobal('fetch', vi.fn());
 
+// SMOODEV-974: stub TokenProvider so these tests don't reach the OAuth
+// handshake — they care about provider/hook wiring, not network behavior.
+class StubTokenProvider extends TokenProvider {
+    constructor() {
+        super({ authUrl: 'https://stub.invalid', clientId: 'stub', clientSecret: 'stub' });
+    }
+    async getAccessToken(): Promise<string> {
+        return 'stub-jwt';
+    }
+}
+
 const BASE_OPTIONS = {
     baseUrl: 'https://api.smooai.dev',
-    apiKey: 'test-key',
     orgId: 'org-123',
     environment: 'production',
+    tokenProvider: new StubTokenProvider(),
 };
 
 // Test component that reads from the config client


### PR DESCRIPTION
Release on main failed because `SmooConfigProvider.test.tsx` still passed `apiKey` without `clientId` to ConfigClient, which now throws after #82. Updated to use a StubTokenProvider matching the pattern in #82. All 218 tests pass.