### PR TITLE
SMOODEV-1492: Go SDK container/runtime mode (parity with TS reference)

### DIFF
--- a/.changeset/container-runtime-mode-go.md
+++ b/.changeset/container-runtime-mode-go.md
@@ -1,0 +1,13 @@
+---
+'@smooai/config': minor
+---
+
+SMOODEV-1492: Add container/runtime mode to the **Go** SDK (`github.com/SmooAI/config/go/config/container`) — bringing it to parity with the TypeScript reference (SMOODEV-1490) under the five-language contract (SMOODEV-1489).
+
+Container mode makes the HTTP config API the first-class, fail-loud path for long-lived containers (EKS/ECS) instead of the Lambda-oriented baked blob, with idiomatic Go semantics (error returns + `context.Context`, no panics on the error-returning path):
+
+- `InitContainerConfig(ctx, opts) (*ContainerConfigHandle, error)` — validates the container env contract, mints an M2M OAuth token, and does an initial fetch so auth/network failures surface at startup (not first read). Missing/blank required env returns a typed `*ConfigBootstrapError` listing exactly which vars are missing.
+- Fail-loud reads — `handle.SecretConfig`/`PublicConfig`/`FeatureFlag`: `Get(key) (value, ok, err)` returns `*ConfigKeyUnresolvedError{ Key, Env, TriedTiers }` for a required key that resolves absent (the SMOODEV-1478 CrashLoop class); `MustGet(key) (value, ok)` is the fail-loud sync analog that panics on the same. `OptionalKeys` opts specific keys out (returns the zero value, `ok=false`, no error).
+- `handle.Health() ConfigHealth` and `container.ConfigHealthOf(handle)` — non-erroring status for Kubernetes readiness/liveness probes; serves last-good within the 30s cache TTL, reports `unhealthy` past hard-expiry.
+- `container.SelectMode(*SelectModeInputs) string` — mode selection (explicit `SMOOAI_CONFIG_MODE=container`, blob/file present → default, or auto-select on M2M creds).
+- Same defaults as every SDK: 30s cache TTL, 60s token refresh buffer, 401→invalidate→retry once. New `ConfigClient.SeedCache` / `ConfigClient.GetCachedValue` helpers back the env-tier override + last-good serving.

--- a/docs/Container-Runtime-Mode.md
+++ b/docs/Container-Runtime-Mode.md
@@ -235,13 +235,13 @@ M2M credentials never sit in plaintext manifests.
 
 ## 7. Per-language entry points
 
-| SDK        | Init                              | Health            |
-| ---------- | --------------------------------- | ----------------- |
-| TypeScript | `initContainerConfig({ schema })` | `config.health()` |
-| .NET       | `InitContainerConfig(...)`        | `ConfigHealth()`  |
+| SDK        | Init                              | Health                                       |
+| ---------- | --------------------------------- | -------------------------------------------- |
+| TypeScript | `initContainerConfig({ schema })` | `config.health()`                            |
+| .NET       | `InitContainerConfig(...)`        | `ConfigHealth()`                             |
 | Go         | `InitContainerConfig(ctx, ...)`   | `handle.Health()` / `ConfigHealthOf(handle)` |
-| Python     | `init_container_config(...)`      | `config_health()` |
-| Rust       | `init_container_config(...)`      | `config_health()` |
+| Python     | `init_container_config(...)`      | `config_health()`                            |
+| Rust       | `init_container_config(...)`      | `config_health()`                            |
 
 Each SDK's README links back to this doc and shows the language's
 `initContainerConfig` + health snippet.

--- a/docs/Container-Runtime-Mode.md
+++ b/docs/Container-Runtime-Mode.md
@@ -239,7 +239,7 @@ M2M credentials never sit in plaintext manifests.
 | ---------- | --------------------------------- | ----------------- |
 | TypeScript | `initContainerConfig({ schema })` | `config.health()` |
 | .NET       | `InitContainerConfig(...)`        | `ConfigHealth()`  |
-| Go         | `InitContainerConfig(ctx, ...)`   | `ConfigHealth()`  |
+| Go         | `InitContainerConfig(ctx, ...)`   | `handle.Health()` / `ConfigHealthOf(handle)` |
 | Python     | `init_container_config(...)`      | `config_health()` |
 | Rust       | `init_container_config(...)`      | `config_health()` |
 

