### PR TITLE
SMOODEV-1490: Container/runtime mode (TS reference impl)

### DIFF
--- a/.changeset/container-runtime-mode-ts.md
+++ b/.changeset/container-runtime-mode-ts.md
@@ -1,0 +1,13 @@
+---
+'@smooai/config': minor
+---
+
+SMOODEV-1490: Add container/runtime mode (`@smooai/config/container`) — the TypeScript reference implementation of the five-language parity contract (SMOODEV-1489).
+
+Container mode makes the HTTP config API the first-class, fail-loud path for long-lived containers (EKS/ECS) instead of the Lambda-oriented baked blob:
+
+- `initContainerConfig(options?)` — validates the container env contract, mints an M2M OAuth token, and does an initial config fetch so auth/network failures surface at startup (not first read). Missing/blank required env throws a typed `ConfigBootstrapError` listing exactly which vars are missing.
+- Fail-loud reads — `secretConfig.get`/`getSync` (and public/flag analogs) throw `ConfigKeyUnresolvedError { key, env, triedTiers }` for a required key that resolves absent, instead of silently returning `undefined` (the SMOODEV-1478 CrashLoop class). `optionalKeys` opts specific keys out.
+- `configHealth()` / `handle.health()` — non-throwing status for Kubernetes readiness/liveness probes; serves last-good within the 30s cache TTL, reports `Unhealthy` past hard-expiry.
+- `selectMode()` — mode selection (explicit `SMOOAI_CONFIG_MODE=container`, blob/file present → default, or auto-select on M2M creds).
+- New canonical doc `docs/Container-Runtime-Mode.md` with the env contract, an ExternalSecret (External Secrets Operator) recipe, and a readiness-probe example.

--- a/README.md
+++ b/README.md
@@ -492,6 +492,37 @@ client.invalidateCache();
 
 ---
 
+## Container / Runtime Mode (EKS / ECS)
+
+The baked **blob** tier is the blessed path for **Lambda**, but it is the wrong default for long-lived **containers**: when the per-build blob key isn't delivered to the pod, resolution silently falls through to the (absent) file tier and returns `undefined` for a required secret. That caused a real outage — a container got `undefined` for `STRIPE_API_KEY`, `new Stripe(undefined)` threw at module load, the process exited `0` before `listen()`, and the pod CrashLooped with the root cause buried (SMOODEV-1478).
+
+**Container mode** makes the HTTP config API the first-class path for containers, authenticated with an OAuth2 `client_credentials` (M2M) token, and **fails loud**: a required value that doesn't resolve throws a typed error instead of returning `undefined`.
+
+> **Containers use container mode, not the baked blob.** See [`docs/Container-Runtime-Mode.md`](docs/Container-Runtime-Mode.md) for the full env contract, a complete ExternalSecret (External Secrets Operator) recipe, and a readiness-probe example.
+
+```ts
+import { initContainerConfig, ConfigKeyUnresolvedError } from '@smooai/config/container';
+import schema from '../.smooai-config/config';
+
+// Validates the container env, mints a token, and does an initial fetch —
+// startup fails LOUD here (throws), not on first read.
+const config = await initContainerConfig({ schema });
+
+// Fail-loud: a required secret that doesn't resolve throws
+// ConfigKeyUnresolvedError instead of returning undefined.
+const stripeKey = await config.secretConfig.get('stripeApiKey');
+
+// Kubernetes readiness probe — never throws.
+app.get('/healthz/config', (_req, res) => {
+    const h = config.health(); // { status: 'healthy' } | { status: 'unhealthy', reason }
+    res.status(h.status === 'healthy' ? 200 : 503).json(h);
+});
+```
+
+Env contract (identical in every SDK): `SMOOAI_CONFIG_API_URL`, `SMOOAI_CONFIG_CLIENT_ID`, `SMOOAI_CONFIG_CLIENT_SECRET`, `SMOOAI_CONFIG_ORG_ID`, `SMOOAI_CONFIG_ENV` (all required), plus optional `SMOOAI_CONFIG_AUTH_URL` and `SMOOAI_CONFIG_MODE=container` (to force the mode). All schema-declared keys are treated as **required** by default; opt specific keys out with `initContainerConfig({ optionalKeys: ['...'] })`.
+
+---
+
 ## Configuration Tiers
 
 | Tier              | Purpose                 | Examples                                 |

--- a/docs/Container-Runtime-Mode-Spec.md
+++ b/docs/Container-Runtime-Mode-Spec.md
@@ -4,7 +4,7 @@
 
 ## Why
 
-`@smooai/config` has four resolution tiers: **blob → env → HTTP → file**. The blob tier (an encrypted config bundle baked into a Lambda layer / image at deploy time, decrypted with a key delivered separately) is the blessed path for **Lambda**. It is the *wrong* default for long-lived **containers** (EKS/ECS): the per-build blob key has to be delivered to the pod, and when it isn't, resolution silently falls through to the (absent) file tier and returns **`undefined`** for a required secret. A real incident (SMOODEV-1478): a container got `undefined` for `STRIPE_API_KEY`, a module-load `new Stripe(undefined)` threw, the process exited 0 before `listen()`, and the service CrashLooped — with the root cause buried under unrelated log noise.
+`@smooai/config` has four resolution tiers: **blob → env → HTTP → file**. The blob tier (an encrypted config bundle baked into a Lambda layer / image at deploy time, decrypted with a key delivered separately) is the blessed path for **Lambda**. It is the _wrong_ default for long-lived **containers** (EKS/ECS): the per-build blob key has to be delivered to the pod, and when it isn't, resolution silently falls through to the (absent) file tier and returns **`undefined`** for a required secret. A real incident (SMOODEV-1478): a container got `undefined` for `STRIPE_API_KEY`, a module-load `new Stripe(undefined)` threw, the process exited 0 before `listen()`, and the service CrashLooped — with the root cause buried under unrelated log noise.
 
 Container/Runtime Mode makes the **HTTP tier the blessed, first-class path for containers**, authenticated with an OAuth2 `client_credentials` (M2M) token, **fail-loud** so a missing required value is an immediate, clear error (not a silent `undefined`), and **documented** with a canonical Kubernetes/ExternalSecret recipe.
 
@@ -12,21 +12,22 @@ This must be implemented with **identical semantics and env contract across all 
 
 ## 1. Environment contract (identical in every language)
 
-| Env var | Required | Meaning |
-| --- | --- | --- |
-| `SMOOAI_CONFIG_MODE` | no | `container` selects this mode explicitly. Also auto-selected when `SMOOAI_CONFIG_CLIENT_ID` + `SMOOAI_CONFIG_CLIENT_SECRET` are set and no blob/file is present (see §2). |
-| `SMOOAI_CONFIG_API_URL` | yes (container) | Config API base URL (e.g. `https://api.smoo.ai`). |
-| `SMOOAI_CONFIG_AUTH_URL` | no | OAuth issuer base URL. Default `https://auth.smoo.ai`. |
-| `SMOOAI_CONFIG_CLIENT_ID` | yes (container) | M2M OAuth client id. |
-| `SMOOAI_CONFIG_CLIENT_SECRET` | yes (container) | M2M OAuth client secret. (Legacy alias `SMOOAI_CONFIG_API_KEY` accepted for the secret, deprecated.) |
-| `SMOOAI_CONFIG_ORG_ID` | yes (container) | Organization id whose config to fetch. |
-| `SMOOAI_CONFIG_ENV` | yes (container) | Environment name (e.g. `production`). |
+| Env var                       | Required        | Meaning                                                                                                                                                                   |
+| ----------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SMOOAI_CONFIG_MODE`          | no              | `container` selects this mode explicitly. Also auto-selected when `SMOOAI_CONFIG_CLIENT_ID` + `SMOOAI_CONFIG_CLIENT_SECRET` are set and no blob/file is present (see §2). |
+| `SMOOAI_CONFIG_API_URL`       | yes (container) | Config API base URL (e.g. `https://api.smoo.ai`).                                                                                                                         |
+| `SMOOAI_CONFIG_AUTH_URL`      | no              | OAuth issuer base URL. Default `https://auth.smoo.ai`.                                                                                                                    |
+| `SMOOAI_CONFIG_CLIENT_ID`     | yes (container) | M2M OAuth client id.                                                                                                                                                      |
+| `SMOOAI_CONFIG_CLIENT_SECRET` | yes (container) | M2M OAuth client secret. (Legacy alias `SMOOAI_CONFIG_API_KEY` accepted for the secret, deprecated.)                                                                      |
+| `SMOOAI_CONFIG_ORG_ID`        | yes (container) | Organization id whose config to fetch.                                                                                                                                    |
+| `SMOOAI_CONFIG_ENV`           | yes (container) | Environment name (e.g. `production`).                                                                                                                                     |
 
 These names already exist in the TS `ConfigClient`/`bootstrap`; the other languages MUST adopt the exact same names (no per-language variants).
 
 ## 2. Mode selection
 
 Resolution order for picking a mode at init:
+
 1. If `SMOOAI_CONFIG_MODE=container` → **container mode** (HTTP-primary). The blob/file tiers are disabled; env tier still consulted first for individual overrides (an explicitly-set process env var wins, matching existing tier order's `env` precedence over `http`).
 2. Else if a blob/file source is present → existing behavior (Lambda/local), unchanged.
 3. Else if `SMOOAI_CONFIG_CLIENT_ID` + `SMOOAI_CONFIG_CLIENT_SECRET` + `SMOOAI_CONFIG_API_URL` are all set → **container mode** (auto). Emit one info log that container mode was auto-selected.
@@ -44,6 +45,7 @@ Container mode MUST NOT silently degrade to the file tier. If it's selected and 
 ## 4. Public API (idiomatic per language, identical semantics)
 
 Each SDK exposes:
+
 - **`initContainerConfig(options?) -> handle/instance`** — explicit container-mode bootstrap. Validates env (§3), constructs the M2M token provider + HTTP config client, performs an initial token mint + config fetch so failures surface at startup (not first-read). Options mirror the env contract (overrides for testing/embedding). Async where the language has async; blocking-with-explicit-timeout where idiomatic (e.g. go/rust may expose `InitContainerConfig(ctx)`).
 - **`configHealth() -> Healthy | Unhealthy{reason}`** — cheap check that the active config source is usable (token valid/refreshable + last fetch succeeded). Intended for Kubernetes **readiness/liveness probes** and startup gates. Must not throw; returns a status.
 - The existing typed accessors (`secretConfig.get`, `publicConfig.get`, `featureFlag.get` and language analogs) gain the §3 fail-loud behavior when running in container mode.
@@ -58,6 +60,7 @@ A reference HTTP server example exposing `/healthz/config` from `configHealth()`
 ## 6. Docs + Kubernetes/ESO recipe (ships with the feature)
 
 A single canonical doc (this file's companion, `docs/Container-Runtime-Mode.md`) covering:
+
 - The env contract (§1) and how to set it.
 - A complete **ExternalSecret (External Secrets Operator)** example sourcing `SMOOAI_CONFIG_CLIENT_ID/SECRET` from the cluster's backing store (e.g. AWS Secrets Manager), plus a `ConfigMap`/`Deployment` env snippet for the non-secret vars.
 - A readiness-probe example wired to `configHealth()` / `/healthz/config`.
@@ -68,6 +71,7 @@ Each language README links this doc and shows the language's `initContainerConfi
 ## 7. Parity requirements (definition of done per language ticket)
 
 For TS (SMOODEV-1490, reference) then dotnet/go/python/rust (1491-1494):
+
 1. `initContainerConfig` + `configHealth` + the typed errors (`ConfigBootstrapError`, `ConfigKeyUnresolvedError`), exact §1 env names, §2 mode selection, §3 fail-loud, §5 caching.
 2. Tests: bootstrap-missing-env throws and lists the missing vars; required-key-unresolved throws (not absent); optional-key-absent returns absent; happy-path fetch+cache; 401→refresh→retry; `configHealth` healthy/unhealthy.
 3. README section + the shared `docs/Container-Runtime-Mode.md` (authored once, referenced by all).
@@ -75,5 +79,6 @@ For TS (SMOODEV-1490, reference) then dotnet/go/python/rust (1491-1494):
 5. **Behavioral parity check:** the same env + same server state produces the same resolved values and the same error types/conditions in every SDK. Where a language already has partial plumbing (TS `ConfigClient`/`bootstrap`; dotnet/go/python/rust analogs), extend it — do not fork a parallel path.
 
 ## Non-goals
+
 - Changing the blob/Lambda path (untouched; still the Lambda default).
 - The voice/EKS wiring itself (that's SMOODEV-1495, after this epic).

--- a/docs/Container-Runtime-Mode.md
+++ b/docs/Container-Runtime-Mode.md
@@ -1,0 +1,255 @@
+# `@smooai/config` — Container / Runtime Mode
+
+**Epic:** SMOODEV-1489 · **Reference impl:** SMOODEV-1490 (TypeScript)
+
+This is the single canonical, language-agnostic guide for running `@smooai/config`
+in a long-lived **container** (EKS/ECS). The TS/dotnet/go/python/rust SDKs all
+implement the same behavior and the same environment contract — idioms differ,
+behavior does not. The authoritative contract is
+[`Container-Runtime-Mode-Spec.md`](Container-Runtime-Mode-Spec.md); this doc is
+the operator/runbook companion.
+
+---
+
+## Why not the baked blob in a container?
+
+`@smooai/config` resolves values through four tiers: **blob → env → http → file**.
+
+The **blob** tier — an encrypted config bundle baked into a Lambda layer / image at
+deploy time and decrypted with a key delivered separately — is the blessed path for
+**Lambda**. It is the _wrong_ default for a long-lived container:
+
+- The per-build blob key has to be delivered to the running pod. When it isn't,
+  resolution silently falls through to the (absent) file tier and returns
+  **`undefined`** for a required secret.
+- A real incident (**SMOODEV-1478**): a container got `undefined` for
+  `STRIPE_API_KEY`. A module-load `new Stripe(undefined)` threw, the process
+  exited `0` before `listen()`, and the service **CrashLooped** — with the root
+  cause buried under unrelated log noise.
+
+**Container mode** makes the **HTTP tier the first-class path** for containers,
+authenticated with an OAuth2 `client_credentials` (M2M) token, and **fail-loud**:
+a missing required value is an immediate, typed error (never a silent `undefined`),
+and a `configHealth()` status is exposed for Kubernetes probes.
+
+> **Rule of thumb: containers use container mode, not the baked blob.**
+
+---
+
+## 1. Environment contract
+
+Set on the pod. These names are identical in every SDK.
+
+| Env var                       | Required | Meaning                                                                  |
+| ----------------------------- | -------- | ------------------------------------------------------------------------ |
+| `SMOOAI_CONFIG_MODE`          | no       | `container` selects this mode explicitly (also auto-selected — see §2).  |
+| `SMOOAI_CONFIG_API_URL`       | **yes**  | Config API base URL (e.g. `https://api.smoo.ai`).                        |
+| `SMOOAI_CONFIG_AUTH_URL`      | no       | OAuth issuer base URL. Default `https://auth.smoo.ai`.                   |
+| `SMOOAI_CONFIG_CLIENT_ID`     | **yes**  | M2M OAuth client id.                                                     |
+| `SMOOAI_CONFIG_CLIENT_SECRET` | **yes**  | M2M OAuth client secret (legacy alias `SMOOAI_CONFIG_API_KEY` accepted). |
+| `SMOOAI_CONFIG_ORG_ID`        | **yes**  | Organization id whose config to fetch.                                   |
+| `SMOOAI_CONFIG_ENV`           | **yes**  | Environment name (e.g. `production`).                                    |
+
+`initContainerConfig()` validates all of the required vars at startup. If any are
+missing or blank it throws `ConfigBootstrapError` listing **exactly** which vars are
+missing — no partial init.
+
+`SMOOAI_CONFIG_CLIENT_ID` / `SMOOAI_CONFIG_CLIENT_SECRET` are **secrets** — source
+them from your cluster's secret store (AWS Secrets Manager via the External Secrets
+Operator, below). The rest are non-secret and belong in a `ConfigMap` / plain
+`Deployment` env.
+
+---
+
+## 2. Mode selection
+
+At init, the SDK picks a mode in this order:
+
+1. `SMOOAI_CONFIG_MODE=container` → **container mode** (HTTP-primary, fail-loud).
+2. else if a blob/file source is present → existing behavior (Lambda/local), unchanged.
+3. else if `SMOOAI_CONFIG_CLIENT_ID` + `SMOOAI_CONFIG_CLIENT_SECRET` + `SMOOAI_CONFIG_API_URL`
+   are all set → **container mode** (auto; logs once).
+4. else → existing default behavior.
+
+Container mode **never** silently degrades to the file tier. If it's selected and the
+HTTP tier can't be constructed (missing required env), it fails at bootstrap.
+
+In container mode the resolution chain is **env → http** only. An explicitly-set
+process env var still wins (matching the existing tier precedence), so per-key
+overrides work for break-glass; everything else comes from the config server.
+
+---
+
+## 3. Fail-loud semantics
+
+- **Bootstrap** — `initContainerConfig()` validates the §1 env and performs an
+  initial token mint + config fetch, so auth/network failures surface at **startup**,
+  not on first read. Missing env → `ConfigBootstrapError { missing: string[] }`.
+- **Required-key reads** — `secretConfig.get` / `getSync` (and the public/flag
+  analogs) for a **required** key that resolves absent across the active tiers
+  throw `ConfigKeyUnresolvedError { key, env, triedTiers }`. They **never** return
+  `undefined`/null/empty for a required key.
+- **Optional keys** — pass `initContainerConfig({ optionalKeys: ['someKey'] })`; reads
+  of those return the language's absent value instead of throwing.
+- **Default-required posture** — every key declared in your schema is treated as
+  required unless listed in `optionalKeys`. (Design decision for the TS reference;
+  mirrored by all SDKs. See the design note in the package README.)
+
+This directly closes the SMOODEV-1478 / SMOODEV-1135 silent-`undefined` class.
+
+---
+
+## 4. Caching & refresh
+
+- **Token** — cached and proactively refreshed before expiry (default 60s buffer).
+  On a `401` the SDK invalidates the token and retries once.
+- **Config values** — cached with a TTL (**default 30s** in every SDK). A background
+  refresh failure does **not** flip a previously-healthy value to unresolved: the SDK
+  logs and serves the **last-good** value until the TTL hard-expires, at which point
+  `configHealth()` reports `Unhealthy`.
+
+---
+
+## 5. Health check (readiness / liveness)
+
+`configHealth()` (and `handle.health()`) returns a non-throwing status:
+
+```ts
+{ status: 'healthy' }
+{ status: 'unhealthy', reason: string }
+```
+
+It is `Healthy` once the initial fetch has succeeded and stays `Healthy` while serving
+last-good within the cache TTL; it flips `Unhealthy` when the initial fetch never
+succeeded, or a refresh has been failing past the TTL hard-expiry.
+
+Wire it to a `/healthz/config` endpoint (TypeScript example):
+
+```ts
+import { initContainerConfig } from '@smooai/config/container';
+import schema from '../.smooai-config/config';
+
+const config = await initContainerConfig({ schema });
+
+app.get('/healthz/config', (_req, res) => {
+    const h = config.health();
+    res.status(h.status === 'healthy' ? 200 : 503).json(h);
+});
+```
+
+---
+
+## 6. Kubernetes recipe
+
+### 6.1 ExternalSecret — pull the M2M creds from AWS Secrets Manager
+
+Using the [External Secrets Operator](https://external-secrets.io/). Assumes a
+`SecretStore`/`ClusterSecretStore` named `aws-secrets-manager` already wired to your
+account, and a Secrets Manager secret `smooai/config/m2m` with JSON keys
+`client_id` and `client_secret`.
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: smooai-config-m2m
+    namespace: my-service
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: aws-secrets-manager
+        kind: ClusterSecretStore
+    target:
+        name: smooai-config-m2m # the k8s Secret this creates
+        creationPolicy: Owner
+    data:
+        - secretKey: SMOOAI_CONFIG_CLIENT_ID
+          remoteRef:
+              key: smooai/config/m2m
+              property: client_id
+        - secretKey: SMOOAI_CONFIG_CLIENT_SECRET
+          remoteRef:
+              key: smooai/config/m2m
+              property: client_secret
+```
+
+### 6.2 Deployment — non-secret env + secret env + readiness probe
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: my-service
+    namespace: my-service
+spec:
+    replicas: 2
+    selector:
+        matchLabels: { app: my-service }
+    template:
+        metadata:
+            labels: { app: my-service }
+        spec:
+            containers:
+                - name: my-service
+                  image: ghcr.io/smooai/my-service:latest
+                  ports:
+                      - containerPort: 8080
+                  env:
+                      # --- Non-secret container-mode config (plain env) ---
+                      - name: SMOOAI_CONFIG_MODE
+                        value: container
+                      - name: SMOOAI_CONFIG_API_URL
+                        value: https://api.smoo.ai
+                      - name: SMOOAI_CONFIG_AUTH_URL
+                        value: https://auth.smoo.ai
+                      - name: SMOOAI_CONFIG_ORG_ID
+                        value: '00000000-0000-0000-0000-000000000000' # your org id
+                      - name: SMOOAI_CONFIG_ENV
+                        value: production
+                      # --- Secret container-mode config (from the ExternalSecret) ---
+                      - name: SMOOAI_CONFIG_CLIENT_ID
+                        valueFrom:
+                            secretKeyRef:
+                                name: smooai-config-m2m
+                                key: SMOOAI_CONFIG_CLIENT_ID
+                      - name: SMOOAI_CONFIG_CLIENT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: smooai-config-m2m
+                                key: SMOOAI_CONFIG_CLIENT_SECRET
+                  # --- Readiness probe wired to configHealth() ---
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz/config
+                          port: 8080
+                      initialDelaySeconds: 3
+                      periodSeconds: 10
+                      failureThreshold: 3
+```
+
+The non-secret vars can also live in a `ConfigMap` and be pulled in with `envFrom`;
+the secret vars must come from the `secretKeyRef` (or `envFrom` a `secretRef`) so the
+M2M credentials never sit in plaintext manifests.
+
+---
+
+## 7. Per-language entry points
+
+| SDK        | Init                              | Health            |
+| ---------- | --------------------------------- | ----------------- |
+| TypeScript | `initContainerConfig({ schema })` | `config.health()` |
+| .NET       | `InitContainerConfig(...)`        | `ConfigHealth()`  |
+| Go         | `InitContainerConfig(ctx, ...)`   | `ConfigHealth()`  |
+| Python     | `init_container_config(...)`      | `config_health()` |
+| Rust       | `init_container_config(...)`      | `config_health()` |
+
+Each SDK's README links back to this doc and shows the language's
+`initContainerConfig` + health snippet.
+
+---
+
+## Related
+
+- [`Container-Runtime-Mode-Spec.md`](Container-Runtime-Mode-Spec.md) — the authoritative parity contract.
+- SMOODEV-1478 — the silent-`undefined` CrashLoop incident this mode prevents.
+- SMOODEV-1495 — the voice/EKS wiring that consumes this (follow-up).

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
             "import": "./dist/server/index.mjs",
             "require": "./dist/server/index.js"
         },
+        "./container": {
+            "types": "./dist/container/index.d.ts",
+            "import": "./dist/container/index.mjs",
+            "require": "./dist/container/index.js"
+        },
         "./platform/client": {
             "types": "./dist/platform/client.d.ts",
             "browser": {

--- a/src/container/__tests__/container.test.ts
+++ b/src/container/__tests__/container.test.ts
@@ -1,0 +1,302 @@
+import { defineConfig, StringSchema } from '@/config/config';
+import { ConfigClient } from '@/platform/client';
+import { TokenProvider } from '@/platform/TokenProvider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetSelectModeLogForTests, ConfigBootstrapError, configHealth, ConfigKeyUnresolvedError, initContainerConfig, selectMode } from '../index';
+
+// Mock @smooai/fetch so ConfigClient/TokenProvider never hit the network.
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+vi.mock('@smooai/fetch', () => ({ default: mockFetch }));
+
+// A minimal schema with one secret + one public + one flag.
+const schema = defineConfig({
+    publicConfigSchema: { apiBaseUrl: StringSchema },
+    secretConfigSchema: { stripeApiKey: StringSchema, sendgridApiKey: StringSchema },
+    featureFlagSchema: { newCheckout: StringSchema },
+});
+
+/** A TokenProvider that returns a fixed JWT without an OAuth round-trip. */
+class StubTokenProvider extends TokenProvider {
+    public invalidateCallCount = 0;
+    constructor(private readonly token: string = 'test-token') {
+        super({ authUrl: 'https://stub.invalid', clientId: 'id', clientSecret: 'secret' });
+    }
+    async getAccessToken(): Promise<string> {
+        return this.token;
+    }
+    invalidate(): void {
+        this.invalidateCallCount++;
+        super.invalidate();
+    }
+}
+
+function makeClient(tokenProvider?: TokenProvider): ConfigClient {
+    return new ConfigClient({
+        baseUrl: 'https://api.smooai.test',
+        orgId: 'org-1',
+        environment: 'production',
+        cacheTtlMs: 30_000,
+        tokenProvider: tokenProvider ?? new StubTokenProvider(),
+    });
+}
+
+/** Queue mock fetch responses (FIFO). */
+function queueFetch(responses: Array<{ ok?: boolean; status?: number; json?: unknown; text?: string }>) {
+    mockFetch.mockReset();
+    for (const r of responses) {
+        const ok = r.ok ?? true;
+        const status = r.status ?? (ok ? 200 : 500);
+        mockFetch.mockResolvedValueOnce({
+            ok,
+            status,
+            statusText: ok ? 'OK' : 'ERR',
+            json: async () => r.json,
+            text: async () => r.text ?? JSON.stringify(r.json),
+        });
+    }
+}
+
+const ORIGINAL_ENV = { ...process.env };
+// Schema-key env names that the env tier would read. Cleared per-test so a
+// host shell that happens to export e.g. SENDGRID_API_KEY can't leak into the
+// env tier and break isolation.
+const SCHEMA_KEY_ENV = ['STRIPE_API_KEY', 'SENDGRID_API_KEY', 'API_BASE_URL', 'NEW_CHECKOUT'];
+function clearSmooEnv() {
+    for (const k of Object.keys(process.env)) {
+        if (k.startsWith('SMOOAI_') || k.startsWith('SMOO_CONFIG')) delete process.env[k];
+    }
+    for (const k of SCHEMA_KEY_ENV) delete process.env[k];
+}
+
+beforeEach(() => {
+    clearSmooEnv();
+    mockFetch.mockReset();
+    __resetSelectModeLogForTests();
+});
+
+afterEach(() => {
+    for (const k of Object.keys(process.env)) {
+        if (!(k in ORIGINAL_ENV)) delete process.env[k];
+    }
+    for (const [k, v] of Object.entries(ORIGINAL_ENV)) process.env[k] = v;
+});
+
+describe('initContainerConfig — bootstrap validation', () => {
+    it('throws ConfigBootstrapError listing every missing required env var', async () => {
+        // No env set, no injected client.
+        const err = await initContainerConfig({ schema }).catch((e) => e);
+        expect(err).toBeInstanceOf(ConfigBootstrapError);
+        expect(err.missing).toEqual(
+            expect.arrayContaining([
+                'SMOOAI_CONFIG_API_URL',
+                'SMOOAI_CONFIG_CLIENT_ID',
+                'SMOOAI_CONFIG_CLIENT_SECRET',
+                'SMOOAI_CONFIG_ORG_ID',
+                'SMOOAI_CONFIG_ENV',
+            ]),
+        );
+        expect(err.message).toContain('SMOOAI_CONFIG_API_URL');
+    });
+
+    it('lists only the actually-missing vars (partial env)', async () => {
+        process.env.SMOOAI_CONFIG_API_URL = 'https://api.smooai.test';
+        process.env.SMOOAI_CONFIG_CLIENT_ID = 'id';
+        process.env.SMOOAI_CONFIG_ORG_ID = 'org-1';
+        process.env.SMOOAI_CONFIG_ENV = 'production';
+        // CLIENT_SECRET missing.
+        const err = await initContainerConfig({ schema }).catch((e) => e);
+        expect(err).toBeInstanceOf(ConfigBootstrapError);
+        expect(err.missing).toEqual(['SMOOAI_CONFIG_CLIENT_SECRET']);
+    });
+
+    it('treats a blank (whitespace) env var as missing', async () => {
+        process.env.SMOOAI_CONFIG_API_URL = 'https://api.smooai.test';
+        process.env.SMOOAI_CONFIG_CLIENT_ID = '   ';
+        process.env.SMOOAI_CONFIG_CLIENT_SECRET = 'secret';
+        process.env.SMOOAI_CONFIG_ORG_ID = 'org-1';
+        process.env.SMOOAI_CONFIG_ENV = 'production';
+        const err = await initContainerConfig({ schema }).catch((e) => e);
+        expect(err).toBeInstanceOf(ConfigBootstrapError);
+        expect(err.missing).toEqual(['SMOOAI_CONFIG_CLIENT_ID']);
+    });
+
+    it('accepts legacy SMOOAI_CONFIG_API_KEY as the client secret', async () => {
+        process.env.SMOOAI_CONFIG_API_URL = 'https://api.smooai.test';
+        process.env.SMOOAI_CONFIG_CLIENT_ID = 'id';
+        process.env.SMOOAI_CONFIG_API_KEY = 'legacy-secret';
+        process.env.SMOOAI_CONFIG_ORG_ID = 'org-1';
+        process.env.SMOOAI_CONFIG_ENV = 'production';
+        // token mint + initial getAllValues
+        queueFetch([{ json: { access_token: 'T', expires_in: 3600 } }, { json: { values: {} } }]);
+        const handle = await initContainerConfig({ schema });
+        expect(handle).toBeDefined();
+    });
+
+    it('with an injected ConfigClient, only SMOOAI_CONFIG_ENV is required', async () => {
+        const err = await initContainerConfig({ schema, configClient: makeClient() }).catch((e) => e);
+        expect(err).toBeInstanceOf(ConfigBootstrapError);
+        expect(err.missing).toEqual(['SMOOAI_CONFIG_ENV']);
+    });
+});
+
+describe('initContainerConfig — startup fetch (fail at boot, not first read)', () => {
+    it('throws when the initial config fetch fails (no silent degraded start)', async () => {
+        // initial getAllValues -> 500
+        queueFetch([{ ok: false, status: 500, text: 'boom' }]);
+        const err = await initContainerConfig({
+            schema,
+            environment: 'production',
+            configClient: makeClient(),
+        }).catch((e) => e);
+        expect(err).toBeInstanceOf(Error);
+        expect(String(err)).toMatch(/500/);
+    });
+
+    it('happy path: initial fetch succeeds and a value reads from cache without a 2nd HTTP call', async () => {
+        // initial getAllValues returns the full map.
+        queueFetch([{ json: { values: { stripeApiKey: 'sk_live_123', apiBaseUrl: 'https://x' } } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        const callsAfterInit = mockFetch.mock.calls.length;
+        expect(await handle.secretConfig.get('stripeApiKey')).toBe('sk_live_123');
+        expect(await handle.publicConfig.get('apiBaseUrl')).toBe('https://x');
+        // getAllValues seeded the cache, so no extra fetches.
+        expect(mockFetch.mock.calls.length).toBe(callsAfterInit);
+    });
+});
+
+describe('fail-loud reads (§3)', () => {
+    it('required secret unresolved -> throws ConfigKeyUnresolvedError (not undefined)', async () => {
+        // initial getAllValues: empty. Then per-key getValue for the missing key -> {value: undefined}.
+        queueFetch([{ json: { values: {} } }, { json: { value: undefined } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        const err = await handle.secretConfig.get('stripeApiKey').catch((e) => e);
+        expect(err).toBeInstanceOf(ConfigKeyUnresolvedError);
+        expect(err.key).toBe('stripeApiKey');
+        expect(err.env).toBe('production');
+        expect(err.triedTiers).toEqual(['env', 'http']);
+    });
+
+    it('optional key absent -> returns undefined, does NOT throw', async () => {
+        queueFetch([{ json: { values: {} } }, { json: { value: undefined } }]);
+        const handle = await initContainerConfig({
+            schema,
+            environment: 'production',
+            configClient: makeClient(),
+            optionalKeys: ['sendgridApiKey'],
+        });
+        await expect(handle.secretConfig.get('sendgridApiKey')).resolves.toBeUndefined();
+    });
+
+    it('getSync for an unresolved required key throws (no silent undefined)', async () => {
+        queueFetch([{ json: { values: {} } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        expect(() => handle.secretConfig.getSync('stripeApiKey')).toThrow(ConfigKeyUnresolvedError);
+    });
+
+    it('getSync returns a cached value when present', async () => {
+        queueFetch([{ json: { values: { stripeApiKey: 'sk_cached' } } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        expect(handle.secretConfig.getSync('stripeApiKey')).toBe('sk_cached');
+    });
+
+    it('an explicit process env override wins over HTTP (env tier precedence)', async () => {
+        process.env.STRIPE_API_KEY = 'sk_from_env';
+        queueFetch([{ json: { values: { stripeApiKey: 'sk_from_http' } } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        expect(await handle.secretConfig.get('stripeApiKey')).toBe('sk_from_env');
+    });
+});
+
+describe('401 -> refresh -> retry (§5)', () => {
+    it('invalidates the token and retries once on a 401', async () => {
+        const tp = new StubTokenProvider();
+        const client = makeClient(tp);
+        // initial getAllValues ok (empty)
+        // then per-key getValue: 401 (triggers invalidate+retry), then 200.
+        queueFetch([{ json: { values: {} } }, { ok: false, status: 401, text: 'expired' }, { json: { value: 'sk_after_refresh' } }]);
+        // @smooai/fetch throws on non-2xx with err.response.status — emulate that
+        // for the 401 by making the 2nd call reject.
+        mockFetch.mockReset();
+        mockFetch
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ values: {} }) })
+            .mockRejectedValueOnce(Object.assign(new Error('HTTP 401'), { response: { status: 401 } }))
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ value: 'sk_after_refresh' }) });
+
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: client });
+        const v = await handle.secretConfig.get('stripeApiKey');
+        expect(v).toBe('sk_after_refresh');
+        expect(tp.invalidateCallCount).toBe(1);
+    });
+});
+
+describe('configHealth (§4)', () => {
+    it('reports healthy after a successful initial fetch', async () => {
+        queueFetch([{ json: { values: { stripeApiKey: 'sk' } } }]);
+        const handle = await initContainerConfig({ schema, environment: 'production', configClient: makeClient() });
+        expect(handle.health()).toEqual({ status: 'healthy' });
+        expect(configHealth(handle)).toEqual({ status: 'healthy' });
+    });
+
+    it('serves healthy on a background refresh failure within TTL, unhealthy past hard-expiry', async () => {
+        vi.useFakeTimers();
+        try {
+            // initial getAllValues seeds stripeApiKey.
+            mockFetch.mockReset();
+            mockFetch
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ values: { stripeApiKey: 'sk_initial' } }) })
+                // subsequent getValue refresh fails.
+                .mockRejectedValue(Object.assign(new Error('network down'), { response: { status: 503 } }));
+
+            const handle = await initContainerConfig({
+                schema,
+                environment: 'production',
+                configClient: makeClient(),
+                cacheTtlMs: 30_000,
+            });
+            expect(handle.health()).toEqual({ status: 'healthy' });
+
+            // Force a refresh failure by reading after the per-key cache expires.
+            // The cached value from getAllValues is still served (last-good).
+            vi.advanceTimersByTime(31_000); // expire the per-key TTL cache
+            const v = await handle.secretConfig.get('stripeApiKey').catch((e) => e);
+            // last-good cache is gone (TTL expired) AND http failed -> unresolved required.
+            expect(v).toBeInstanceOf(ConfigKeyUnresolvedError);
+
+            // Health: last refresh failed and we're past the TTL window -> unhealthy.
+            const h = handle.health();
+            expect(h.status).toBe('unhealthy');
+            if (h.status === 'unhealthy') expect(h.reason).toMatch(/network down|TTL/);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe('selectMode (§2)', () => {
+    it('SMOOAI_CONFIG_MODE=container forces container mode', () => {
+        expect(selectMode({ mode: 'container' })).toBe('container');
+        expect(selectMode({ mode: 'CONTAINER' })).toBe('container');
+    });
+
+    it('a present blob source means default mode (not container)', () => {
+        expect(selectMode({ blobPresent: true, clientId: 'id', clientSecret: 's', apiUrl: 'u' })).toBe('default');
+    });
+
+    it('a present file source means default mode', () => {
+        expect(selectMode({ filePresent: true, clientId: 'id', clientSecret: 's', apiUrl: 'u' })).toBe('default');
+    });
+
+    it('auto-selects container when CLIENT_ID + CLIENT_SECRET + API_URL set and no blob/file', () => {
+        expect(selectMode({ clientId: 'id', clientSecret: 's', apiUrl: 'u' })).toBe('container');
+    });
+
+    it('falls back to default when the M2M creds are incomplete', () => {
+        expect(selectMode({ clientId: 'id', apiUrl: 'u' })).toBe('default');
+        expect(selectMode({})).toBe('default');
+    });
+
+    it('reads from process.env when inputs are omitted', () => {
+        process.env.SMOOAI_CONFIG_MODE = 'container';
+        expect(selectMode()).toBe('container');
+    });
+});

--- a/src/container/errors.ts
+++ b/src/container/errors.ts
@@ -1,0 +1,74 @@
+/**
+ * Typed errors for `@smooai/config` container/runtime mode.
+ *
+ * These are the load-bearing part of the SMOODEV-1490 fail-loud contract:
+ * a missing required value must surface as a clear, actionable error — never
+ * a silent `undefined` that detonates downstream (the SMOODEV-1478 incident:
+ * a container got `undefined` for `STRIPE_API_KEY`, `new Stripe(undefined)`
+ * threw at module load, the process exited 0 before `listen()`, and the pod
+ * CrashLooped with the root cause buried under unrelated log noise).
+ *
+ * Parity note: the dotnet/go/python/rust SDKs MUST expose errors with the
+ * same names and the same carried fields (different idioms, identical data):
+ *   - ConfigBootstrapError  -> { missing: string[] }
+ *   - ConfigKeyUnresolvedError -> { key, env, triedTiers }
+ */
+
+/** One of the resolution tiers consulted during a value read. */
+export type ConfigTier = 'blob' | 'env' | 'http' | 'file';
+
+/**
+ * Thrown by `initContainerConfig` when the container-required environment
+ * (see §1 of the spec) is missing or blank. Carries the exact list of
+ * offending env var names so the operator can fix the deployment without
+ * guessing. No partial init: if any required var is absent, bootstrap fails
+ * whole.
+ */
+export class ConfigBootstrapError extends Error {
+    /** Env var names (e.g. `SMOOAI_CONFIG_CLIENT_ID`) that are missing or blank. */
+    readonly missing: string[];
+
+    constructor(missing: string[], options?: ErrorOptions) {
+        super(
+            `[@smooai/config] container-mode bootstrap failed: missing required env ${missing.join(', ')}. ` +
+                `Set ${missing.length === 1 ? 'this variable' : 'these variables'} before calling initContainerConfig() ` +
+                `(see docs/Container-Runtime-Mode.md for the Kubernetes/ExternalSecret recipe).`,
+            options,
+        );
+        this.name = 'ConfigBootstrapError';
+        this.missing = missing;
+    }
+}
+
+/**
+ * Thrown by a required-key read (`secretConfig.get`/`getSync` and the
+ * public/flag analogs) in container mode when the value resolves to absent
+ * across every active tier. This is the exact class that closes the
+ * silent-`undefined` hole (SMOODEV-1478 / SMOODEV-1135).
+ *
+ * Optional keys (declared via `initContainerConfig({ optionalKeys })`) do NOT
+ * throw this — they return the language's absent value.
+ */
+export class ConfigKeyUnresolvedError extends Error {
+    /** The camelCase config key that could not be resolved. */
+    readonly key: string;
+    /** The environment the read targeted (e.g. `production`). */
+    readonly env: string;
+    /** The tiers that were consulted, in order, before giving up. */
+    readonly triedTiers: ConfigTier[];
+
+    constructor(args: { key: string; env: string; triedTiers: ConfigTier[] }, options?: ErrorOptions) {
+        const { key, env, triedTiers } = args;
+        super(
+            `[@smooai/config] required config key "${key}" did not resolve in environment "${env}" ` +
+                `(container mode; tiers tried: ${triedTiers.join(' → ') || 'none'}). ` +
+                `Set a value for this key in the config server for "${env}", or mark it optional via ` +
+                `initContainerConfig({ optionalKeys: ['${key}'] }).`,
+            options,
+        );
+        this.name = 'ConfigKeyUnresolvedError';
+        this.key = key;
+        this.env = env;
+        this.triedTiers = triedTiers;
+    }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,0 +1,490 @@
+/**
+ * `@smooai/config/container` — container/runtime mode (SMOODEV-1489 / SMOODEV-1490).
+ *
+ * The TypeScript **reference** implementation of container mode; the
+ * dotnet/go/python/rust SDKs mirror this behavior exactly (identical env
+ * contract and error semantics — idioms differ, behavior does not).
+ *
+ * ## Why
+ *
+ * `@smooai/config` resolves values through four tiers: blob → env → http →
+ * file. The blob tier (an encrypted bundle baked into a Lambda layer / image
+ * at deploy time, decrypted with a separately-delivered key) is the blessed
+ * path for **Lambda**. It is the *wrong* default for long-lived **containers**
+ * (EKS/ECS): when the per-build blob key isn't delivered to the pod,
+ * resolution silently falls through to the (absent) file tier and returns
+ * `undefined` for a required secret (SMOODEV-1478 outage).
+ *
+ * Container mode makes the **HTTP tier the blessed, first-class path** for
+ * containers, authenticated with an OAuth2 `client_credentials` (M2M) token,
+ * **fail-loud** so a missing required value is an immediate, clear error
+ * (a typed {@link ConfigKeyUnresolvedError}, never a silent `undefined`).
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { initContainerConfig } from '@smooai/config/container';
+ * import schema from '../.smooai-config/config';
+ *
+ * // Validates env, mints a token, does an initial fetch — startup fails
+ * // loudly here, not on first read.
+ * const config = await initContainerConfig({ schema });
+ *
+ * // Fail-loud: a required secret that doesn't resolve throws.
+ * const stripeKey = await config.secretConfig.get('stripeApiKey');
+ *
+ * // Readiness probe handler:
+ * app.get('/healthz/config', () => {
+ *   const h = config.health();
+ *   return h.status === 'healthy' ? 200 : 503;
+ * });
+ * ```
+ *
+ * ## Env contract (§1 — identical across all five SDKs)
+ *
+ *   SMOOAI_CONFIG_MODE          `container` forces this mode (see §2 / selectMode).
+ *   SMOOAI_CONFIG_API_URL       (required) config API base URL.
+ *   SMOOAI_CONFIG_AUTH_URL      OAuth issuer base URL (default https://auth.smoo.ai).
+ *   SMOOAI_CONFIG_CLIENT_ID     (required) M2M OAuth client id.
+ *   SMOOAI_CONFIG_CLIENT_SECRET (required) M2M OAuth client secret
+ *                               (legacy alias SMOOAI_CONFIG_API_KEY accepted).
+ *   SMOOAI_CONFIG_ORG_ID        (required) org id whose config to fetch.
+ *   SMOOAI_CONFIG_ENV           (required) environment name (e.g. production).
+ */
+import { defineConfig, InferConfigTypes } from '@/config/config';
+import { ConfigClient } from '@/platform/client';
+import { TokenProvider } from '@/platform/TokenProvider';
+import Logger from '@smooai/logger/Logger';
+import { ConfigBootstrapError, ConfigKeyUnresolvedError, ConfigTier } from './errors';
+
+export { ConfigBootstrapError, ConfigKeyUnresolvedError } from './errors';
+export type { ConfigTier } from './errors';
+
+const logger = new Logger({ name: '@smooai/config/container' });
+
+/** Default config-value cache TTL (§5). Same 30s default in every SDK. */
+export const DEFAULT_CACHE_TTL_MS = 30_000;
+
+/** Default token proactive-refresh window (§5). Matches `TokenProvider`. */
+export const DEFAULT_TOKEN_REFRESH_BUFFER_SECONDS = 60;
+
+function readEnv(name: string): string | undefined {
+    if (typeof process !== 'undefined' && process.env) return process.env[name];
+    return undefined;
+}
+
+/** Blank-aware presence check for env vars (a set-but-empty var counts as missing). */
+function nonBlank(v: string | undefined): string | undefined {
+    if (v === undefined) return undefined;
+    const trimmed = v.trim();
+    return trimmed.length > 0 ? v : undefined;
+}
+
+function isSet(v: unknown): boolean {
+    return v !== undefined && v !== null && v !== '';
+}
+
+/**
+ * Options for {@link initContainerConfig}. Every field mirrors an env var in
+ * the §1 contract so tests and embedders can construct a config handle
+ * without touching `process.env`. When omitted, the env var is read.
+ */
+export interface InitContainerConfigOptions<Schema extends ReturnType<typeof defineConfig> = ReturnType<typeof defineConfig>> {
+    /**
+     * The `defineConfig(...)` schema for this service. Required so the handle
+     * can expose typed `secretConfig`/`publicConfig`/`featureFlag` accessors
+     * and know which keys exist. (The schema's keys are treated as
+     * **required** in container mode by default — see `optionalKeys`.)
+     */
+    schema: Schema;
+    /** Config API base URL. Falls back to `SMOOAI_CONFIG_API_URL`. */
+    apiUrl?: string;
+    /** OAuth issuer base URL. Falls back to `SMOOAI_CONFIG_AUTH_URL`, then `https://auth.smoo.ai`. */
+    authUrl?: string;
+    /** M2M OAuth client id. Falls back to `SMOOAI_CONFIG_CLIENT_ID`. */
+    clientId?: string;
+    /** M2M OAuth client secret. Falls back to `SMOOAI_CONFIG_CLIENT_SECRET`, then legacy `SMOOAI_CONFIG_API_KEY`. */
+    clientSecret?: string;
+    /** Org id whose config to fetch. Falls back to `SMOOAI_CONFIG_ORG_ID`. */
+    orgId?: string;
+    /** Environment name (e.g. `production`). Falls back to `SMOOAI_CONFIG_ENV`. */
+    environment?: string;
+    /**
+     * Config value cache TTL in ms. Default {@link DEFAULT_CACHE_TTL_MS} (30s).
+     * A background refresh failure serves the last-good value until this TTL
+     * hard-expires, at which point `health()` reports `unhealthy` (§5).
+     */
+    cacheTtlMs?: number;
+    /**
+     * Seconds before token expiry to proactively refresh. Default
+     * {@link DEFAULT_TOKEN_REFRESH_BUFFER_SECONDS} (60s). Forwarded to `TokenProvider`.
+     */
+    tokenRefreshBufferSeconds?: number;
+    /**
+     * Keys that are allowed to be absent. A read of any of these returns the
+     * absent value instead of throwing {@link ConfigKeyUnresolvedError}.
+     * Everything else declared in `schema` is required (container mode's
+     * default-required posture — see the design note in the README).
+     */
+    optionalKeys?: readonly string[];
+    /**
+     * Test/embedding seam — inject a pre-built `ConfigClient`. When supplied,
+     * `apiUrl`/`authUrl`/`clientId`/`clientSecret`/`orgId` env validation is
+     * skipped (the client already carries them) but `environment` is still
+     * required.
+     */
+    configClient?: ConfigClient;
+    /** Test/embedding seam — inject a pre-built `TokenProvider`. */
+    tokenProvider?: TokenProvider;
+}
+
+/** Status returned by {@link ContainerConfigHandle.health}. Never throws. */
+export type ConfigHealth = { status: 'healthy' } | { status: 'unhealthy'; reason: string };
+
+/**
+ * The handle returned by {@link initContainerConfig}. Exposes the same tier
+ * accessors as `buildConfig` (async `get` + sync `getSync`) but with §3
+ * fail-loud behavior, plus a non-throwing {@link ContainerConfigHandle.health}
+ * for k8s readiness/liveness probes.
+ */
+export interface ContainerConfigHandle<Schema extends ReturnType<typeof defineConfig>> {
+    publicConfig: {
+        get: <K extends PublicKeyOf<Schema>>(key: K) => Promise<ConfigTypeOf<Schema>[K]>;
+        getSync: <K extends PublicKeyOf<Schema>>(key: K) => ConfigTypeOf<Schema>[K];
+    };
+    secretConfig: {
+        get: <K extends SecretKeyOf<Schema>>(key: K) => Promise<ConfigTypeOf<Schema>[K]>;
+        getSync: <K extends SecretKeyOf<Schema>>(key: K) => ConfigTypeOf<Schema>[K];
+    };
+    featureFlag: {
+        get: <K extends FlagKeyOf<Schema>>(key: K) => Promise<ConfigTypeOf<Schema>[K]>;
+        getSync: <K extends FlagKeyOf<Schema>>(key: K) => ConfigTypeOf<Schema>[K];
+    };
+    /** Cheap, non-throwing status for readiness/liveness probes (§4). */
+    health: () => ConfigHealth;
+    /** The underlying `ConfigClient` (escape hatch for advanced callers). */
+    readonly client: ConfigClient;
+}
+
+type ConfigTypeOf<Schema extends ReturnType<typeof defineConfig>> = InferConfigTypes<Schema>['ConfigType'];
+type PublicKeyOf<Schema extends ReturnType<typeof defineConfig>> = Extract<
+    InferConfigTypes<Schema>['PublicConfigKeys'][keyof InferConfigTypes<Schema>['PublicConfigKeys']],
+    keyof ConfigTypeOf<Schema>
+>;
+type SecretKeyOf<Schema extends ReturnType<typeof defineConfig>> = Extract<
+    InferConfigTypes<Schema>['SecretConfigKeys'][keyof InferConfigTypes<Schema>['SecretConfigKeys']],
+    keyof ConfigTypeOf<Schema>
+>;
+type FlagKeyOf<Schema extends ReturnType<typeof defineConfig>> = Extract<
+    InferConfigTypes<Schema>['FeatureFlagKeys'][keyof InferConfigTypes<Schema>['FeatureFlagKeys']],
+    keyof ConfigTypeOf<Schema>
+>;
+
+/**
+ * Resolve and validate the container-mode env contract (§1).
+ * Returns the resolved values, or throws {@link ConfigBootstrapError} listing
+ * exactly which required vars are missing/blank. No partial result.
+ */
+interface ResolvedContainerEnv {
+    apiUrl: string;
+    authUrl: string;
+    clientId: string;
+    clientSecret: string;
+    orgId: string;
+    environment: string;
+}
+
+function resolveAndValidateEnv(options: InitContainerConfigOptions): ResolvedContainerEnv {
+    const apiUrl = nonBlank(options.apiUrl) ?? nonBlank(readEnv('SMOOAI_CONFIG_API_URL'));
+    const authUrl = nonBlank(options.authUrl) ?? nonBlank(readEnv('SMOOAI_CONFIG_AUTH_URL')) ?? nonBlank(readEnv('SMOOAI_AUTH_URL')) ?? 'https://auth.smoo.ai';
+    const clientId = nonBlank(options.clientId) ?? nonBlank(readEnv('SMOOAI_CONFIG_CLIENT_ID'));
+    const clientSecret = nonBlank(options.clientSecret) ?? nonBlank(readEnv('SMOOAI_CONFIG_CLIENT_SECRET')) ?? nonBlank(readEnv('SMOOAI_CONFIG_API_KEY'));
+    const orgId = nonBlank(options.orgId) ?? nonBlank(readEnv('SMOOAI_CONFIG_ORG_ID'));
+    const environment = nonBlank(options.environment) ?? nonBlank(readEnv('SMOOAI_CONFIG_ENV'));
+
+    // When a ConfigClient is injected it already carries apiUrl/auth/clientId/
+    // /secret/orgId — only the environment is still container-required.
+    const clientInjected = options.configClient !== undefined;
+
+    const missing: string[] = [];
+    if (!clientInjected) {
+        if (!apiUrl) missing.push('SMOOAI_CONFIG_API_URL');
+        if (!clientId) missing.push('SMOOAI_CONFIG_CLIENT_ID');
+        if (!clientSecret) missing.push('SMOOAI_CONFIG_CLIENT_SECRET');
+        if (!orgId) missing.push('SMOOAI_CONFIG_ORG_ID');
+    }
+    if (!environment) missing.push('SMOOAI_CONFIG_ENV');
+
+    if (missing.length > 0) {
+        throw new ConfigBootstrapError(missing);
+    }
+
+    return {
+        apiUrl: apiUrl ?? '',
+        authUrl,
+        clientId: clientId ?? '',
+        clientSecret: clientSecret ?? '',
+        orgId: orgId ?? '',
+        environment: environment!,
+    };
+}
+
+/**
+ * Explicit container-mode bootstrap (§4). Validates the §1 env, constructs
+ * the M2M `TokenProvider` + `ConfigClient`, and performs an **initial token
+ * mint + config fetch** so auth/network failures surface at startup, not on
+ * first read. Returns a {@link ContainerConfigHandle} whose accessors are
+ * fail-loud (§3).
+ *
+ * @throws {ConfigBootstrapError} when container-required env is missing/blank.
+ * @throws on auth/network failure during the initial token mint or fetch.
+ */
+export async function initContainerConfig<Schema extends ReturnType<typeof defineConfig>>(
+    options: InitContainerConfigOptions<Schema>,
+): Promise<ContainerConfigHandle<Schema>> {
+    if (!options || !options.schema) {
+        throw new ConfigBootstrapError(['schema']);
+    }
+    const env = resolveAndValidateEnv(options);
+    const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    const refreshBufferSeconds = options.tokenRefreshBufferSeconds ?? DEFAULT_TOKEN_REFRESH_BUFFER_SECONDS;
+    const optionalKeys = new Set<string>(options.optionalKeys ?? []);
+
+    // Build the ConfigClient. When the caller injects one (test/embedding
+    // seam) it already carries its own TokenProvider, so we don't build a
+    // second one (env creds may be empty in that path).
+    const client =
+        options.configClient ??
+        new ConfigClient({
+            baseUrl: env.apiUrl,
+            orgId: env.orgId,
+            environment: env.environment,
+            cacheTtlMs,
+            tokenProvider:
+                options.tokenProvider ??
+                new TokenProvider({
+                    authUrl: env.authUrl,
+                    clientId: env.clientId,
+                    clientSecret: env.clientSecret,
+                    refreshWindowSec: refreshBufferSeconds,
+                }),
+        });
+
+    // Health state (§5): once an initial fetch succeeds we serve last-good on
+    // a later background refresh failure until the cache TTL hard-expires.
+    let lastFetchOk = false;
+    let lastFetchAt = 0;
+    let lastError: string | undefined;
+
+    // Initial config fetch — fail loud at startup, not first read. The OAuth
+    // token mint happens inside getAllValues (the ConfigClient's TokenProvider
+    // exchanges on the first authed request), so an auth failure surfaces here
+    // too. A pod that can't reach the config server should CrashLoop visibly,
+    // not start degraded.
+    try {
+        await client.getAllValues(env.environment);
+        lastFetchOk = true;
+        lastFetchAt = Date.now();
+    } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        throw err;
+    }
+
+    const isOptional = (key: string): boolean => optionalKeys.has(key);
+
+    /**
+     * Async tier read for a single key. Order matches the existing chain's
+     * env-over-http precedence: an explicitly-set process env var wins, else
+     * the HTTP (config server) value. Blob/file tiers are disabled in
+     * container mode (§2).
+     */
+    async function resolve(key: string): Promise<{ value: unknown; tried: ConfigTier[] }> {
+        const tried: ConfigTier[] = [];
+
+        // env tier — explicit process override (matches existing precedence).
+        tried.push('env');
+        const fromEnv = readEnv(envVarNameFor(key));
+        if (isSet(fromEnv)) {
+            client.seedCache(key, fromEnv, env.environment);
+            return { value: fromEnv, tried };
+        }
+
+        // http tier — the blessed container path.
+        tried.push('http');
+        try {
+            const value = await client.getValue(key, env.environment);
+            lastFetchOk = true;
+            lastFetchAt = Date.now();
+            lastError = undefined;
+            if (isSet(value)) return { value, tried };
+            return { value: undefined, tried };
+        } catch (err) {
+            lastError = err instanceof Error ? err.message : String(err);
+            // §5: serve last-good from cache until TTL hard-expiry.
+            const cached = client.getCachedValue(key, env.environment);
+            if (isSet(cached)) {
+                logger.warn({ key, err }, 'container config: HTTP refresh failed; serving last-good cached value');
+                return { value: cached, tried };
+            }
+            return { value: undefined, tried };
+        }
+    }
+
+    function syncResolve(key: string): { value: unknown; tried: ConfigTier[] } {
+        const tried: ConfigTier[] = [];
+        tried.push('env');
+        const fromEnv = readEnv(envVarNameFor(key));
+        if (isSet(fromEnv)) return { value: fromEnv, tried };
+        tried.push('http');
+        const cached = client.getCachedValue(key, env.environment);
+        return { value: cached, tried };
+    }
+
+    function assertKey(key: unknown, tier: 'public' | 'secret' | 'featureFlag'): asserts key is string {
+        if (typeof key === 'string' && key.length > 0) return;
+        const tierEnum = tier === 'public' ? 'PublicConfigKeys' : tier === 'secret' ? 'SecretConfigKeys' : 'FeatureFlagKeys';
+        throw new Error(
+            `@smooai/config (container): ${tier}Config called with ${
+                key === undefined ? 'undefined' : key === null ? 'null' : `non-string (${typeof key})`
+            } key. Most common cause: reading \`${tierEnum}.<X>\` for a key not declared in your schema.`,
+        );
+    }
+
+    function makeAsyncGetter<K extends string>(assertTier: 'public' | 'secret' | 'featureFlag') {
+        return async (key: K): Promise<unknown> => {
+            assertKey(key, assertTier);
+            const { value, tried } = await resolve(key);
+            if (isSet(value)) return value;
+            if (isOptional(key)) return undefined;
+            throw new ConfigKeyUnresolvedError({ key, env: env.environment, triedTiers: tried });
+        };
+    }
+
+    function makeSyncGetter<K extends string>(assertTier: 'public' | 'secret' | 'featureFlag') {
+        return (key: K): unknown => {
+            assertKey(key, assertTier);
+            const { value, tried } = syncResolve(key);
+            if (isSet(value)) return value;
+            if (isOptional(key)) return undefined;
+            throw new ConfigKeyUnresolvedError({ key, env: env.environment, triedTiers: tried });
+        };
+    }
+
+    // Token validity contributes to health: if we can't mint/refresh, the
+    // HTTP tier is dead. We probe cheaply by checking the cached token isn't
+    // both absent and unrefreshable — but TokenProvider already refreshes
+    // proactively, so the truest signal is the last fetch outcome + TTL.
+    function health(): ConfigHealth {
+        if (!lastFetchOk) {
+            return { status: 'unhealthy', reason: lastError ?? 'initial config fetch has not succeeded' };
+        }
+        const age = Date.now() - lastFetchAt;
+        // Serve healthy while within (cacheTtlMs) of the last good fetch even
+        // if a background refresh just failed. Past the hard TTL, a failed
+        // refresh flips us unhealthy (§5).
+        if (lastError !== undefined && age > cacheTtlMs) {
+            return { status: 'unhealthy', reason: `last config refresh failed and cache TTL (${cacheTtlMs}ms) expired: ${lastError}` };
+        }
+        return { status: 'healthy' };
+    }
+
+    return {
+        publicConfig: {
+            get: makeAsyncGetter('public') as ContainerConfigHandle<Schema>['publicConfig']['get'],
+            getSync: makeSyncGetter('public') as ContainerConfigHandle<Schema>['publicConfig']['getSync'],
+        },
+        secretConfig: {
+            get: makeAsyncGetter('secret') as ContainerConfigHandle<Schema>['secretConfig']['get'],
+            getSync: makeSyncGetter('secret') as ContainerConfigHandle<Schema>['secretConfig']['getSync'],
+        },
+        featureFlag: {
+            get: makeAsyncGetter('featureFlag') as ContainerConfigHandle<Schema>['featureFlag']['get'],
+            getSync: makeSyncGetter('featureFlag') as ContainerConfigHandle<Schema>['featureFlag']['getSync'],
+        },
+        health,
+        client,
+    };
+}
+
+/**
+ * Standalone health check (§4) for a handle. Exposed both as
+ * `handle.health()` and as this free function for call sites that prefer the
+ * functional form. Never throws.
+ */
+export function configHealth<Schema extends ReturnType<typeof defineConfig>>(handle: ContainerConfigHandle<Schema>): ConfigHealth {
+    try {
+        return handle.health();
+    } catch (err) {
+        return { status: 'unhealthy', reason: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+/**
+ * Mode the SDK should run in, per §2. `'container'` means HTTP-primary
+ * fail-loud; `'default'` means the existing blob → env → http → file chain.
+ */
+export type ConfigMode = 'container' | 'default';
+
+/** Inputs for {@link selectMode}. Defaults read from `process.env`. */
+export interface SelectModeInputs {
+    /** `SMOOAI_CONFIG_MODE`. */
+    mode?: string;
+    /** `SMOOAI_CONFIG_CLIENT_ID`. */
+    clientId?: string;
+    /** `SMOOAI_CONFIG_CLIENT_SECRET` (or legacy `SMOOAI_CONFIG_API_KEY`). */
+    clientSecret?: string;
+    /** `SMOOAI_CONFIG_API_URL`. */
+    apiUrl?: string;
+    /** Whether a baked blob source is present (`SMOO_CONFIG_KEY` + `SMOO_CONFIG_KEY_FILE`). */
+    blobPresent?: boolean;
+    /** Whether a local `.smooai-config/` file source is present. */
+    filePresent?: boolean;
+}
+
+/**
+ * Mode selection (§2). Resolution order:
+ *   1. `SMOOAI_CONFIG_MODE=container` → container mode (explicit).
+ *   2. else if a blob/file source is present → default (Lambda/local), unchanged.
+ *   3. else if CLIENT_ID + CLIENT_SECRET + API_URL all set → container (auto;
+ *      logs once that container mode was auto-selected).
+ *   4. else → default.
+ *
+ * Container mode MUST NOT silently degrade to the file tier — that decision is
+ * enforced by {@link initContainerConfig}'s bootstrap validation; this only
+ * decides which mode to enter.
+ */
+let autoSelectLogged = false;
+export function selectMode(inputs: SelectModeInputs = {}): ConfigMode {
+    const mode = nonBlank(inputs.mode) ?? nonBlank(readEnv('SMOOAI_CONFIG_MODE'));
+    if (mode?.toLowerCase() === 'container') return 'container';
+
+    const blobPresent = inputs.blobPresent ?? (isSet(readEnv('SMOO_CONFIG_KEY')) && isSet(readEnv('SMOO_CONFIG_KEY_FILE')));
+    const filePresent = inputs.filePresent ?? false;
+    if (blobPresent || filePresent) return 'default';
+
+    const clientId = nonBlank(inputs.clientId) ?? nonBlank(readEnv('SMOOAI_CONFIG_CLIENT_ID'));
+    const clientSecret = nonBlank(inputs.clientSecret) ?? nonBlank(readEnv('SMOOAI_CONFIG_CLIENT_SECRET')) ?? nonBlank(readEnv('SMOOAI_CONFIG_API_KEY'));
+    const apiUrl = nonBlank(inputs.apiUrl) ?? nonBlank(readEnv('SMOOAI_CONFIG_API_URL'));
+
+    if (clientId && clientSecret && apiUrl) {
+        if (!autoSelectLogged) {
+            autoSelectLogged = true;
+            logger.info(
+                { mode: 'container' },
+                '@smooai/config: container mode auto-selected (CLIENT_ID + CLIENT_SECRET + API_URL set, no blob/file source present)',
+            );
+        }
+        return 'container';
+    }
+    return 'default';
+}
+
+/** Test-only: reset the once-per-process auto-select log latch. */
+export function __resetSelectModeLogForTests(): void {
+    autoSelectLogged = false;
+}
+
+/** camelCase → UPPER_SNAKE_CASE for env-var reads (matches server tier). */
+function envVarNameFor(key: string): string {
+    return key.replace(/([A-Z])/g, '_$1').toUpperCase();
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,8 @@ const serverEntry = [
     'src/server/index.ts',
     'src/server/internal.ts',
     'src/server/sync-worker.ts',
+    'src/container/index.ts',
+    'src/container/errors.ts',
     'src/platform/client.ts',
     'src/platform/build.ts',
     'src/nextjs/index.ts',


### PR DESCRIPTION
## Problem

`@smooai/config` resolves through four tiers (blob → env → http → file). The **blob** tier is the blessed path for **Lambda**, but the wrong default for long-lived **containers** (EKS/ECS): when the per-build blob key isn't delivered to the pod, resolution silently falls through to the (absent) file tier and returns `undefined` for a required secret. That caused a real outage — a container got `undefined` for `STRIPE_API_KEY`, `new Stripe(undefined)` threw at module load, the process exited `0` before `listen()`, and the pod CrashLooped (SMOODEV-1478).

## Solution

The **TypeScript reference implementation** of container/runtime mode (epic SMOODEV-1489; spec in `docs/Container-Runtime-Mode-Spec.md`). New `@smooai/config/container` entry point:

- **`initContainerConfig(options?)`** — validates the §1 env contract (throws `ConfigBootstrapError { missing }` listing exactly which vars are missing — no partial init), constructs the M2M `TokenProvider` + `ConfigClient`, and does an initial token mint + config fetch so auth/network failures surface at **startup**, not first read. Options mirror the env contract for testing/embedding.
- **Fail-loud reads (§3)** — `secretConfig.get`/`getSync` (and public/flag analogs) throw `ConfigKeyUnresolvedError { key, env, triedTiers }` for a required key that resolves absent across the active tiers, instead of returning `undefined`. `getSync` throws too. `optionalKeys` opts specific keys out (returns absent).
- **`configHealth()` / `handle.health()`** — non-throwing `Healthy | Unhealthy{reason}` status for k8s readiness/liveness probes. Serves last-good within the 30s cache TTL on a background refresh failure; reports `Unhealthy` past hard-expiry.
- **`selectMode()`** — mode selection per §2 (explicit `SMOOAI_CONFIG_MODE=container`, blob/file present → default, auto-select on M2M creds; logs once).
- **Caching/refresh (§5)** — token proactive refresh (60s buffer) + 401 → invalidate → retry-once (reused from `TokenProvider`/`ConfigClient`); config TTL default 30s.

## Design decision (for parity)

The schema makes every key `.optional()` — it carries no required/optional metadata. **Container mode treats all schema-declared keys as required by default**, with an explicit `optionalKeys` opt-out. This is the cleanest mapping of the spec's "required-key" concept onto the existing schema and is documented for the other SDKs to mirror.

## Docs

- New canonical `docs/Container-Runtime-Mode.md` (shared, referenced by all SDKs): env contract, complete ExternalSecret (External Secrets Operator) recipe + Deployment env snippet + readiness probe, "containers use container mode, not the baked blob" guidance.
- README section linking it with a TS `initContainerConfig` + health snippet.

## Tests

`src/container/__tests__/container.test.ts` — bootstrap missing-env (lists vars), required-key-unresolved throws (not absent), optional-key-absent returns absent, happy-path fetch+cache, 401→refresh→retry, configHealth healthy/unhealthy, selectMode. Full TS suite green (246 tests).

## Non-goals

Blob/Lambda path untouched (still the Lambda default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)