### PR TITLE
SMOODEV-974: Fix Python ConfigManager/runtime/priority-chain post-OAuth

### DIFF
--- a/python/src/smooai_config/config_manager.py
+++ b/python/src/smooai_config/config_manager.py
@@ -92,6 +92,9 @@ class ConfigManager:
         self,
         *,
         api_key: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        auth_url: str | None = None,
         base_url: str | None = None,
         org_id: str | None = None,
         environment: str | None = None,
@@ -110,7 +113,14 @@ class ConfigManager:
         self._public_cache: dict[str, tuple[Any, float]] = {}
         self._secret_cache: dict[str, tuple[Any, float]] = {}
         self._feature_flag_cache: dict[str, tuple[Any, float]] = {}
+        # SMOODEV-974: ConfigClient now exchanges (client_id, client_secret)
+        # for an OAuth JWT before each call. Accept the new params; keep
+        # ``api_key`` as a deprecated alias for ``client_secret`` so existing
+        # callers continue to work.
         self._api_key = api_key
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._auth_url = auth_url
         self._base_url = base_url
         self._org_id = org_id
         self._environment = environment
@@ -149,19 +159,31 @@ class ConfigManager:
         )
 
         # 3. Try remote fetch if API creds available
+        # SMOODEV-974: ConfigClient now requires (client_id, client_secret) to
+        # mint an OAuth JWT. ``api_key`` is accepted as a deprecated alias for
+        # ``client_secret`` to keep the public surface stable.
         remote_config: dict[str, Any] = {}
-        api_key = self._api_key or self._resolve_env_var("SMOOAI_CONFIG_API_KEY")
+        client_secret = (
+            self._client_secret
+            or self._api_key
+            or self._resolve_env_var("SMOOAI_CONFIG_CLIENT_SECRET")
+            or self._resolve_env_var("SMOOAI_CONFIG_API_KEY")
+        )
+        client_id = self._client_id or self._resolve_env_var("SMOOAI_CONFIG_CLIENT_ID")
         base_url = self._base_url or self._resolve_env_var("SMOOAI_CONFIG_API_URL")
         org_id = self._org_id or self._resolve_env_var("SMOOAI_CONFIG_ORG_ID")
+        auth_url = self._auth_url or self._resolve_env_var("SMOOAI_CONFIG_AUTH_URL")
 
-        if api_key and base_url and org_id:
+        if client_id and client_secret and base_url and org_id:
             # Resolve environment: explicit param > env var > default "development"
             resolved_environment = self._environment or self._resolve_env_var("SMOOAI_CONFIG_ENV") or "development"
 
             try:
                 client = ConfigClient(
                     base_url=base_url,
-                    api_key=api_key,
+                    auth_url=auth_url,
+                    client_id=client_id,
+                    client_secret=client_secret,
                     org_id=org_id,
                     environment=resolved_environment,
                 )

--- a/python/src/smooai_config/runtime.py
+++ b/python/src/smooai_config/runtime.py
@@ -114,6 +114,9 @@ def build_config_runtime(
     flag_cache_ttl_seconds: float = 30.0,
     base_url: str | None = None,
     api_key: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    auth_url: str | None = None,
     org_id: str | None = None,
     environment: str | None = None,
 ) -> ConfigClient:
@@ -125,6 +128,11 @@ def build_config_runtime(
     If a ``flag_client`` is passed, it's used as-is (hydrated). Otherwise a
     fresh :class:`ConfigClient` is constructed from the usual env vars +
     optional overrides.
+
+    SMOODEV-974: ConfigClient now exchanges (client_id, client_secret) for
+    an OAuth JWT before each call. Either pass them explicitly, or set the
+    ``SMOOAI_CONFIG_CLIENT_ID`` / ``SMOOAI_CONFIG_CLIENT_SECRET`` env vars.
+    ``api_key`` remains accepted as a deprecated alias for ``client_secret``.
 
     Example::
 
@@ -141,6 +149,9 @@ def build_config_runtime(
 
     client = ConfigClient(
         base_url=base_url,
+        auth_url=auth_url,
+        client_id=client_id,
+        client_secret=client_secret,
         api_key=api_key,
         org_id=org_id,
         environment=environment,

--- a/python/tests/test_config_manager.py
+++ b/python/tests/test_config_manager.py
@@ -18,6 +18,7 @@ from smooai_config.file_config import _clear_config_dir_cache
 
 TEST_BASE_URL = "https://config-test.smooai.dev"
 TEST_API_KEY = "test-api-key-abc123"
+TEST_CLIENT_ID = "test-client-id-abc123"
 TEST_ORG_ID = "550e8400-e29b-41d4-a716-446655440000"
 
 
@@ -186,6 +187,7 @@ class TestRemoteEnrichment:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -205,6 +207,7 @@ class TestRemoteEnrichment:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -231,6 +234,7 @@ class TestMergePrecedence:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -254,6 +258,7 @@ class TestMergePrecedence:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -289,6 +294,7 @@ class TestNestedObjectMerge:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -314,6 +320,7 @@ class TestNestedObjectMerge:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -349,6 +356,7 @@ class TestGracefulDegradationServerError:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -380,6 +388,7 @@ class TestGracefulDegradationConnectionRefused:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -519,6 +528,7 @@ class TestApiCredsFromEnvVars:
                 "SMOOAI_ENV_CONFIG_DIR": config_dir,
                 "SMOOAI_CONFIG_ENV": "production",
                 "SMOOAI_CONFIG_API_KEY": TEST_API_KEY,
+                "SMOOAI_CONFIG_CLIENT_ID": TEST_CLIENT_ID,
                 "SMOOAI_CONFIG_API_URL": TEST_BASE_URL,
                 "SMOOAI_CONFIG_ORG_ID": TEST_ORG_ID,
             },
@@ -540,7 +550,7 @@ class TestApiCredsFromEnvVars:
             env={
                 "SMOOAI_ENV_CONFIG_DIR": config_dir,
                 "SMOOAI_CONFIG_ENV": "test",
-                # No SMOOAI_CONFIG_API_KEY
+                # No SMOOAI_CONFIG_API_KEY / SMOOAI_CONFIG_CLIENT_ID
                 "SMOOAI_CONFIG_API_URL": TEST_BASE_URL,
                 "SMOOAI_CONFIG_ORG_ID": TEST_ORG_ID,
             },
@@ -568,6 +578,7 @@ class TestApiCredsFromConstructor:
 
         mgr = ConfigManager(
             api_key="constructor-key",
+            client_id="constructor-client-id",
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -575,6 +586,7 @@ class TestApiCredsFromConstructor:
                 "SMOOAI_ENV_CONFIG_DIR": config_dir,
                 "SMOOAI_CONFIG_ENV": "test",
                 "SMOOAI_CONFIG_API_KEY": "env-key",
+                "SMOOAI_CONFIG_CLIENT_ID": "env-client-id",
                 "SMOOAI_CONFIG_API_URL": "https://env-url.example.com",
                 "SMOOAI_CONFIG_ORG_ID": "env-org-id",
             },
@@ -630,6 +642,7 @@ class TestThreadSafety:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -688,6 +701,7 @@ class TestFullIntegration:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -733,6 +747,7 @@ class TestFullIntegration:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -763,6 +778,7 @@ class TestEnvironmentResolution:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="staging",
@@ -788,6 +804,7 @@ class TestEnvironmentResolution:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             # No explicit environment param
@@ -812,6 +829,7 @@ class TestEnvironmentResolution:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             # No explicit environment, no SMOOAI_CONFIG_ENV
@@ -842,6 +860,7 @@ class TestInvalidationRefetches:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -890,6 +909,7 @@ class TestInvalidationRefetches:
 
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",
@@ -1013,6 +1033,7 @@ class TestDeferredConfigValues:
         transport = create_mock_transport(values={"HOST": "remote-host", "PORT": 8080})
         mgr = ConfigManager(
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             base_url=TEST_BASE_URL,
             org_id=TEST_ORG_ID,
             environment="production",

--- a/python/tests/test_priority_chain_integration.py
+++ b/python/tests/test_priority_chain_integration.py
@@ -45,6 +45,7 @@ from smooai_config.runtime import (
 
 TEST_BASE_URL = "https://config.smooai.test"
 TEST_API_KEY = "test-api-key-priority-chain"
+TEST_CLIENT_ID = "test-client-id-priority-chain"
 TEST_ORG_ID = "550e8400-e29b-41d4-a716-446655440000"
 # SMOODEV-975: After OAuth exchange the runtime client uses this JWT.
 TEST_JWT = "stub-jwt-priority-chain"
@@ -162,6 +163,7 @@ class TestConfigManagerPriority:
         with _patch_client_transport(transport):
             mgr = ConfigManager(
                 api_key=TEST_API_KEY,
+                client_id=TEST_CLIENT_ID,
                 base_url=TEST_BASE_URL,
                 org_id=TEST_ORG_ID,
                 environment="production",
@@ -183,6 +185,7 @@ class TestConfigManagerPriority:
         with _patch_client_transport(transport):
             mgr = ConfigManager(
                 api_key=TEST_API_KEY,
+                client_id=TEST_CLIENT_ID,
                 base_url=TEST_BASE_URL,
                 org_id=TEST_ORG_ID,
                 environment="production",
@@ -219,6 +222,7 @@ class TestConfigManagerHttpFault:
         with _patch_client_transport(transport):
             mgr = ConfigManager(
                 api_key=TEST_API_KEY,
+                client_id=TEST_CLIENT_ID,
                 base_url=TEST_BASE_URL,
                 org_id=TEST_ORG_ID,
                 environment="production",
@@ -239,6 +243,7 @@ class TestConfigManagerHttpFault:
         with _patch_client_transport(transport):
             mgr = ConfigManager(
                 api_key=TEST_API_KEY,
+                client_id=TEST_CLIENT_ID,
                 base_url=TEST_BASE_URL,
                 org_id=TEST_ORG_ID,
                 environment="production",
@@ -279,6 +284,7 @@ class TestConfigManagerCaching:
         with _patch_client_transport(transport):
             mgr = ConfigManager(
                 api_key=TEST_API_KEY,
+                client_id=TEST_CLIENT_ID,
                 base_url=TEST_BASE_URL,
                 org_id=TEST_ORG_ID,
                 environment="production",
@@ -322,6 +328,7 @@ class TestBlobHydration:
         client = ConfigClient(
             base_url=TEST_BASE_URL,
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             org_id=TEST_ORG_ID,
             environment="production",
         )
@@ -342,6 +349,7 @@ class TestBlobHydration:
         client = ConfigClient(
             base_url=TEST_BASE_URL,
             api_key=TEST_API_KEY,
+            client_id=TEST_CLIENT_ID,
             org_id=TEST_ORG_ID,
             environment="production",
         )

--- a/python/tests/test_runtime.py
+++ b/python/tests/test_runtime.py
@@ -91,6 +91,9 @@ def test_hydrate_seeds_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     # ConfigClient requires these — stub so construction succeeds.
     monkeypatch.setenv("SMOOAI_CONFIG_API_URL", "https://api.smoo.ai")
     monkeypatch.setenv("SMOOAI_CONFIG_API_KEY", "test-key")
+    # SMOODEV-974: ConfigClient ctor requires client_id when no token_provider
+    # is injected. Stub the env var so construction succeeds offline.
+    monkeypatch.setenv("SMOOAI_CONFIG_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("SMOOAI_CONFIG_ORG_ID", "test-org")
     monkeypatch.setenv("SMOOAI_CONFIG_ENV", "production")
 
@@ -112,6 +115,9 @@ def test_hydrate_returns_zero_without_env(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.delenv("SMOO_CONFIG_KEY", raising=False)
     monkeypatch.setenv("SMOOAI_CONFIG_API_URL", "https://api.smoo.ai")
     monkeypatch.setenv("SMOOAI_CONFIG_API_KEY", "test-key")
+    # SMOODEV-974: ConfigClient ctor requires client_id when no token_provider
+    # is injected. Stub the env var so construction succeeds offline.
+    monkeypatch.setenv("SMOOAI_CONFIG_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("SMOOAI_CONFIG_ORG_ID", "test-org")
     monkeypatch.setenv("SMOOAI_CONFIG_ENV", "production")
 


### PR DESCRIPTION
## Summary

After PRs #82/#83/#85 shipped the OAuth `client_credentials` flow across all 5 ConfigClient SDKs, the Release workflow on `6c66970` failed with **21 Python test failures**. Two distinct root causes:

- **Production gap.** `ConfigManager._initialize` and `runtime.build_config_runtime` forwarded `api_key` to `ConfigClient` but never `client_id`, so the new ctor guard (`client_id is required`) fired and the warning got swallowed — `ConfigManager` silently dropped back to file+env tiers. Local dev shells had `SMOOAI_CONFIG_CLIENT_ID` exported, which masked the bug.
- **Test fixture gap.** Per-test `ConfigManager(api_key=…, base_url=…, org_id=…)` constructions (and the env-vars test) supplied no `client_id`, so the same guard fired even in tests that never made HTTP calls. The `/token` mock from PR #85 was already in place; just needed to thread `client_id`.

## Changes

**Production**
- `ConfigManager` accepts `client_id` / `client_secret` / `auth_url`, resolves from `SMOOAI_CONFIG_CLIENT_ID` / `_CLIENT_SECRET` / `_AUTH_URL` env vars, and gates the remote fetch on `(client_id, client_secret, base_url, org_id)`. `api_key` remains a deprecated alias for `client_secret`.
- `runtime.build_config_runtime` threads `client_id` / `client_secret` / `auth_url` through to the constructed `ConfigClient`.

**Tests**
- `test_config_manager`: add `TEST_CLIENT_ID`, pass it alongside `api_key` in every `ConfigManager(...)`, add `SMOOAI_CONFIG_CLIENT_ID` to the env-vars and constructor tests.
- `test_priority_chain_integration`: same plus pass `client_id` to the bare `ConfigClient` construction in `TestBlobHydration`.
- `test_runtime`: stub `SMOOAI_CONFIG_CLIENT_ID` alongside the existing `api_key` stub.

No assertion was loosened — every test still verifies the original behavior under the OAuth-aware client.

## Test plan
- [x] `pnpm python:test` — 323 passed (with all local `SMOOAI_*` env vars unset, matching CI)
- [x] `pnpm python:lint` — clean
- [x] `pnpm python:typecheck` — 0 errors

Unblocks v6.0.0 of `@smooai/config`. No changeset — the major bump from PR #85 already covers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)