--- a/go/config/README.md
+++ b/go/config/README.md
@@ -330,15 +330,15 @@ http.HandleFunc("/healthz/config", func(w http.ResponseWriter, _ *http.Request) 
 
 Key API:
 
-| Symbol                                                              | Purpose                                                                                  |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `InitContainerConfig(ctx, opts) (*ContainerConfigHandle, error)`   | Validate env, mint token, initial fetch. Fail-loud at startup.                           |
-| `handle.SecretConfig` / `PublicConfig` / `FeatureFlag`             | Tier accessors. `Get(key) (value, ok, err)` returns `*ConfigKeyUnresolvedError` for a missing required key; `MustGet(key) (value, ok)` is the sync analog that panics on the same. |
-| `handle.Health() ConfigHealth`                                     | Non-throwing readiness status (`"healthy"` / `"unhealthy"` + reason).                    |
-| `container.ConfigHealthOf(handle) ConfigHealth`                    | Free-function form; never errors/panics (nil-safe).                                       |
-| `container.SelectMode(*SelectModeInputs) string`                   | `"container"` or `"default"` per the §2 selection rules.                                  |
-| `container.ConfigBootstrapError{ Missing []string }`               | Missing/blank container-required env at init.                                            |
-| `container.ConfigKeyUnresolvedError{ Key, Env string; TriedTiers []Tier }` | A required key that resolved absent across all active tiers.                      |
+| Symbol                                                                     | Purpose                                                                                                                                                                            |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `InitContainerConfig(ctx, opts) (*ContainerConfigHandle, error)`           | Validate env, mint token, initial fetch. Fail-loud at startup.                                                                                                                     |
+| `handle.SecretConfig` / `PublicConfig` / `FeatureFlag`                     | Tier accessors. `Get(key) (value, ok, err)` returns `*ConfigKeyUnresolvedError` for a missing required key; `MustGet(key) (value, ok)` is the sync analog that panics on the same. |
+| `handle.Health() ConfigHealth`                                             | Non-throwing readiness status (`"healthy"` / `"unhealthy"` + reason).                                                                                                              |
+| `container.ConfigHealthOf(handle) ConfigHealth`                            | Free-function form; never errors/panics (nil-safe).                                                                                                                                |
+| `container.SelectMode(*SelectModeInputs) string`                           | `"container"` or `"default"` per the §2 selection rules.                                                                                                                           |
+| `container.ConfigBootstrapError{ Missing []string }`                       | Missing/blank container-required env at init.                                                                                                                                      |
+| `container.ConfigKeyUnresolvedError{ Key, Env string; TriedTiers []Tier }` | A required key that resolved absent across all active tiers.                                                                                                                       |
 
 By design, the schema carries no required/optional metadata, so container mode treats **all** schema keys as required; opt specific keys out via `InitContainerConfigOptions.OptionalKeys`. An optional key that resolves absent returns the zero value with `ok=false` and no error.
 

--- a/go/config/README.md
+++ b/go/config/README.md
@@ -285,6 +285,63 @@ Without both set, `NewRuntimeConfigManager` returns a regular `*ConfigManager` c
 
 The blob format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` — wire-identical to the TypeScript, Python, Rust, and .NET runtimes. A blob baked in any language decrypts in any other.
 
+### Container / Runtime Mode
+
+For long-lived containers (EKS/ECS) the baked blob is the **wrong** default: when the per-build blob key isn't delivered to the pod, resolution silently falls through to the absent file tier and returns the zero value for a required secret (the SMOODEV-1478 CrashLoop). **Container mode** makes the HTTP config API the first-class, **fail-loud** path — a missing required value is an immediate, typed `*ConfigKeyUnresolvedError`, never a silent zero value.
+
+This is the Go side of the five-language parity contract. The behavior (env contract, mode selection, fail-loud semantics, 30s cache TTL, 60s token refresh buffer, 401→refresh→retry) is identical across the TS/dotnet/go/python/rust SDKs — see the shared **[`docs/Container-Runtime-Mode.md`](../../docs/Container-Runtime-Mode.md)** for the env contract, the ExternalSecret (External Secrets Operator) recipe, and a readiness-probe example.
+
+```go
+import (
+    "context"
+    "log"
+    "net/http"
+
+    config "github.com/SmooAI/config/go/config"
+    "github.com/SmooAI/config/go/config/container"
+)
+
+// Validates the container env contract, mints an M2M token, and does an
+// initial fetch — startup fails loudly here, not on first read.
+h, err := container.InitContainerConfig(context.Background(), container.InitContainerConfigOptions{
+    Schema: schema, // your *config.ConfigDefinition
+})
+if err != nil {
+    log.Fatalf("config bootstrap failed: %v", err) // CrashLoop visibly
+}
+
+// Fail-loud: a required secret that doesn't resolve returns a *ConfigKeyUnresolvedError.
+stripeKey, ok, err := h.SecretConfig.Get("stripeApiKey")
+if err != nil {
+    log.Fatal(err)
+}
+_ = ok
+_ = stripeKey
+
+// Kubernetes readiness probe — never errors.
+http.HandleFunc("/healthz/config", func(w http.ResponseWriter, _ *http.Request) {
+    if container.ConfigHealthOf(h).IsHealthy() {
+        w.WriteHeader(http.StatusOK)
+        return
+    }
+    w.WriteHeader(http.StatusServiceUnavailable)
+})
+```
+
+Key API:
+
+| Symbol                                                              | Purpose                                                                                  |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `InitContainerConfig(ctx, opts) (*ContainerConfigHandle, error)`   | Validate env, mint token, initial fetch. Fail-loud at startup.                           |
+| `handle.SecretConfig` / `PublicConfig` / `FeatureFlag`             | Tier accessors. `Get(key) (value, ok, err)` returns `*ConfigKeyUnresolvedError` for a missing required key; `MustGet(key) (value, ok)` is the sync analog that panics on the same. |
+| `handle.Health() ConfigHealth`                                     | Non-throwing readiness status (`"healthy"` / `"unhealthy"` + reason).                    |
+| `container.ConfigHealthOf(handle) ConfigHealth`                    | Free-function form; never errors/panics (nil-safe).                                       |
+| `container.SelectMode(*SelectModeInputs) string`                   | `"container"` or `"default"` per the §2 selection rules.                                  |
+| `container.ConfigBootstrapError{ Missing []string }`               | Missing/blank container-required env at init.                                            |
+| `container.ConfigKeyUnresolvedError{ Key, Env string; TriedTiers []Tier }` | A required key that resolved absent across all active tiers.                      |
+
+By design, the schema carries no required/optional metadata, so container mode treats **all** schema keys as required; opt specific keys out via `InitContainerConfigOptions.OptionalKeys`. An optional key that resolves absent returns the zero value with `ok=false` and no error.
+
 ## Environment Variables
 
 All clients read from the same set of environment variables:

--- a/go/config/client.go
+++ b/go/config/client.go
@@ -329,6 +329,35 @@ func (c *ConfigClient) GetAllValues(environment string) (map[string]any, error) 
 	return result.Values, nil
 }
 
+// SeedCache pre-populates a single cache entry without a network request.
+// Pass an empty environment to use the client's default. Mirrors the TS
+// ConfigClient.seedCache — used by container mode to record an env-tier
+// override so a subsequent GetCachedValue (sync read) sees it.
+func (c *ConfigClient) SeedCache(key string, value any, environment string) {
+	env := c.resolveEnv(environment)
+	c.mu.Lock()
+	c.cache[env+":"+key] = cacheEntry{value: value, expiresAt: c.computeExpiresAt()}
+	c.mu.Unlock()
+}
+
+// GetCachedValue synchronously reads a value from the local cache without a
+// network request. Returns (nil, false) when the key is absent or its TTL has
+// expired. Mirrors the TS ConfigClient.getCachedValue. Pass an empty
+// environment to use the client's default.
+func (c *ConfigClient) GetCachedValue(key, environment string) (any, bool) {
+	env := c.resolveEnv(environment)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.cache[env+":"+key]
+	if !ok {
+		return nil, false
+	}
+	if !entry.expiresAt.IsZero() && !time.Now().Before(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.value, true
+}
+
 // InvalidateCache clears all locally cached values.
 func (c *ConfigClient) InvalidateCache() {
 	c.mu.Lock()

--- a/go/config/container/container.go
+++ b/go/config/container/container.go
@@ -1,0 +1,454 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	config "github.com/SmooAI/config/go/config"
+)
+
+// DefaultCacheTTL is the default config-value cache TTL (§5). Same 30s default
+// in every SDK. A background refresh failure serves the last-good value until
+// this TTL hard-expires, at which point Health reports unhealthy.
+const DefaultCacheTTL = 30 * time.Second
+
+// DefaultTokenRefreshBufferSeconds is the default token proactive-refresh
+// window in seconds (§5). Matches TokenProvider's default.
+const DefaultTokenRefreshBufferSeconds = 60
+
+// ConfigClient is the subset of *config.ConfigClient that container mode
+// depends on. Declaring it as an interface lets tests inject a stub without a
+// live HTTP server, mirroring the TS configClient injection seam.
+type ConfigClient interface {
+	GetAllValues(environment string) (map[string]any, error)
+	GetValue(key, environment string) (any, error)
+	GetCachedValue(key, environment string) (any, bool)
+	SeedCache(key string, value any, environment string)
+}
+
+// TokenProvider is the subset of *config.TokenProvider container mode needs.
+// Injectable for tests.
+type TokenProvider interface {
+	GetAccessToken(ctx context.Context) (string, error)
+	Invalidate()
+}
+
+// InitContainerConfigOptions mirrors the §1 env contract so tests and embedders
+// can construct a handle without touching the process environment. When a field
+// is empty, the corresponding env var is read.
+type InitContainerConfigOptions struct {
+	// Schema is the config definition for this service (required). Its declared
+	// keys are treated as required in container mode by default — see
+	// OptionalKeys for the opt-out.
+	Schema *config.ConfigDefinition
+
+	// APIURL is the config API base URL. Falls back to SMOOAI_CONFIG_API_URL.
+	APIURL string
+	// AuthURL is the OAuth issuer base URL. Falls back to SMOOAI_CONFIG_AUTH_URL,
+	// then legacy SMOOAI_AUTH_URL, then https://auth.smoo.ai.
+	AuthURL string
+	// ClientID is the M2M OAuth client id. Falls back to SMOOAI_CONFIG_CLIENT_ID.
+	ClientID string
+	// ClientSecret is the M2M OAuth client secret. Falls back to
+	// SMOOAI_CONFIG_CLIENT_SECRET, then legacy SMOOAI_CONFIG_API_KEY.
+	ClientSecret string
+	// OrgID is the org id whose config to fetch. Falls back to SMOOAI_CONFIG_ORG_ID.
+	OrgID string
+	// Environment is the environment name (e.g. "production"). Falls back to
+	// SMOOAI_CONFIG_ENV.
+	Environment string
+
+	// CacheTTL is the config-value cache TTL. Zero uses DefaultCacheTTL (30s).
+	CacheTTL time.Duration
+	// TokenRefreshBuffer is the seconds before token expiry to proactively
+	// refresh. Zero uses DefaultTokenRefreshBufferSeconds (60s).
+	TokenRefreshBuffer int
+
+	// OptionalKeys are keys allowed to be absent. A read of any of these returns
+	// the zero value with ok=false instead of a ConfigKeyUnresolvedError.
+	// Everything else declared in Schema is required (container mode's
+	// default-required posture).
+	OptionalKeys []string
+
+	// ConfigClient is a test/embedding seam — inject a pre-built client. When
+	// supplied, APIURL/AuthURL/ClientID/ClientSecret/OrgID env validation is
+	// skipped (the client already carries them) but Environment is still required.
+	ConfigClient ConfigClient
+	// TokenProvider is a test/embedding seam — inject a pre-built token provider.
+	TokenProvider TokenProvider
+
+	// EnvOverride replaces os.Getenv lookups (primarily for tests).
+	EnvOverride map[string]string
+}
+
+// ConfigHealth is the status returned by ContainerConfigHandle.Health. Never an
+// error. Status is "healthy" or "unhealthy"; Reason is populated when unhealthy.
+type ConfigHealth struct {
+	Status string
+	Reason string
+}
+
+// IsHealthy reports whether the status is "healthy".
+func (h ConfigHealth) IsHealthy() bool { return h.Status == "healthy" }
+
+// tierAccessor exposes fail-loud reads for one schema tier (public / secret /
+// feature flag). Get returns the resolved value or a ConfigKeyUnresolvedError
+// (for required keys). MustGet panics on that error — the fail-loud "sync"
+// analog of the TS getSync (§3).
+type tierAccessor struct {
+	handle *ContainerConfigHandle
+	tier   string // "public" | "secret" | "featureFlag" (for messages)
+}
+
+// Get resolves a single key. For a key declared in the schema and not in
+// OptionalKeys, a missing value returns a *ConfigKeyUnresolvedError rather than
+// the zero value (§3 fail-loud). For an optional key, a missing value returns
+// (nil, false, nil). ok reports whether a value was present.
+func (a tierAccessor) Get(key string) (value any, ok bool, err error) {
+	if key == "" {
+		return nil, false, fmt.Errorf(
+			"@smooai/config (container): %sConfig.Get called with empty key. "+
+				"Most common cause: reading a key not declared in your schema", a.tier)
+	}
+	v, present, tried := a.handle.resolve(key)
+	if present {
+		return v, true, nil
+	}
+	if a.handle.isOptional(key) {
+		return nil, false, nil
+	}
+	return nil, false, &ConfigKeyUnresolvedError{Key: key, Env: a.handle.environment, TriedTiers: tried}
+}
+
+// MustGet is the fail-loud sync analog of the TS getSync. It resolves a key
+// from the env override or the local cache only (no network) and panics with a
+// *ConfigKeyUnresolvedError when a required key is absent. Optional keys return
+// (nil, false). Use Get for the error-returning form.
+func (a tierAccessor) MustGet(key string) (value any, ok bool) {
+	if key == "" {
+		panic(fmt.Errorf(
+			"@smooai/config (container): %sConfig.MustGet called with empty key. "+
+				"Most common cause: reading a key not declared in your schema", a.tier))
+	}
+	v, present, tried := a.handle.syncResolve(key)
+	if present {
+		return v, true
+	}
+	if a.handle.isOptional(key) {
+		return nil, false
+	}
+	panic(&ConfigKeyUnresolvedError{Key: key, Env: a.handle.environment, TriedTiers: tried})
+}
+
+// ContainerConfigHandle is returned by InitContainerConfig. It exposes the same
+// tier accessors as the base config manager but with §3 fail-loud behavior,
+// plus a non-throwing Health for Kubernetes readiness/liveness probes.
+type ContainerConfigHandle struct {
+	client      ConfigClient
+	environment string
+	cacheTTL    time.Duration
+	optional    map[string]struct{}
+	getEnv      func(string) string
+
+	// PublicConfig / SecretConfig / FeatureFlag are the fail-loud accessors.
+	PublicConfig tierAccessor
+	SecretConfig tierAccessor
+	FeatureFlag  tierAccessor
+
+	mu          sync.Mutex
+	lastFetchOK bool
+	lastFetchAt time.Time
+	lastError   string
+}
+
+// Client returns the underlying ConfigClient (escape hatch for advanced callers).
+func (h *ContainerConfigHandle) Client() ConfigClient { return h.client }
+
+func (h *ContainerConfigHandle) isOptional(key string) bool {
+	_, ok := h.optional[key]
+	return ok
+}
+
+// resolve reads a single key through the active container tiers: env override
+// first (explicit process env wins, matching the existing chain's precedence),
+// then the HTTP config server. Blob/file tiers are disabled (§2). present
+// reports whether a non-absent value was found; tried lists the tiers consulted.
+func (h *ContainerConfigHandle) resolve(key string) (value any, present bool, tried []Tier) {
+	tried = append(tried, TierEnv)
+	if fromEnv, ok := h.envOverride(key); ok {
+		// Seed the cache so a later MustGet (sync read) sees the override too.
+		h.client.SeedCache(key, fromEnv, h.environment)
+		return fromEnv, true, tried
+	}
+
+	tried = append(tried, TierHTTP)
+	v, err := h.client.GetValue(key, h.environment)
+	if err != nil {
+		h.recordError(err)
+		// §5: serve last-good from cache until TTL hard-expiry.
+		if cached, ok := h.client.GetCachedValue(key, h.environment); ok && isSet(cached) {
+			log.Printf("@smooai/config (container): HTTP refresh failed for key %q; serving last-good cached value: %v", key, err)
+			return cached, true, tried
+		}
+		return nil, false, tried
+	}
+	h.recordSuccess()
+	if isSet(v) {
+		return v, true, tried
+	}
+	return nil, false, tried
+}
+
+// syncResolve is the no-network read backing MustGet: env override then the
+// local cache only.
+func (h *ContainerConfigHandle) syncResolve(key string) (value any, present bool, tried []Tier) {
+	tried = append(tried, TierEnv)
+	if fromEnv, ok := h.envOverride(key); ok {
+		return fromEnv, true, tried
+	}
+	tried = append(tried, TierHTTP)
+	if cached, ok := h.client.GetCachedValue(key, h.environment); ok && isSet(cached) {
+		return cached, true, tried
+	}
+	return nil, false, tried
+}
+
+// envOverride reads an explicit process env var for a key (UPPER_SNAKE_CASE of
+// the camelCase key). A set-but-blank var counts as absent.
+func (h *ContainerConfigHandle) envOverride(key string) (string, bool) {
+	v := h.getEnv(envVarNameFor(key))
+	if strings.TrimSpace(v) == "" {
+		return "", false
+	}
+	return v, true
+}
+
+func (h *ContainerConfigHandle) recordSuccess() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastFetchOK = true
+	h.lastFetchAt = time.Now()
+	h.lastError = ""
+}
+
+func (h *ContainerConfigHandle) recordError(err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastError = err.Error()
+}
+
+// Health is a cheap, non-erroring status for readiness/liveness probes (§4). It
+// serves "healthy" while within the cache TTL of the last good fetch even if a
+// background refresh just failed; past the hard TTL a failed refresh flips it
+// "unhealthy" (§5).
+func (h *ContainerConfigHandle) Health() ConfigHealth {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.lastFetchOK {
+		reason := h.lastError
+		if reason == "" {
+			reason = "initial config fetch has not succeeded"
+		}
+		return ConfigHealth{Status: "unhealthy", Reason: reason}
+	}
+	if h.lastError != "" && time.Since(h.lastFetchAt) > h.cacheTTL {
+		return ConfigHealth{
+			Status: "unhealthy",
+			Reason: fmt.Sprintf("last config refresh failed and cache TTL (%s) expired: %s", h.cacheTTL, h.lastError),
+		}
+	}
+	return ConfigHealth{Status: "healthy"}
+}
+
+// ConfigHealth is the free-function form of handle.Health (§4). Never errors or
+// panics; a nil handle reports unhealthy.
+func ConfigHealthOf(handle *ContainerConfigHandle) ConfigHealth {
+	if handle == nil {
+		return ConfigHealth{Status: "unhealthy", Reason: "nil config handle"}
+	}
+	return handle.Health()
+}
+
+type resolvedEnv struct {
+	apiURL       string
+	authURL      string
+	clientID     string
+	clientSecret string
+	orgID        string
+	environment  string
+}
+
+func resolveAndValidateEnv(opts InitContainerConfigOptions, getEnv func(string) string) (resolvedEnv, error) {
+	pick := func(optVal string, envNames ...string) string {
+		if v := strings.TrimSpace(optVal); v != "" {
+			return optVal
+		}
+		for _, name := range envNames {
+			if v := getEnv(name); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+
+	authURL := pick(opts.AuthURL, "SMOOAI_CONFIG_AUTH_URL", "SMOOAI_AUTH_URL")
+	if authURL == "" {
+		authURL = "https://auth.smoo.ai"
+	}
+
+	env := resolvedEnv{
+		apiURL:       pick(opts.APIURL, "SMOOAI_CONFIG_API_URL"),
+		authURL:      authURL,
+		clientID:     pick(opts.ClientID, "SMOOAI_CONFIG_CLIENT_ID"),
+		clientSecret: pick(opts.ClientSecret, "SMOOAI_CONFIG_CLIENT_SECRET", "SMOOAI_CONFIG_API_KEY"),
+		orgID:        pick(opts.OrgID, "SMOOAI_CONFIG_ORG_ID"),
+		environment:  pick(opts.Environment, "SMOOAI_CONFIG_ENV"),
+	}
+
+	// When a ConfigClient is injected it already carries
+	// apiURL/auth/clientID/secret/orgID — only the environment is still required.
+	clientInjected := opts.ConfigClient != nil
+
+	var missing []string
+	if !clientInjected {
+		if env.apiURL == "" {
+			missing = append(missing, "SMOOAI_CONFIG_API_URL")
+		}
+		if env.clientID == "" {
+			missing = append(missing, "SMOOAI_CONFIG_CLIENT_ID")
+		}
+		if env.clientSecret == "" {
+			missing = append(missing, "SMOOAI_CONFIG_CLIENT_SECRET")
+		}
+		if env.orgID == "" {
+			missing = append(missing, "SMOOAI_CONFIG_ORG_ID")
+		}
+	}
+	if env.environment == "" {
+		missing = append(missing, "SMOOAI_CONFIG_ENV")
+	}
+	if len(missing) > 0 {
+		return resolvedEnv{}, &ConfigBootstrapError{Missing: missing}
+	}
+	return env, nil
+}
+
+// InitContainerConfig is the explicit container-mode bootstrap (§4). It
+// validates the §1 env contract, constructs the M2M TokenProvider +
+// ConfigClient, and performs an initial token mint + config fetch so
+// auth/network failures surface at startup rather than on first read. The
+// returned handle's accessors are fail-loud (§3).
+//
+// Returns a *ConfigBootstrapError when container-required env is missing/blank,
+// or the underlying error on auth/network failure during the initial fetch.
+func InitContainerConfig(ctx context.Context, opts InitContainerConfigOptions) (*ContainerConfigHandle, error) {
+	if opts.Schema == nil {
+		return nil, &ConfigBootstrapError{Missing: []string{"Schema"}}
+	}
+
+	getEnv := os.Getenv
+	if opts.EnvOverride != nil {
+		ov := opts.EnvOverride
+		getEnv = func(k string) string { return ov[k] }
+	}
+
+	env, err := resolveAndValidateEnv(opts, getEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheTTL := opts.CacheTTL
+	if cacheTTL <= 0 {
+		cacheTTL = DefaultCacheTTL
+	}
+	refreshBuffer := opts.TokenRefreshBuffer
+	if refreshBuffer <= 0 {
+		refreshBuffer = DefaultTokenRefreshBufferSeconds
+	}
+
+	// Build the ConfigClient unless one is injected (test/embedding seam).
+	var client ConfigClient
+	if opts.ConfigClient != nil {
+		client = opts.ConfigClient
+	} else {
+		clientOpts := []config.ConfigClientOption{
+			config.WithCacheTTL(cacheTTL),
+			config.WithAuthURL(env.authURL),
+		}
+		if opts.TokenProvider != nil {
+			// The injected provider must be a *config.TokenProvider for
+			// WithTokenProvider; if it's a different implementation, fall back
+			// to constructing one from creds below.
+			if tp, ok := opts.TokenProvider.(*config.TokenProvider); ok {
+				clientOpts = append(clientOpts, config.WithTokenProvider(tp))
+			}
+		} else {
+			tp, tpErr := config.NewTokenProvider(
+				env.authURL, env.clientID, env.clientSecret,
+				config.WithTokenProviderRefreshWindow(time.Duration(refreshBuffer)*time.Second),
+			)
+			if tpErr != nil {
+				return nil, fmt.Errorf("@smooai/config (container): build token provider: %w", tpErr)
+			}
+			clientOpts = append(clientOpts, config.WithTokenProvider(tp))
+		}
+		client = config.NewConfigClient(env.apiURL, env.clientID, env.clientSecret, env.orgID, clientOpts...)
+	}
+
+	optional := make(map[string]struct{}, len(opts.OptionalKeys))
+	for _, k := range opts.OptionalKeys {
+		optional[k] = struct{}{}
+	}
+
+	handle := &ContainerConfigHandle{
+		client:      client,
+		environment: env.environment,
+		cacheTTL:    cacheTTL,
+		optional:    optional,
+		getEnv:      getEnv,
+	}
+	handle.PublicConfig = tierAccessor{handle: handle, tier: "public"}
+	handle.SecretConfig = tierAccessor{handle: handle, tier: "secret"}
+	handle.FeatureFlag = tierAccessor{handle: handle, tier: "featureFlag"}
+
+	// Initial config fetch — fail loud at startup, not first read. The OAuth
+	// token mint happens inside GetAllValues (the ConfigClient's TokenProvider
+	// exchanges on the first authed request), so an auth failure surfaces here
+	// too. A pod that can't reach the config server should CrashLoop visibly,
+	// not start degraded.
+	if _, err := client.GetAllValues(env.environment); err != nil {
+		handle.recordError(err)
+		return nil, fmt.Errorf("@smooai/config (container): initial config fetch failed: %w", err)
+	}
+	handle.recordSuccess()
+
+	return handle, nil
+}
+
+func isSet(v any) bool {
+	if v == nil {
+		return false
+	}
+	if s, ok := v.(string); ok {
+		return s != ""
+	}
+	return true
+}
+
+// envVarNameFor converts a camelCase key to UPPER_SNAKE_CASE for env-var reads
+// (matches the server tier and the TS implementation).
+func envVarNameFor(key string) string {
+	var b strings.Builder
+	for _, r := range key {
+		if r >= 'A' && r <= 'Z' {
+			b.WriteByte('_')
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToUpper(b.String())
+}

--- a/go/config/container/container_test.go
+++ b/go/config/container/container_test.go
@@ -1,0 +1,404 @@
+package container
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	config "github.com/SmooAI/config/go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient is an in-memory ConfigClient for the injection-seam tests. It
+// records the env-tier seed and serves values without a network round-trip.
+type stubClient struct {
+	mu          sync.Mutex
+	values      map[string]any
+	cache       map[string]any
+	getValueErr error // when set, GetValue returns this
+	allValueErr error // when set, GetAllValues returns this
+	getValueN   int32
+}
+
+func newStubClient(values map[string]any) *stubClient {
+	return &stubClient{values: values, cache: map[string]any{}}
+}
+
+func (s *stubClient) GetAllValues(environment string) (map[string]any, error) {
+	if s.allValueErr != nil {
+		return nil, s.allValueErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, v := range s.values {
+		s.cache[k] = v
+	}
+	out := map[string]any{}
+	for k, v := range s.values {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (s *stubClient) GetValue(key, environment string) (any, error) {
+	atomic.AddInt32(&s.getValueN, 1)
+	if s.getValueErr != nil {
+		return nil, s.getValueErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.values[key]
+	if !ok {
+		return nil, nil
+	}
+	s.cache[key] = v
+	return v, nil
+}
+
+func (s *stubClient) GetCachedValue(key, environment string) (any, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.cache[key]
+	return v, ok
+}
+
+func (s *stubClient) SeedCache(key string, value any, environment string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache[key] = value
+}
+
+func testSchema(t *testing.T) *config.ConfigDefinition {
+	t.Helper()
+	return config.DefineConfig(
+		map[string]any{"type": "object", "properties": map[string]any{"apiUrl": map[string]any{"type": "string"}}},
+		map[string]any{"type": "object", "properties": map[string]any{"stripeApiKey": map[string]any{"type": "string"}}},
+		map[string]any{"type": "object", "properties": map[string]any{"betaEnabled": map[string]any{"type": "boolean"}}},
+	)
+}
+
+// --- §7.2: bootstrap-missing-env errors + lists missing -----------------------
+
+func TestInitContainerConfig_MissingEnv_ErrorsAndListsMissing(t *testing.T) {
+	_, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema:      testSchema(t),
+		EnvOverride: map[string]string{}, // nothing set
+	})
+	require.Error(t, err)
+
+	var be *ConfigBootstrapError
+	require.True(t, errors.As(err, &be), "expected *ConfigBootstrapError, got %T", err)
+	assert.ElementsMatch(t, []string{
+		"SMOOAI_CONFIG_API_URL",
+		"SMOOAI_CONFIG_CLIENT_ID",
+		"SMOOAI_CONFIG_CLIENT_SECRET",
+		"SMOOAI_CONFIG_ORG_ID",
+		"SMOOAI_CONFIG_ENV",
+	}, be.Missing)
+	assert.Contains(t, be.Error(), "SMOOAI_CONFIG_CLIENT_ID")
+}
+
+func TestInitContainerConfig_BlankEnvCountsAsMissing(t *testing.T) {
+	_, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema: testSchema(t),
+		EnvOverride: map[string]string{
+			"SMOOAI_CONFIG_API_URL":       "  ", // blank
+			"SMOOAI_CONFIG_CLIENT_ID":     "id",
+			"SMOOAI_CONFIG_CLIENT_SECRET": "sk",
+			"SMOOAI_CONFIG_ORG_ID":        "org",
+			"SMOOAI_CONFIG_ENV":           "production",
+		},
+	})
+	var be *ConfigBootstrapError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, []string{"SMOOAI_CONFIG_API_URL"}, be.Missing)
+}
+
+func TestInitContainerConfig_MissingSchema(t *testing.T) {
+	_, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{})
+	var be *ConfigBootstrapError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, []string{"Schema"}, be.Missing)
+}
+
+func TestInitContainerConfig_InjectedClient_OnlyEnvRequired(t *testing.T) {
+	// With a ConfigClient injected, only SMOOAI_CONFIG_ENV is required.
+	stub := newStubClient(map[string]any{"stripeApiKey": "sk_live_x"})
+	h, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema:       testSchema(t),
+		ConfigClient: stub,
+		EnvOverride:  map[string]string{"SMOOAI_CONFIG_ENV": "production"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, "production", h.environment)
+}
+
+func TestInitContainerConfig_InjectedClient_MissingEnvStillErrors(t *testing.T) {
+	stub := newStubClient(map[string]any{})
+	_, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema:       testSchema(t),
+		ConfigClient: stub,
+		EnvOverride:  map[string]string{},
+	})
+	var be *ConfigBootstrapError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, []string{"SMOOAI_CONFIG_ENV"}, be.Missing)
+}
+
+// --- §7.2: happy path fetch + cache ------------------------------------------
+
+func newHandle(t *testing.T, values map[string]any, opts ...func(*InitContainerConfigOptions)) (*ContainerConfigHandle, *stubClient) {
+	t.Helper()
+	stub := newStubClient(values)
+	o := InitContainerConfigOptions{
+		Schema:       testSchema(t),
+		ConfigClient: stub,
+		EnvOverride:  map[string]string{"SMOOAI_CONFIG_ENV": "production"},
+	}
+	for _, f := range opts {
+		f(&o)
+	}
+	h, err := InitContainerConfig(context.Background(), o)
+	require.NoError(t, err)
+	return h, stub
+}
+
+func TestGet_HappyPath(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{"stripeApiKey": "sk_live_x", "apiUrl": "https://api.smoo.ai"})
+
+	v, ok, err := h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "sk_live_x", v)
+
+	pv, ok, err := h.PublicConfig.Get("apiUrl")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "https://api.smoo.ai", pv)
+}
+
+func TestGet_UsesCacheAfterInitialFetch(t *testing.T) {
+	h, stub := newHandle(t, map[string]any{"stripeApiKey": "sk_live_x"})
+	// MustGet reads cache only — the initial GetAllValues seeded it, so no
+	// GetValue network call should be needed.
+	v, ok := h.SecretConfig.MustGet("stripeApiKey")
+	assert.True(t, ok)
+	assert.Equal(t, "sk_live_x", v)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&stub.getValueN), "MustGet must not call GetValue")
+}
+
+// --- §7.2: required-key-unresolved errors (not absent) -----------------------
+
+func TestGet_RequiredKeyUnresolved_Errors(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{}) // server has no value for the key
+
+	_, ok, err := h.SecretConfig.Get("stripeApiKey")
+	assert.False(t, ok)
+	require.Error(t, err)
+	var ue *ConfigKeyUnresolvedError
+	require.ErrorAs(t, err, &ue)
+	assert.Equal(t, "stripeApiKey", ue.Key)
+	assert.Equal(t, "production", ue.Env)
+	assert.Equal(t, []Tier{TierEnv, TierHTTP}, ue.TriedTiers)
+}
+
+func TestMustGet_RequiredKeyUnresolved_Panics(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{})
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "MustGet should panic on unresolved required key")
+		ue, ok := r.(*ConfigKeyUnresolvedError)
+		require.True(t, ok, "panic value should be *ConfigKeyUnresolvedError, got %T", r)
+		assert.Equal(t, "stripeApiKey", ue.Key)
+	}()
+	h.SecretConfig.MustGet("stripeApiKey")
+}
+
+// --- §7.2: optional-key-absent returns absent (ok=false, no error) -----------
+
+func TestGet_OptionalKeyAbsent_NoError(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{}, func(o *InitContainerConfigOptions) {
+		o.OptionalKeys = []string{"stripeApiKey"}
+	})
+	v, ok, err := h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}
+
+func TestMustGet_OptionalKeyAbsent_NoPanic(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{}, func(o *InitContainerConfigOptions) {
+		o.OptionalKeys = []string{"stripeApiKey"}
+	})
+	v, ok := h.SecretConfig.MustGet("stripeApiKey")
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}
+
+func TestGet_EmptyKey_Errors(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{})
+	_, _, err := h.SecretConfig.Get("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty key")
+}
+
+// --- env-tier override wins over HTTP ----------------------------------------
+
+func TestGet_EnvOverrideWinsOverHTTP(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{"stripeApiKey": "from_server"}, func(o *InitContainerConfigOptions) {
+		o.EnvOverride = map[string]string{
+			"SMOOAI_CONFIG_ENV": "production",
+			"STRIPE_API_KEY":    "from_env",
+		}
+	})
+	v, ok, err := h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "from_env", v)
+}
+
+// --- §5: background-refresh failure serves last-good cached value ------------
+
+func TestGet_RefreshFailure_ServesLastGood(t *testing.T) {
+	h, stub := newHandle(t, map[string]any{"stripeApiKey": "cached_value"})
+	// Prime the cache with a successful read.
+	v, ok, err := h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "cached_value", v)
+
+	// Now force GetValue to fail; the cached value should still be served.
+	stub.getValueErr = errors.New("network down")
+	v, ok, err = h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "cached_value", v)
+}
+
+// --- §7.2: 401 → refresh → retry (exercises the real ConfigClient) -----------
+
+func Test401_Refresh_Retry(t *testing.T) {
+	var tokenMints int32
+	var valuesAttempts int32
+
+	auth := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenMints, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"jwt-token","expires_in":3600}`))
+	}))
+	defer auth.Close()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&valuesAttempts, 1)
+		if n == 1 {
+			// First values fetch (initial getAllValues) succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":{"stripeApiKey":"sk_live_x"}}`))
+			return
+		}
+		// On the GetValue read, return 401 the first time, then 200.
+		if n == 2 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"expired"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":"sk_live_refreshed"}`))
+	}))
+	defer api.Close()
+
+	h, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema:       testSchema(t),
+		APIURL:       api.URL,
+		AuthURL:      auth.URL,
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		OrgID:        "org",
+		Environment:  "production",
+		CacheTTL:     1 * time.Nanosecond, // force the GetValue read to bypass cache
+	})
+	require.NoError(t, err)
+
+	// Sleep so the 1ns initial-fetch cache entry expires, forcing a fresh GetValue.
+	time.Sleep(2 * time.Millisecond)
+
+	v, ok, err := h.SecretConfig.Get("stripeApiKey")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "sk_live_refreshed", v)
+	// Token minted twice: once initially, once after the 401 invalidation.
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&tokenMints), int32(2))
+}
+
+// --- §4: Health healthy / unhealthy ------------------------------------------
+
+func TestHealth_HealthyAfterInit(t *testing.T) {
+	h, _ := newHandle(t, map[string]any{"stripeApiKey": "x"})
+	hh := h.Health()
+	assert.Equal(t, "healthy", hh.Status)
+	assert.True(t, hh.IsHealthy())
+
+	// Free-function form.
+	assert.Equal(t, "healthy", ConfigHealthOf(h).Status)
+}
+
+func TestHealth_UnhealthyWhenInitialFetchFails(t *testing.T) {
+	stub := newStubClient(map[string]any{})
+	stub.allValueErr = errors.New("config server unreachable")
+	_, err := InitContainerConfig(context.Background(), InitContainerConfigOptions{
+		Schema:       testSchema(t),
+		ConfigClient: stub,
+		EnvOverride:  map[string]string{"SMOOAI_CONFIG_ENV": "production"},
+	})
+	// Initial fetch failure surfaces at init (fail-loud).
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config server unreachable")
+}
+
+func TestHealth_UnhealthyAfterRefreshFailurePastTTL(t *testing.T) {
+	h, stub := newHandle(t, map[string]any{"stripeApiKey": "x"}, func(o *InitContainerConfigOptions) {
+		o.CacheTTL = 5 * time.Millisecond
+	})
+	require.Equal(t, "healthy", h.Health().Status)
+
+	// A refresh fails — within TTL we still report healthy (serve last-good).
+	stub.getValueErr = errors.New("transient")
+	_, _, _ = h.SecretConfig.Get("stripeApiKey")
+	assert.Equal(t, "healthy", h.Health().Status, "within TTL a failed refresh stays healthy")
+
+	// Past hard TTL, a failed refresh flips unhealthy.
+	time.Sleep(8 * time.Millisecond)
+	hh := h.Health()
+	assert.Equal(t, "unhealthy", hh.Status)
+	assert.Contains(t, hh.Reason, "transient")
+}
+
+func TestConfigHealthOf_NilHandle(t *testing.T) {
+	hh := ConfigHealthOf(nil)
+	assert.Equal(t, "unhealthy", hh.Status)
+	assert.NotEmpty(t, hh.Reason)
+}
+
+func TestClient_EscapeHatch(t *testing.T) {
+	h, stub := newHandle(t, map[string]any{})
+	assert.Same(t, ConfigClient(stub), h.Client())
+}
+
+func TestEnvVarNameFor(t *testing.T) {
+	cases := map[string]string{
+		"stripeApiKey": "STRIPE_API_KEY",
+		"apiUrl":       "API_URL",
+		"betaEnabled":  "BETA_ENABLED",
+		"x":            "X",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, envVarNameFor(in), "envVarNameFor(%q)", in)
+	}
+}

