### PR TITLE
SMOODEV-1412: README — CLI moved to th config in smooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 **Type-safe config, secrets, and feature flags for every layer of your stack** -- One schema, one API, every language. Rename a key and every call site is a compile error, not a 3 AM page.
 
+> 📣 **The CLI moved.** Use `th config` from the [smooth repo](https://github.com/SmooAI/smooth) for all operator commands (login, get, set, list, push, pull, diff, init, etc.). The standalone `smooai-config` CLI that used to live in this repo is deprecated and being deleted (SMOODEV-1411). **The runtime library `@smooai/config` (TypeScript / Python / Rust / Go / .NET, consumed via `secretConfig.get(...)` / `publicConfig.get(...)` / `featureFlag.get(...)`) is unchanged** — only the operator CLI surface moved to Rust in the smooth repo.
+
 ![NPM Version](https://img.shields.io/npm/v/%40smooai%2Fconfig?style=for-the-badge)
 ![NPM Downloads](https://img.shields.io/npm/dw/%40smooai%2Fconfig?style=for-the-badge)
 ![NPM Last Update](https://img.shields.io/npm/last-update/%40smooai%2Fconfig?style=for-the-badge)


### PR DESCRIPTION
## Summary

Lane F of the SMOODEV-1411/1412 CLI migration: add a banner to the top of the README calling out that the standalone `smooai-config` CLI in this repo is deprecated and being deleted under SMOODEV-1411. Operator commands (login, get, set, list, push, pull, diff, init, etc.) now go through `th config` in the [smooth](https://github.com/SmooAI/smooth) repo.

**The runtime library (`@smooai/config` — TypeScript, Python, Rust, Go, .NET) is unchanged.** The whole runtime side of the README — `defineConfig()`, the Next.js / Vite plugins, the Server Components + client hydration story, `buildConfigObject` / `secretConfig.getSync()` / sync-worker sidecar packaging, the React hooks, the runtime `ConfigClient` env vars, the configuration tiers + B2M restrictions, the multi-language SDK orientation snippets — all stays as is, because all of that is the runtime library, not the CLI.

The README didn't actually have explicit `smooai-config` CLI sections (no `login` / `get` / `set` / `push` operator command sections to remove). It's already focused on the runtime client and SDK integration. So this is just the banner — no strikethroughs or section removals needed.

Other `smooai-config` references in the README are intentionally left in place:

- `.smooai-config/config.ts` — the schema directory path, not the CLI.
- `pip install smooai-config` / `cargo add smooai-config` — Python and Rust runtime package names, unchanged.

## Test plan

- [x] grep README for `smooai-config` — confirms the only remaining references are the schema directory path and the Python/Rust runtime package names (which are not the CLI)
- [x] commit message ends with `Co-Authored-By` trailer; no `--no-verify`
- [ ] CI green (will land via merge after CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)