--- a/go/config/container/errors.go
+++ b/go/config/container/errors.go
@@ -1,0 +1,107 @@
+// Package container implements @smooai/config container/runtime mode for Go
+// (SMOODEV-1489 / SMOODEV-1492). It mirrors the TypeScript reference
+// (src/container) exactly: identical env contract and error semantics. Idioms
+// differ (Go returns errors instead of throwing, takes a context.Context), the
+// behavior does not.
+//
+// # Why
+//
+// @smooai/config resolves values through four tiers: blob → env → http → file.
+// The blob tier (an encrypted bundle baked into a Lambda layer / image at
+// deploy time, decrypted with a separately-delivered key) is the blessed path
+// for Lambda. It is the wrong default for long-lived containers (EKS/ECS): when
+// the per-build blob key isn't delivered to the pod, resolution silently falls
+// through to the (absent) file tier and returns the zero value for a required
+// secret (the SMOODEV-1478 CrashLoop outage).
+//
+// Container mode makes the HTTP tier the blessed, first-class path for
+// containers, authenticated with an OAuth2 client_credentials (M2M) token, and
+// fail-loud: a missing required value is an immediate, typed
+// ConfigKeyUnresolvedError, never a silent zero value.
+package container
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Tier is one of the resolution tiers consulted during a value read.
+// Container mode disables the blob and file tiers (§2) and consults env then
+// http. The full set is retained for parity with the TS ConfigTier union and
+// for the TriedTiers context carried by ConfigKeyUnresolvedError.
+type Tier string
+
+const (
+	// TierBlob is the encrypted Lambda-layer bundle tier (disabled in container mode).
+	TierBlob Tier = "blob"
+	// TierEnv is the explicit process-environment-variable override tier.
+	TierEnv Tier = "env"
+	// TierHTTP is the config-server tier — the blessed container path.
+	TierHTTP Tier = "http"
+	// TierFile is the local .smooai-config/ file tier (disabled in container mode).
+	TierFile Tier = "file"
+)
+
+// ConfigBootstrapError is returned by InitContainerConfig when the
+// container-required environment (§1 of the spec) is missing or blank. It
+// carries the exact list of offending env var names so the operator can fix the
+// deployment without guessing. No partial init: if any required var is absent,
+// bootstrap fails whole.
+//
+// Parity: mirrors the TS ConfigBootstrapError { missing: string[] }.
+type ConfigBootstrapError struct {
+	// Missing holds the env var names (e.g. "SMOOAI_CONFIG_CLIENT_ID") that are
+	// missing or blank.
+	Missing []string
+}
+
+// Error implements the error interface.
+func (e *ConfigBootstrapError) Error() string {
+	noun := "this variable"
+	if len(e.Missing) != 1 {
+		noun = "these variables"
+	}
+	return fmt.Sprintf(
+		"[@smooai/config] container-mode bootstrap failed: missing required env %s. "+
+			"Set %s before calling InitContainerConfig "+
+			"(see docs/Container-Runtime-Mode.md for the Kubernetes/ExternalSecret recipe).",
+		strings.Join(e.Missing, ", "), noun,
+	)
+}
+
+// ConfigKeyUnresolvedError is returned by a required-key read (SecretConfig.Get
+// / MustGet and the public/flag analogs) in container mode when the value
+// resolves to absent across every active tier. This is the exact type that
+// closes the silent-zero-value hole (SMOODEV-1478 / SMOODEV-1135).
+//
+// Optional keys (declared via InitContainerConfigOptions.OptionalKeys) do NOT
+// produce this error — they return the zero value with ok=false.
+//
+// Parity: mirrors the TS ConfigKeyUnresolvedError { key, env, triedTiers }.
+type ConfigKeyUnresolvedError struct {
+	// Key is the camelCase config key that could not be resolved.
+	Key string
+	// Env is the environment the read targeted (e.g. "production").
+	Env string
+	// TriedTiers are the tiers that were consulted, in order, before giving up.
+	TriedTiers []Tier
+}
+
+// Error implements the error interface.
+func (e *ConfigKeyUnresolvedError) Error() string {
+	tried := make([]string, len(e.TriedTiers))
+	for i, t := range e.TriedTiers {
+		tried[i] = string(t)
+	}
+	triedStr := strings.Join(tried, " → ")
+	if triedStr == "" {
+		triedStr = "none"
+	}
+	return fmt.Sprintf(
+		"[@smooai/config] required config key %q did not resolve in environment %q "+
+			"(container mode; tiers tried: %s). "+
+			"Set a value for this key in the config server for %q, or mark it optional via "+
+			"InitContainerConfigOptions.OptionalKeys.",
+		e.Key, e.Env, triedStr, e.Env,
+	)
+}

--- a/go/config/container/errors_test.go
+++ b/go/config/container/errors_test.go
@@ -1,0 +1,39 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigBootstrapError_Message(t *testing.T) {
+	e := &ConfigBootstrapError{Missing: []string{"SMOOAI_CONFIG_CLIENT_ID", "SMOOAI_CONFIG_ENV"}}
+	msg := e.Error()
+	assert.Contains(t, msg, "SMOOAI_CONFIG_CLIENT_ID")
+	assert.Contains(t, msg, "SMOOAI_CONFIG_ENV")
+	assert.Contains(t, msg, "these variables")
+	assert.Contains(t, msg, "docs/Container-Runtime-Mode.md")
+}
+
+func TestConfigBootstrapError_SingularNoun(t *testing.T) {
+	e := &ConfigBootstrapError{Missing: []string{"SMOOAI_CONFIG_ENV"}}
+	assert.Contains(t, e.Error(), "this variable")
+}
+
+func TestConfigKeyUnresolvedError_Message(t *testing.T) {
+	e := &ConfigKeyUnresolvedError{
+		Key:        "stripeApiKey",
+		Env:        "production",
+		TriedTiers: []Tier{TierEnv, TierHTTP},
+	}
+	msg := e.Error()
+	assert.Contains(t, msg, "stripeApiKey")
+	assert.Contains(t, msg, "production")
+	assert.Contains(t, msg, "env → http")
+	assert.Contains(t, msg, "OptionalKeys")
+}
+
+func TestConfigKeyUnresolvedError_NoTiers(t *testing.T) {
+	e := &ConfigKeyUnresolvedError{Key: "k", Env: "dev"}
+	assert.Contains(t, e.Error(), "tiers tried: none")
+}

--- a/go/config/container/mode.go
+++ b/go/config/container/mode.go
@@ -1,0 +1,113 @@
+package container
+
+import (
+	"log"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Mode is the mode the SDK should run in, per §2. "container" means
+// HTTP-primary fail-loud; "default" means the existing blob → env → http → file
+// chain.
+const (
+	ModeContainer = "container"
+	ModeDefault   = "default"
+)
+
+// SelectModeInputs are the inputs for SelectMode. Empty fields fall back to the
+// corresponding env var.
+type SelectModeInputs struct {
+	// Mode is SMOOAI_CONFIG_MODE.
+	Mode string
+	// ClientID is SMOOAI_CONFIG_CLIENT_ID.
+	ClientID string
+	// ClientSecret is SMOOAI_CONFIG_CLIENT_SECRET (or legacy SMOOAI_CONFIG_API_KEY).
+	ClientSecret string
+	// APIURL is SMOOAI_CONFIG_API_URL.
+	APIURL string
+	// BlobPresent reports whether a baked blob source is present
+	// (SMOO_CONFIG_KEY + SMOO_CONFIG_KEY_FILE). When the pointer is nil the env
+	// vars are consulted.
+	BlobPresent *bool
+	// FilePresent reports whether a local .smooai-config/ file source is present.
+	// When the pointer is nil it defaults to false.
+	FilePresent *bool
+
+	// EnvOverride replaces os.Getenv lookups (primarily for tests).
+	EnvOverride map[string]string
+}
+
+var autoSelectLogOnce sync.Once
+
+// SelectMode decides which mode to enter, per §2. Resolution order:
+//
+//  1. SMOOAI_CONFIG_MODE=container → container mode (explicit).
+//  2. else if a blob/file source is present → default (Lambda/local), unchanged.
+//  3. else if CLIENT_ID + CLIENT_SECRET + API_URL all set → container (auto;
+//     logs once that container mode was auto-selected).
+//  4. else → default.
+//
+// Container mode MUST NOT silently degrade to the file tier — that decision is
+// enforced by InitContainerConfig's bootstrap validation; this only decides
+// which mode to enter.
+func SelectMode(inputs *SelectModeInputs) string {
+	if inputs == nil {
+		inputs = &SelectModeInputs{}
+	}
+	getEnv := os.Getenv
+	if inputs.EnvOverride != nil {
+		ov := inputs.EnvOverride
+		getEnv = func(k string) string { return ov[k] }
+	}
+	pick := func(optVal string, envNames ...string) string {
+		if v := strings.TrimSpace(optVal); v != "" {
+			return optVal
+		}
+		for _, name := range envNames {
+			if v := getEnv(name); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+
+	mode := pick(inputs.Mode, "SMOOAI_CONFIG_MODE")
+	if strings.EqualFold(mode, ModeContainer) {
+		return ModeContainer
+	}
+
+	blobPresent := false
+	if inputs.BlobPresent != nil {
+		blobPresent = *inputs.BlobPresent
+	} else {
+		blobPresent = strings.TrimSpace(getEnv("SMOO_CONFIG_KEY")) != "" &&
+			strings.TrimSpace(getEnv("SMOO_CONFIG_KEY_FILE")) != ""
+	}
+	filePresent := false
+	if inputs.FilePresent != nil {
+		filePresent = *inputs.FilePresent
+	}
+	if blobPresent || filePresent {
+		return ModeDefault
+	}
+
+	clientID := pick(inputs.ClientID, "SMOOAI_CONFIG_CLIENT_ID")
+	clientSecret := pick(inputs.ClientSecret, "SMOOAI_CONFIG_CLIENT_SECRET", "SMOOAI_CONFIG_API_KEY")
+	apiURL := pick(inputs.APIURL, "SMOOAI_CONFIG_API_URL")
+
+	if clientID != "" && clientSecret != "" && apiURL != "" {
+		autoSelectLogOnce.Do(func() {
+			log.Printf("@smooai/config: container mode auto-selected " +
+				"(CLIENT_ID + CLIENT_SECRET + API_URL set, no blob/file source present)")
+		})
+		return ModeContainer
+	}
+	return ModeDefault
+}
+
+// resetSelectModeLogForTests resets the once-per-process auto-select log latch.
+// Test-only.
+func resetSelectModeLogForTests() {
+	autoSelectLogOnce = sync.Once{}
+}

--- a/go/config/container/mode_test.go
+++ b/go/config/container/mode_test.go
@@ -1,0 +1,110 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestSelectMode_ExplicitContainer(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{
+		EnvOverride: map[string]string{"SMOOAI_CONFIG_MODE": "container"},
+	})
+	assert.Equal(t, ModeContainer, got)
+}
+
+func TestSelectMode_ExplicitContainerCaseInsensitive(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{Mode: "Container"})
+	assert.Equal(t, ModeContainer, got)
+}
+
+func TestSelectMode_BlobPresent_Default(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	// Even with M2M creds set, a present blob means default mode.
+	got := SelectMode(&SelectModeInputs{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		APIURL:       "https://api.smoo.ai",
+		BlobPresent:  boolPtr(true),
+	})
+	assert.Equal(t, ModeDefault, got)
+}
+
+func TestSelectMode_BlobPresentFromEnv_Default(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		APIURL:       "https://api.smoo.ai",
+		EnvOverride: map[string]string{
+			"SMOO_CONFIG_KEY":      "base64key",
+			"SMOO_CONFIG_KEY_FILE": "/path/blob.enc",
+		},
+	})
+	assert.Equal(t, ModeDefault, got)
+}
+
+func TestSelectMode_FilePresent_Default(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		APIURL:       "https://api.smoo.ai",
+		FilePresent:  boolPtr(true),
+	})
+	assert.Equal(t, ModeDefault, got)
+}
+
+func TestSelectMode_AutoSelectOnCreds(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	// EnvOverride with creds present and no blob/file env vars set — keeps the
+	// test independent of the developer machine's ambient SMOO_CONFIG_KEY blob.
+	got := SelectMode(&SelectModeInputs{
+		EnvOverride: map[string]string{
+			"SMOOAI_CONFIG_CLIENT_ID":     "cid",
+			"SMOOAI_CONFIG_CLIENT_SECRET": "csecret",
+			"SMOOAI_CONFIG_API_URL":       "https://api.smoo.ai",
+		},
+	})
+	assert.Equal(t, ModeContainer, got)
+}
+
+func TestSelectMode_AutoSelectViaLegacyApiKeySecret(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{
+		EnvOverride: map[string]string{
+			"SMOOAI_CONFIG_CLIENT_ID": "cid",
+			"SMOOAI_CONFIG_API_KEY":   "legacy_secret",
+			"SMOOAI_CONFIG_API_URL":   "https://api.smoo.ai",
+		},
+	})
+	assert.Equal(t, ModeContainer, got)
+}
+
+func TestSelectMode_DefaultWhenNothingSet(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(&SelectModeInputs{EnvOverride: map[string]string{}})
+	assert.Equal(t, ModeDefault, got)
+}
+
+func TestSelectMode_DefaultWhenIncompleteCreds(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	// Missing API URL → not enough to auto-select.
+	got := SelectMode(&SelectModeInputs{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	})
+	assert.Equal(t, ModeDefault, got)
+}
+
+func TestSelectMode_NilInputs(t *testing.T) {
+	defer resetSelectModeLogForTests()
+	got := SelectMode(nil)
+	// With a clean (test) env the result is deterministic only if no ambient
+	// SMOOAI_CONFIG_* vars are set; assert it returns a valid mode.
+	assert.Contains(t, []string{ModeContainer, ModeDefault}, got)
+}


### PR DESCRIPTION
## Problem

Long-lived containers (EKS/ECS) get the wrong default from `@smooai/config`: the Lambda-oriented baked blob silently falls through to the absent file tier and returns the zero value for a required secret (the SMOODEV-1478 CrashLoop). The TS reference (SMOODEV-1490, PR #92) shipped container/runtime mode to fix this; this brings the **Go** SDK to parity under the five-language contract (SMOODEV-1489).

## Solution

New package `github.com/SmooAI/config/go/config/container`, idiomatic Go (error returns + `context.Context`, no exceptions on the error-returning path):

- **`InitContainerConfig(ctx, opts) (*ContainerConfigHandle, error)`** — validates the §1 env contract, mints an M2M OAuth token, does an initial fetch so auth/network failures surface at **startup**, not first read. Missing/blank required env → `*ConfigBootstrapError{Missing []string}`.
- **Fail-loud reads** via `handle.SecretConfig` / `PublicConfig` / `FeatureFlag`: `Get(key) (value, ok, err)` returns `*ConfigKeyUnresolvedError{Key, Env, TriedTiers}` for a required key that resolves absent; `MustGet(key) (value, ok)` is the fail-loud sync analog that panics on the same. `OptionalKeys` opts specific keys out (zero value, `ok=false`, no error).
- **`handle.Health()` / `container.ConfigHealthOf(handle)`** — non-erroring readiness/liveness status; serves last-good within the 30s cache TTL, `unhealthy` past hard-expiry (§5).
- **`container.SelectMode(*SelectModeInputs) string`** — `"container"` / `"default"` per the §2 rules.
- Same defaults as every SDK: 30s cache TTL, 60s token refresh buffer, 401→invalidate→retry once. New `ConfigClient.SeedCache` / `GetCachedValue` helpers back the env-tier override + last-good serving.

## Idiom deviations from TS (intentional, no behavioral fork)

- `Get` returns `(value, ok, error)` instead of throwing; the "sync/getSync" form is `MustGet` (panics on unresolved-required, matching TS getSync's fail-loud throw).
- The free health function is `ConfigHealthOf(handle)` (not `ConfigHealth`) because `ConfigHealth` is the result **struct** — Go can't share the identifier between a type and a func.
- Injection seams (`ConfigClient` / `TokenProvider`) are interfaces so tests can stub without a live server.

## Tests

35 new tests (`go test ./container/...`), full module suite 336 pass: bootstrap-missing-env lists missing vars; required-key-unresolved errors/panics (not absent); optional-key-absent `ok=false`; happy-path fetch+cache; env-override-wins; refresh-failure-serves-last-good; **401→refresh→retry** against a real `httptest` server; Health healthy/unhealthy across the TTL boundary. `go vet` + `gofmt` clean.

## Docs

README "Container / Runtime Mode" section with a Go snippet + API table, linking the shared `docs/Container-Runtime-Mode.md` (not duplicated); fixed the Go row in that doc's per-language table. Changeset added (`@smooai/config` minor — drives the Go `version.go` bump via release automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)