### PR TITLE
SMOODEV-1491: .NET container/runtime mode (parity with TS reference)

### DIFF
--- a/.changeset/container-runtime-mode-dotnet.md
+++ b/.changeset/container-runtime-mode-dotnet.md
@@ -1,0 +1,14 @@
+---
+'@smooai/config': minor
+---
+
+SMOODEV-1491: Add container/runtime mode to the **.NET** SDK (`SmooAI.Config.Container`) — brings the C# client to parity with the TypeScript reference (SMOODEV-1490) of the five-language contract (SMOODEV-1489).
+
+Container mode makes the HTTP config API the first-class, fail-loud path for long-lived containers (EKS/ECS) instead of the Lambda-oriented baked blob:
+
+- `ContainerConfig.InitContainerConfigAsync(options)` — validates the container env contract, mints an M2M OAuth token, and does an initial fetch-all-values so auth/network failures surface at startup (not first read). Missing/blank required env throws a typed `ConfigBootstrapException` carrying `Missing` (the exact env var names).
+- Fail-loud reads — `SecretConfig.GetAsync`/`GetSync` (and the public/flag analogs) throw `ConfigKeyUnresolvedException { Key, Env, TriedTiers }` for a required key that resolves absent, instead of silently returning `null` (the SMOODEV-1478 CrashLoop class). `OptionalKeys` opts specific keys out. Per the TS design fork, all schema keys are required by default.
+- `ContainerConfig.Health(handle)` / `handle.Health()` — non-throwing `ConfigHealth { Status, Reason }` for Kubernetes readiness/liveness probes; serves last-good within the 30s cache TTL, reports `unhealthy` past hard-expiry.
+- `ContainerConfig.SelectMode(inputs)` — mode selection (explicit `SMOOAI_CONFIG_MODE=container`, blob/file present → default, or auto-select on M2M creds).
+- Same exact `SMOOAI_CONFIG_*` env contract, env-over-http tier precedence, `UPPER_SNAKE_CASE(key)` env overrides, 30s cache TTL, 60s token refresh buffer, and 401 → refresh → retry as the TypeScript reference.
+- README "Container / Runtime Mode" section linking the shared `docs/Container-Runtime-Mode.md`.

--- a/dotnet/src/SmooAI.Config/Container/ConfigTier.cs
+++ b/dotnet/src/SmooAI.Config/Container/ConfigTier.cs
@@ -1,0 +1,36 @@
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// One of the resolution tiers consulted during a container-mode value read.
+/// Mirrors the TS <c>ConfigTier</c> union (<c>blob | env | http | file</c>).
+/// In container mode only <see cref="Env"/> and <see cref="Http"/> are active;
+/// the blob/file tiers are disabled (see the spec §2).
+/// </summary>
+public enum ResolutionTier
+{
+    /// <summary>The baked, AES-GCM-encrypted blob tier (disabled in container mode).</summary>
+    Blob,
+
+    /// <summary>An explicit process environment variable override (<c>UPPER_SNAKE_CASE(key)</c>).</summary>
+    Env,
+
+    /// <summary>The HTTP config API — the blessed container path.</summary>
+    Http,
+
+    /// <summary>The local <c>.smooai-config/&lt;env&gt;.json</c> file tier (disabled in container mode).</summary>
+    File,
+}
+
+/// <summary>String-rendering for <see cref="ResolutionTier"/> matching the TS wire names.</summary>
+public static class ResolutionTierExtensions
+{
+    /// <summary>Render a tier as the lowercase string used in error messages and parity tests.</summary>
+    public static string ToWireString(this ResolutionTier tier) => tier switch
+    {
+        ResolutionTier.Blob => "blob",
+        ResolutionTier.Env => "env",
+        ResolutionTier.Http => "http",
+        ResolutionTier.File => "file",
+        _ => throw new System.ArgumentOutOfRangeException(nameof(tier), tier, null),
+    };
+}

--- a/dotnet/src/SmooAI.Config/Container/ContainerConfig.cs
+++ b/dotnet/src/SmooAI.Config/Container/ContainerConfig.cs
@@ -1,0 +1,265 @@
+using System.Text;
+using System.Text.Json;
+using SmooAI.Config.OAuth;
+
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// <c>SmooAI.Config</c> container / runtime mode (SMOODEV-1489 / SMOODEV-1491).
+/// The .NET implementation of the five-language parity contract; mirrors the
+/// TypeScript reference (SMOODEV-1490) exactly — identical env contract and
+/// error semantics. Idioms differ (async <see cref="Task"/>, exceptions,
+/// PascalCase); behavior does not.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SmooAI.Config</c> resolves values through four tiers: blob → env → http →
+/// file. The blob tier (an encrypted bundle baked into a Lambda layer / image
+/// at deploy time, decrypted with a separately-delivered key) is the blessed
+/// path for <b>Lambda</b>. It is the <i>wrong</i> default for long-lived
+/// <b>containers</b> (EKS/ECS): when the per-build blob key isn't delivered to
+/// the pod, resolution silently falls through to the (absent) file tier and
+/// returns <c>null</c> for a required secret (the SMOODEV-1478 CrashLoop).
+/// </para>
+/// <para>
+/// Container mode makes the <b>HTTP tier the blessed, first-class path</b> for
+/// containers, authenticated with an OAuth2 <c>client_credentials</c> (M2M)
+/// token, and <b>fail-loud</b>: a missing required value is an immediate, typed
+/// <see cref="ConfigKeyUnresolvedException"/>, never a silent <c>null</c>.
+/// </para>
+/// <para>
+/// See <c>docs/Container-Runtime-Mode.md</c> for the env contract and the
+/// Kubernetes / ExternalSecret recipe.
+/// </para>
+/// </remarks>
+public static class ContainerConfig
+{
+    /// <summary>Default config-value cache TTL in ms (spec §5). Same 30s default in every SDK.</summary>
+    public const int DefaultCacheTtlMs = 30_000;
+
+    /// <summary>Default token proactive-refresh window in seconds (spec §5). Matches <see cref="TokenProvider"/>.</summary>
+    public const int DefaultTokenRefreshBufferSeconds = 60;
+
+    private const string DefaultAuthUrl = "https://auth.smoo.ai";
+
+    /// <summary>
+    /// Explicit container-mode bootstrap (spec §4). Validates the §1 env,
+    /// constructs the M2M token provider + HTTP config client, and performs an
+    /// <b>initial token mint + fetch-all-values</b> so auth/network failures
+    /// surface at startup (not on first read). Returns a
+    /// <see cref="ContainerConfigHandle"/> whose accessors are fail-loud (spec §3).
+    /// </summary>
+    /// <param name="options">Init options; every field mirrors a §1 env var.</param>
+    /// <param name="cancellationToken">Cancellation token for the initial fetch.</param>
+    /// <exception cref="ConfigBootstrapException">When container-required env is missing/blank.</exception>
+    /// <exception cref="Exception">On auth/network failure during the initial token mint or fetch.</exception>
+    public static async Task<ContainerConfigHandle> InitContainerConfigAsync(
+        InitContainerConfigOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Schema is null)
+        {
+            throw new ConfigBootstrapException(new[] { "Schema" });
+        }
+
+        var getEnv = options.GetEnv ?? Environment.GetEnvironmentVariable;
+        var env = ResolveAndValidateEnv(options, getEnv);
+
+        var cacheTtl = TimeSpan.FromMilliseconds(options.CacheTtlMs <= 0 ? DefaultCacheTtlMs : options.CacheTtlMs);
+        var refreshBuffer = TimeSpan.FromSeconds(
+            options.TokenRefreshBufferSeconds <= 0 ? DefaultTokenRefreshBufferSeconds : options.TokenRefreshBufferSeconds);
+
+        // Build the ConfigClient. When the caller injects one (test/embedding
+        // seam) it already carries its own TokenProvider, so we don't build a
+        // second one (env creds may be empty in that path).
+        SmooConfigClient client;
+        if (options.ConfigClient is not null)
+        {
+            client = options.ConfigClient;
+        }
+        else
+        {
+            var clientOptions = new SmooConfigClientOptions
+            {
+                BaseUrl = env.ApiUrl,
+                AuthUrl = env.AuthUrl,
+                ClientId = env.ClientId,
+                ClientSecret = env.ClientSecret,
+                OrgId = env.OrgId,
+                DefaultEnvironment = env.Environment,
+                TokenRefreshWindow = refreshBuffer,
+            };
+            client = options.TokenProvider is not null
+                ? SmooConfigClient.CreateWithTokenProvider(clientOptions, options.TokenProvider)
+                : new SmooConfigClient(clientOptions);
+        }
+
+        var handle = new ContainerConfigHandle(client, options.Schema, env.Environment, cacheTtl, options.OptionalKeys, getEnv);
+
+        // Initial fetch — fail loud at startup, not first read. The OAuth token
+        // mint happens inside GetAllValuesAsync (the client's TokenProvider
+        // exchanges on the first authed request), so an auth failure surfaces
+        // here too. A pod that can't reach the config server should CrashLoop
+        // visibly, not start degraded.
+        await handle.PrimeAsync(cancellationToken).ConfigureAwait(false);
+
+        return handle;
+    }
+
+    /// <summary>
+    /// Standalone health check (spec §4) for a handle. Exposed both as
+    /// <see cref="ContainerConfigHandle.Health"/> and as this static form for
+    /// call sites that prefer the functional shape. Never throws.
+    /// </summary>
+    public static ConfigHealth Health(ContainerConfigHandle handle)
+    {
+        if (handle is null) return ConfigHealth.Unhealthy("handle is null");
+        try
+        {
+            return handle.Health();
+        }
+        catch (Exception ex)
+        {
+            return ConfigHealth.Unhealthy(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Mode the SDK should run in, per spec §2. <c>"container"</c> means
+    /// HTTP-primary fail-loud; <c>"default"</c> means the existing
+    /// blob → env → http → file chain.
+    /// </summary>
+    /// <remarks>
+    /// Resolution order:
+    /// <list type="number">
+    ///   <item><c>SMOOAI_CONFIG_MODE=container</c> → container mode (explicit).</item>
+    ///   <item>else if a blob/file source is present → default (Lambda/local), unchanged.</item>
+    ///   <item>else if CLIENT_ID + CLIENT_SECRET + API_URL all set → container (auto).</item>
+    ///   <item>else → default.</item>
+    /// </list>
+    /// </remarks>
+    public static string SelectMode(SelectModeInputs? inputs = null)
+    {
+        inputs ??= new SelectModeInputs();
+        var getEnv = inputs.GetEnv ?? Environment.GetEnvironmentVariable;
+
+        var mode = NonBlank(inputs.Mode) ?? NonBlank(getEnv("SMOOAI_CONFIG_MODE"));
+        if (string.Equals(mode, "container", StringComparison.OrdinalIgnoreCase)) return "container";
+
+        var blobPresent = inputs.BlobPresent
+            ?? (!string.IsNullOrEmpty(getEnv("SMOO_CONFIG_KEY")) && !string.IsNullOrEmpty(getEnv("SMOO_CONFIG_KEY_FILE")));
+        var filePresent = inputs.FilePresent ?? false;
+        if (blobPresent || filePresent) return "default";
+
+        var clientId = NonBlank(inputs.ClientId) ?? NonBlank(getEnv("SMOOAI_CONFIG_CLIENT_ID"));
+        var clientSecret = NonBlank(inputs.ClientSecret)
+            ?? NonBlank(getEnv("SMOOAI_CONFIG_CLIENT_SECRET"))
+            ?? NonBlank(getEnv("SMOOAI_CONFIG_API_KEY"));
+        var apiUrl = NonBlank(inputs.ApiUrl) ?? NonBlank(getEnv("SMOOAI_CONFIG_API_URL"));
+
+        if (clientId is not null && clientSecret is not null && apiUrl is not null)
+        {
+            return "container";
+        }
+        return "default";
+    }
+
+    /// <summary>camelCase → UPPER_SNAKE_CASE for env-var reads (matches the server tier).</summary>
+    internal static string EnvVarNameFor(string key)
+    {
+        var sb = new StringBuilder(key.Length + 8);
+        foreach (var ch in key)
+        {
+            if (char.IsUpper(ch))
+            {
+                sb.Append('_');
+                sb.Append(ch);
+            }
+            else
+            {
+                sb.Append(char.ToUpperInvariant(ch));
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Blank-aware presence check (a set-but-whitespace value counts as missing).</summary>
+    internal static string? NonBlank(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static ResolvedContainerEnv ResolveAndValidateEnv(InitContainerConfigOptions options, Func<string, string?> getEnv)
+    {
+        var apiUrl = NonBlank(options.ApiUrl) ?? NonBlank(getEnv("SMOOAI_CONFIG_API_URL"));
+        var authUrl = NonBlank(options.AuthUrl)
+            ?? NonBlank(getEnv("SMOOAI_CONFIG_AUTH_URL"))
+            ?? NonBlank(getEnv("SMOOAI_AUTH_URL"))
+            ?? DefaultAuthUrl;
+        var clientId = NonBlank(options.ClientId) ?? NonBlank(getEnv("SMOOAI_CONFIG_CLIENT_ID"));
+        var clientSecret = NonBlank(options.ClientSecret)
+            ?? NonBlank(getEnv("SMOOAI_CONFIG_CLIENT_SECRET"))
+            ?? NonBlank(getEnv("SMOOAI_CONFIG_API_KEY"));
+        var orgId = NonBlank(options.OrgId) ?? NonBlank(getEnv("SMOOAI_CONFIG_ORG_ID"));
+        var environment = NonBlank(options.Environment) ?? NonBlank(getEnv("SMOOAI_CONFIG_ENV"));
+
+        // When a ConfigClient is injected it already carries apiUrl/auth/
+        // clientId/secret/orgId — only the environment is still container-required.
+        var clientInjected = options.ConfigClient is not null;
+
+        var missing = new List<string>();
+        if (!clientInjected)
+        {
+            if (apiUrl is null) missing.Add("SMOOAI_CONFIG_API_URL");
+            if (clientId is null) missing.Add("SMOOAI_CONFIG_CLIENT_ID");
+            if (clientSecret is null) missing.Add("SMOOAI_CONFIG_CLIENT_SECRET");
+            if (orgId is null) missing.Add("SMOOAI_CONFIG_ORG_ID");
+        }
+        if (environment is null) missing.Add("SMOOAI_CONFIG_ENV");
+
+        if (missing.Count > 0)
+        {
+            throw new ConfigBootstrapException(missing);
+        }
+
+        return new ResolvedContainerEnv(
+            apiUrl ?? string.Empty,
+            authUrl,
+            clientId ?? string.Empty,
+            clientSecret ?? string.Empty,
+            orgId ?? string.Empty,
+            environment!);
+    }
+
+    private sealed record ResolvedContainerEnv(
+        string ApiUrl,
+        string AuthUrl,
+        string ClientId,
+        string ClientSecret,
+        string OrgId,
+        string Environment);
+}
+
+/// <summary>Inputs for <see cref="ContainerConfig.SelectMode"/>. Defaults read from the process env.</summary>
+public sealed class SelectModeInputs
+{
+    /// <summary><c>SMOOAI_CONFIG_MODE</c>.</summary>
+    public string? Mode { get; init; }
+
+    /// <summary><c>SMOOAI_CONFIG_CLIENT_ID</c>.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary><c>SMOOAI_CONFIG_CLIENT_SECRET</c> (or legacy <c>SMOOAI_CONFIG_API_KEY</c>).</summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary><c>SMOOAI_CONFIG_API_URL</c>.</summary>
+    public string? ApiUrl { get; init; }
+
+    /// <summary>Whether a baked blob source is present (<c>SMOO_CONFIG_KEY</c> + <c>SMOO_CONFIG_KEY_FILE</c>).</summary>
+    public bool? BlobPresent { get; init; }
+
+    /// <summary>Whether a local <c>.smooai-config/</c> file source is present.</summary>
+    public bool? FilePresent { get; init; }
+
+    /// <summary>Test-only seam — override env-var lookup.</summary>
+    internal Func<string, string?>? GetEnv { get; init; }
+}

--- a/dotnet/src/SmooAI.Config/Container/ContainerConfigHandle.cs
+++ b/dotnet/src/SmooAI.Config/Container/ContainerConfigHandle.cs
@@ -1,0 +1,345 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// The handle returned by <see cref="ContainerConfig.InitContainerConfigAsync"/>.
+/// Exposes the same tier accessors as the default chain (async
+/// <c>GetAsync</c> + sync <c>GetSync</c>) but with spec §3 fail-loud behavior,
+/// plus a non-throwing <see cref="Health"/> for Kubernetes readiness/liveness
+/// probes.
+/// </summary>
+public sealed class ContainerConfigHandle
+{
+    private readonly SmooConfigClient _client;
+    private readonly ContainerConfigSchema _schema;
+    private readonly string _environment;
+    private readonly TimeSpan _cacheTtl;
+    private readonly HashSet<string> _optionalKeys;
+    private readonly Func<string, string?> _getEnv;
+
+    // Per-key value cache (the dotnet SmooConfigClient has no value cache of its
+    // own; we mirror the TS ConfigClient's seedCache/getCachedValue/TTL here).
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
+
+    // Health state (spec §5): once an initial fetch succeeds we serve last-good
+    // on a later background refresh failure until the cache TTL hard-expires.
+    private readonly object _healthLock = new();
+    private bool _lastFetchOk;
+    private DateTimeOffset _lastFetchAt;
+    private string? _lastError;
+
+    /// <summary>Clock seam for TTL/expiry checks. Swap in tests.</summary>
+    internal Func<DateTimeOffset> UtcNow { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>Public (client + server) config tier accessor.</summary>
+    public ConfigTierAccessor PublicConfig { get; }
+
+    /// <summary>Secret (server-only) config tier accessor.</summary>
+    public ConfigTierAccessor SecretConfig { get; }
+
+    /// <summary>Feature-flag tier accessor.</summary>
+    public ConfigTierAccessor FeatureFlag { get; }
+
+    /// <summary>
+    /// The underlying <see cref="SmooConfigClient"/> (escape hatch for advanced
+    /// callers; e.g. segment-aware feature-flag evaluation).
+    /// </summary>
+    public SmooConfigClient Client => _client;
+
+    internal ContainerConfigHandle(
+        SmooConfigClient client,
+        ContainerConfigSchema schema,
+        string environment,
+        TimeSpan cacheTtl,
+        IReadOnlyList<string>? optionalKeys,
+        Func<string, string?> getEnv)
+    {
+        _client = client;
+        _schema = schema;
+        _environment = environment;
+        _cacheTtl = cacheTtl;
+        _optionalKeys = new HashSet<string>(optionalKeys ?? Array.Empty<string>(), StringComparer.Ordinal);
+        _getEnv = getEnv;
+
+        PublicConfig = new ConfigTierAccessor(this, ConfigKeyTier.Public);
+        SecretConfig = new ConfigTierAccessor(this, ConfigKeyTier.Secret);
+        FeatureFlag = new ConfigTierAccessor(this, ConfigKeyTier.FeatureFlag);
+    }
+
+    /// <summary>
+    /// Initial fetch-all-values — primes the cache and the health state at
+    /// startup. Throws on auth/network failure so bootstrap fails loud (spec §4).
+    /// </summary>
+    internal async Task PrimeAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var all = await _client.GetAllValuesAsync(_environment, cancellationToken).ConfigureAwait(false);
+            var now = UtcNow();
+            foreach (var (key, value) in all)
+            {
+                _cache[key] = new CacheEntry(value, now);
+            }
+            MarkFetchOk(now);
+        }
+        catch (Exception ex)
+        {
+            lock (_healthLock) { _lastError = ex.Message; }
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Cheap, non-throwing status for readiness/liveness probes (spec §4).
+    /// Serves <c>healthy</c> while within the cache TTL of the last good fetch
+    /// even if a background refresh just failed; past the hard TTL, a failed
+    /// refresh flips to <c>unhealthy</c> (spec §5).
+    /// </summary>
+    public ConfigHealth Health()
+    {
+        lock (_healthLock)
+        {
+            if (!_lastFetchOk)
+            {
+                return ConfigHealth.Unhealthy(_lastError ?? "initial config fetch has not succeeded");
+            }
+            var age = UtcNow() - _lastFetchAt;
+            if (_lastError is not null && age > _cacheTtl)
+            {
+                return ConfigHealth.Unhealthy(
+                    $"last config refresh failed and cache TTL ({_cacheTtl.TotalMilliseconds}ms) expired: {_lastError}");
+            }
+            return ConfigHealth.Healthy();
+        }
+    }
+
+    private void MarkFetchOk(DateTimeOffset at)
+    {
+        lock (_healthLock)
+        {
+            _lastFetchOk = true;
+            _lastFetchAt = at;
+            _lastError = null;
+        }
+    }
+
+    private bool IsOptional(string key) => _optionalKeys.Contains(key);
+
+    /// <summary>
+    /// Async tier read for a single key. Order matches the existing chain's
+    /// env-over-http precedence: an explicitly-set process env var wins, else
+    /// the HTTP (config server) value. Blob/file tiers are disabled (spec §2).
+    /// </summary>
+    private async Task<ResolveResult> ResolveAsync(string key, CancellationToken cancellationToken)
+    {
+        var tried = new List<string> { ResolutionTier.Env.ToWireString() };
+
+        var fromEnv = ContainerConfig.NonBlank(_getEnv(ContainerConfig.EnvVarNameFor(key)));
+        if (fromEnv is not null)
+        {
+            // Seed the cache so a later GetSync sees the env override too.
+            _cache[key] = new CacheEntry(JsonValueFromString(fromEnv), UtcNow());
+            return new ResolveResult(fromEnv, tried);
+        }
+
+        tried.Add(ResolutionTier.Http.ToWireString());
+        var entry = GetFreshCacheEntry(key);
+        if (entry is not null)
+        {
+            // Cache hit within TTL — no HTTP round-trip (matches TS, where the
+            // initial getAllValues seeds the cache so subsequent reads are free).
+            var cachedValue = ElementToValue(entry.Value);
+            if (cachedValue is not null) return new ResolveResult(cachedValue, tried);
+            return new ResolveResult(null, tried);
+        }
+
+        try
+        {
+            var element = await _client.GetValueAsync(key, _environment, cancellationToken).ConfigureAwait(false);
+            var now = UtcNow();
+            _cache[key] = new CacheEntry(element, now);
+            MarkFetchOk(now);
+            var value = ElementToValue(element);
+            return new ResolveResult(value, tried);
+        }
+        catch (Exception ex)
+        {
+            lock (_healthLock) { _lastError = ex.Message; }
+            // §5: serve last-good from cache until the TTL hard-expires. Past
+            // hard-expiry GetFreshCacheEntry returns null, so the read resolves
+            // absent and a required key fails loud (matches the TS contract).
+            var staleEntry = GetFreshCacheEntry(key);
+            var stale = staleEntry is not null ? ElementToValue(staleEntry.Value) : null;
+            if (stale is not null) return new ResolveResult(stale, tried);
+            return new ResolveResult(null, tried);
+        }
+    }
+
+    /// <summary>Sync tier read — env override, else last cached HTTP value.</summary>
+    private ResolveResult SyncResolve(string key)
+    {
+        var tried = new List<string> { ResolutionTier.Env.ToWireString() };
+
+        var fromEnv = ContainerConfig.NonBlank(_getEnv(ContainerConfig.EnvVarNameFor(key)));
+        if (fromEnv is not null) return new ResolveResult(fromEnv, tried);
+
+        tried.Add(ResolutionTier.Http.ToWireString());
+        var entry = GetFreshCacheEntry(key);
+        var value = entry is not null ? ElementToValue(entry.Value) : null;
+        return new ResolveResult(value, tried);
+    }
+
+    private CacheEntry? GetFreshCacheEntry(string key)
+    {
+        if (!_cache.TryGetValue(key, out var entry)) return null;
+        if (UtcNow() - entry.FetchedAt > _cacheTtl) return null; // TTL hard-expired.
+        return entry;
+    }
+
+    private void AssertKey(string? key, ConfigKeyTier tier)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException(
+                $"SmooAI.Config (container): {tier}Config called with a null/empty key.",
+                nameof(key));
+        }
+        if (!_schema.ContainsInTier(key!, tier))
+        {
+            throw new ArgumentException(
+                $"SmooAI.Config (container): key \"{key}\" is not declared as a {tier} key in the schema. " +
+                $"Add it to your schema (or read it via the correct tier accessor).",
+                nameof(key));
+        }
+    }
+
+    private async Task<object?> GetAsyncCore(string key, ConfigKeyTier tier, CancellationToken cancellationToken)
+    {
+        AssertKey(key, tier);
+        var result = await ResolveAsync(key, cancellationToken).ConfigureAwait(false);
+        if (result.Value is not null) return result.Value;
+        if (IsOptional(key)) return null;
+        throw new ConfigKeyUnresolvedException(key, _environment, result.TriedTiers);
+    }
+
+    private object? GetSyncCore(string key, ConfigKeyTier tier)
+    {
+        AssertKey(key, tier);
+        var result = SyncResolve(key);
+        if (result.Value is not null) return result.Value;
+        if (IsOptional(key)) return null;
+        throw new ConfigKeyUnresolvedException(key, _environment, result.TriedTiers);
+    }
+
+    private async Task<T?> GetTypedAsync<T>(string key, ConfigKeyTier tier, CancellationToken cancellationToken)
+    {
+        var value = await GetAsyncCore(key, tier, cancellationToken).ConfigureAwait(false);
+        return Coerce<T>(value);
+    }
+
+    private T? GetTypedSync<T>(string key, ConfigKeyTier tier)
+    {
+        var value = GetSyncCore(key, tier);
+        return Coerce<T>(value);
+    }
+
+    private static T? Coerce<T>(object? value)
+    {
+        if (value is null) return default;
+        if (value is T typed) return typed;
+        if (value is JsonElement el) return el.Deserialize<T>(SmooConfigClient.JsonOptions);
+        if (value is string s)
+        {
+            if (typeof(T) == typeof(string)) return (T)(object)s;
+            // Try JSON-deserialize the raw string (e.g. a number or bool came
+            // from an env override). Fall back to ChangeType for primitives.
+            try { return JsonSerializer.Deserialize<T>(s, SmooConfigClient.JsonOptions); }
+            catch (JsonException) { return (T)Convert.ChangeType(s, typeof(T)); }
+        }
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    /// <summary>
+    /// Convert a server <see cref="JsonElement"/> to a CLR value, returning
+    /// <c>null</c> for absent (Null/Undefined). Strings unwrap to
+    /// <see cref="string"/>; everything else stays a <see cref="JsonElement"/>.
+    /// </summary>
+    private static object? ElementToValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            JsonValueKind.String => element.GetString(),
+            _ => element,
+        };
+    }
+
+    private static JsonElement JsonValueFromString(string value)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return doc.RootElement.Clone();
+    }
+
+    private sealed record CacheEntry(JsonElement Value, DateTimeOffset FetchedAt);
+
+    private sealed record ResolveResult(object? Value, IReadOnlyList<string> TriedTiers);
+
+    /// <summary>
+    /// Tier-scoped accessor exposing fail-loud <c>GetAsync</c>/<c>GetSync</c>
+    /// reads. Both the typed and untyped overloads throw
+    /// <see cref="ConfigKeyUnresolvedException"/> for a required key that
+    /// resolves absent (spec §3); optional keys return <c>null</c>/<c>default</c>.
+    /// </summary>
+    public sealed class ConfigTierAccessor
+    {
+        private readonly ContainerConfigHandle _handle;
+        private readonly ConfigKeyTier _tier;
+
+        internal ConfigTierAccessor(ContainerConfigHandle handle, ConfigKeyTier tier)
+        {
+            _handle = handle;
+            _tier = tier;
+        }
+
+        /// <summary>
+        /// Resolve <paramref name="key"/> as a string (the common case for
+        /// secrets and URLs). Fail-loud (spec §3).
+        /// </summary>
+        public async Task<string?> GetAsync(string key, CancellationToken cancellationToken = default)
+        {
+            var value = await _handle.GetAsyncCore(key, _tier, cancellationToken).ConfigureAwait(false);
+            return value switch
+            {
+                null => null,
+                string s => s,
+                JsonElement el => ElementToValue(el) as string ?? el.GetRawText(),
+                _ => value.ToString(),
+            };
+        }
+
+        /// <summary>Synchronous string read (spec §3 fail-loud).</summary>
+        public string? GetSync(string key)
+        {
+            var value = _handle.GetSyncCore(key, _tier);
+            return value switch
+            {
+                null => null,
+                string s => s,
+                JsonElement el => ElementToValue(el) as string ?? el.GetRawText(),
+                _ => value.ToString(),
+            };
+        }
+
+        /// <summary>
+        /// Resolve <paramref name="key"/> deserialized into
+        /// <typeparamref name="T"/>. Fail-loud (spec §3).
+        /// </summary>
+        public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+            => _handle.GetTypedAsync<T>(key, _tier, cancellationToken);
+
+        /// <summary>Synchronous typed read (spec §3 fail-loud).</summary>
+        public T? GetSync<T>(string key) => _handle.GetTypedSync<T>(key, _tier);
+    }
+}

--- a/dotnet/src/SmooAI.Config/Container/ContainerConfigSchema.cs
+++ b/dotnet/src/SmooAI.Config/Container/ContainerConfigSchema.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// The set of config keys a service declares, partitioned into public, secret,
+/// and feature-flag tiers. This is the .NET analog of the TS <c>defineConfig</c>
+/// schema that <see cref="ContainerConfig.InitContainerConfigAsync"/> takes:
+/// it tells the container handle which keys exist (so reads can be validated)
+/// and which tier each belongs to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Design fork (matches TS):</b> the schema carries no required/optional
+/// metadata, so container mode treats <b>every</b> declared key as
+/// <b>required</b> by default. Use
+/// <see cref="InitContainerConfigOptions.OptionalKeys"/> to opt specific keys
+/// out of fail-loud resolution.
+/// </para>
+/// <para>
+/// Build one from explicit key sets, or parse a <c>schema.json</c> /
+/// serialized <c>defineConfig</c> object via <see cref="FromSchemaElement"/> /
+/// <see cref="FromSchemaJson"/> (same shapes the
+/// <see cref="Build.SchemaClassifier"/> recognizes).
+/// </para>
+/// </remarks>
+public sealed class ContainerConfigSchema
+{
+    private readonly IReadOnlyDictionary<string, ConfigKeyTier> _tierByKey;
+
+    /// <summary>Public (client + server) config keys.</summary>
+    public IReadOnlyCollection<string> PublicKeys { get; }
+
+    /// <summary>Secret (server-only) config keys.</summary>
+    public IReadOnlyCollection<string> SecretKeys { get; }
+
+    /// <summary>Feature-flag keys.</summary>
+    public IReadOnlyCollection<string> FeatureFlagKeys { get; }
+
+    /// <summary>All declared keys across every tier.</summary>
+    public IReadOnlyCollection<string> AllKeys => _tierByKey.Keys.ToArray();
+
+    /// <summary>Build a schema from explicit, tier-partitioned key sets.</summary>
+    /// <param name="publicKeys">Public-tier keys (may be null/empty).</param>
+    /// <param name="secretKeys">Secret-tier keys (may be null/empty).</param>
+    /// <param name="featureFlagKeys">Feature-flag keys (may be null/empty).</param>
+    /// <exception cref="ArgumentException">When the same key appears in more than one tier.</exception>
+    public ContainerConfigSchema(
+        IEnumerable<string>? publicKeys = null,
+        IEnumerable<string>? secretKeys = null,
+        IEnumerable<string>? featureFlagKeys = null)
+    {
+        var pub = Dedup(publicKeys);
+        var sec = Dedup(secretKeys);
+        var flags = Dedup(featureFlagKeys);
+
+        var tierByKey = new Dictionary<string, ConfigKeyTier>(StringComparer.Ordinal);
+        AssignTier(tierByKey, pub, ConfigKeyTier.Public);
+        AssignTier(tierByKey, sec, ConfigKeyTier.Secret);
+        AssignTier(tierByKey, flags, ConfigKeyTier.FeatureFlag);
+
+        PublicKeys = pub;
+        SecretKeys = sec;
+        FeatureFlagKeys = flags;
+        _tierByKey = tierByKey;
+    }
+
+    /// <summary>Whether the given key is declared in any tier.</summary>
+    public bool Contains(string key) => _tierByKey.ContainsKey(key);
+
+    /// <summary>
+    /// Whether <paramref name="key"/> is declared in the given <paramref name="tier"/>.
+    /// </summary>
+    public bool ContainsInTier(string key, ConfigKeyTier tier)
+        => _tierByKey.TryGetValue(key, out var t) && t == tier;
+
+    /// <summary>
+    /// Parse a schema JSON string (JSON-Schema shape or serialized
+    /// <c>defineConfig</c> shape) into a <see cref="ContainerConfigSchema"/>.
+    /// </summary>
+    public static ContainerConfigSchema FromSchemaJson(string schemaJson)
+    {
+        if (string.IsNullOrWhiteSpace(schemaJson)) throw new ArgumentException("Schema JSON is required.", nameof(schemaJson));
+        using var doc = JsonDocument.Parse(schemaJson);
+        return FromSchemaElement(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Parse a schema file on disk into a <see cref="ContainerConfigSchema"/>.
+    /// </summary>
+    public static ContainerConfigSchema FromSchemaFile(string schemaPath)
+    {
+        if (string.IsNullOrWhiteSpace(schemaPath)) throw new ArgumentException("Schema path is required.", nameof(schemaPath));
+        return FromSchemaJson(File.ReadAllText(schemaPath));
+    }
+
+    /// <summary>
+    /// Build a schema from a parsed <see cref="JsonElement"/>. Recognizes both
+    /// the JSON-Schema shape (<c>{ properties: { public, secret, featureFlags } }</c>)
+    /// and the serialized <c>defineConfig</c> shape
+    /// (<c>{ publicConfigSchema, secretConfigSchema, featureFlagSchema }</c>).
+    /// </summary>
+    public static ContainerConfigSchema FromSchemaElement(JsonElement root)
+    {
+        var publicKeys = new HashSet<string>(StringComparer.Ordinal);
+        var secretKeys = new HashSet<string>(StringComparer.Ordinal);
+        var flagKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        if (root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("properties", out var properties)
+            && properties.ValueKind == JsonValueKind.Object)
+        {
+            AddKeysFromSection(properties, "public", publicKeys);
+            AddKeysFromSection(properties, "secret", secretKeys);
+            AddKeysFromSection(properties, "featureFlags", flagKeys);
+        }
+
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            AddKeysFromObject(root, "publicConfigSchema", publicKeys);
+            AddKeysFromObject(root, "secretConfigSchema", secretKeys);
+            AddKeysFromObject(root, "featureFlagSchema", flagKeys);
+        }
+
+        return new ContainerConfigSchema(publicKeys, secretKeys, flagKeys);
+    }
+
+    private static List<string> Dedup(IEnumerable<string>? keys)
+    {
+        if (keys is null) return new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ordered = new List<string>();
+        foreach (var k in keys)
+        {
+            if (string.IsNullOrWhiteSpace(k)) continue;
+            if (seen.Add(k)) ordered.Add(k);
+        }
+        return ordered;
+    }
+
+    private static void AssignTier(Dictionary<string, ConfigKeyTier> target, IEnumerable<string> keys, ConfigKeyTier tier)
+    {
+        foreach (var key in keys)
+        {
+            if (target.TryGetValue(key, out var existing) && existing != tier)
+            {
+                throw new ArgumentException(
+                    $"Config key \"{key}\" is declared in more than one tier ({existing} and {tier}). Each key must belong to exactly one tier.",
+                    nameof(keys));
+            }
+            target[key] = tier;
+        }
+    }
+
+    private static void AddKeysFromSection(JsonElement properties, string sectionName, HashSet<string> target)
+    {
+        if (!properties.TryGetProperty(sectionName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        if (!section.TryGetProperty("properties", out var keys) || keys.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in keys.EnumerateObject()) target.Add(prop.Name);
+    }
+
+    private static void AddKeysFromObject(JsonElement root, string objectName, HashSet<string> target)
+    {
+        if (!root.TryGetProperty(objectName, out var section) || section.ValueKind != JsonValueKind.Object) return;
+        foreach (var prop in section.EnumerateObject()) target.Add(prop.Name);
+    }
+}
+
+/// <summary>Which tier a container-schema key belongs to.</summary>
+public enum ConfigKeyTier
+{
+    /// <summary>Public (client + server) value.</summary>
+    Public,
+
+    /// <summary>Secret (server-only) value.</summary>
+    Secret,
+
+    /// <summary>Feature-flag value.</summary>
+    FeatureFlag,
+}

--- a/dotnet/src/SmooAI.Config/Container/Errors.cs
+++ b/dotnet/src/SmooAI.Config/Container/Errors.cs
@@ -1,0 +1,83 @@
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// Thrown by <see cref="ContainerConfig.InitContainerConfigAsync"/> when the
+/// container-required environment (spec §1) is missing or blank. Carries the
+/// exact list of offending env var names so the operator can fix the
+/// deployment without guessing. No partial init: if any required var is
+/// absent, bootstrap fails whole.
+/// </summary>
+/// <remarks>
+/// Parity note: the TS/go/python/rust SDKs expose this with the same name and
+/// the same carried field (<c>missing: string[]</c> ↔ <see cref="Missing"/>).
+/// </remarks>
+public sealed class ConfigBootstrapException : Exception
+{
+    /// <summary>
+    /// Env var names (e.g. <c>SMOOAI_CONFIG_CLIENT_ID</c>) that are missing or
+    /// blank. Never empty when this exception is thrown.
+    /// </summary>
+    public IReadOnlyList<string> Missing { get; }
+
+    /// <summary>Create the exception from the list of missing env var names.</summary>
+    public ConfigBootstrapException(IReadOnlyList<string> missing)
+        : base(BuildMessage(missing))
+    {
+        Missing = missing ?? Array.Empty<string>();
+    }
+
+    private static string BuildMessage(IReadOnlyList<string>? missing)
+    {
+        var names = missing is null || missing.Count == 0 ? "(none)" : string.Join(", ", missing);
+        var which = missing is { Count: 1 } ? "this variable" : "these variables";
+        return $"[SmooAI.Config] container-mode bootstrap failed: missing required env {names}. " +
+               $"Set {which} before calling InitContainerConfigAsync() " +
+               "(see docs/Container-Runtime-Mode.md for the Kubernetes/ExternalSecret recipe).";
+    }
+}
+
+/// <summary>
+/// Thrown by a required-key read (<c>SecretConfig.GetAsync</c>/<c>GetSync</c>
+/// and the public/flag analogs) in container mode when the value resolves to
+/// absent across every active tier. This is the exact class that closes the
+/// silent-<c>null</c> hole (SMOODEV-1478 / SMOODEV-1135).
+/// </summary>
+/// <remarks>
+/// Optional keys (declared via <c>InitContainerConfigOptions.OptionalKeys</c>)
+/// do NOT throw this — they return the language's absent value (<c>null</c> /
+/// <c>default</c>).
+/// <para>
+/// Parity note: the TS/go/python/rust SDKs expose this with the same name and
+/// the same carried fields (<c>key</c>, <c>env</c>, <c>triedTiers</c> ↔
+/// <see cref="Key"/>, <see cref="Env"/>, <see cref="TriedTiers"/>).
+/// </para>
+/// </remarks>
+public sealed class ConfigKeyUnresolvedException : Exception
+{
+    /// <summary>The camelCase config key that could not be resolved.</summary>
+    public string Key { get; }
+
+    /// <summary>The environment the read targeted (e.g. <c>production</c>).</summary>
+    public string Env { get; }
+
+    /// <summary>The tiers that were consulted, in order, before giving up (e.g. <c>["env", "http"]</c>).</summary>
+    public IReadOnlyList<string> TriedTiers { get; }
+
+    /// <summary>Create the exception with the key, environment, and tiers tried.</summary>
+    public ConfigKeyUnresolvedException(string key, string env, IReadOnlyList<string> triedTiers)
+        : base(BuildMessage(key, env, triedTiers))
+    {
+        Key = key;
+        Env = env;
+        TriedTiers = triedTiers ?? Array.Empty<string>();
+    }
+
+    private static string BuildMessage(string key, string env, IReadOnlyList<string>? triedTiers)
+    {
+        var tiers = triedTiers is null || triedTiers.Count == 0 ? "none" : string.Join(" → ", triedTiers);
+        return $"[SmooAI.Config] required config key \"{key}\" did not resolve in environment \"{env}\" " +
+               $"(container mode; tiers tried: {tiers}). " +
+               $"Set a value for this key in the config server for \"{env}\", or mark it optional via " +
+               $"InitContainerConfigOptions.OptionalKeys.";
+    }
+}

--- a/dotnet/src/SmooAI.Config/Container/InitContainerConfigOptions.cs
+++ b/dotnet/src/SmooAI.Config/Container/InitContainerConfigOptions.cs
@@ -1,0 +1,120 @@
+using SmooAI.Config.OAuth;
+
+namespace SmooAI.Config.Container;
+
+/// <summary>
+/// Options for <see cref="ContainerConfig.InitContainerConfigAsync"/>. Every
+/// field mirrors an env var in the spec §1 contract so tests and embedders can
+/// construct a config handle without touching the process environment. When a
+/// field is omitted (null), the corresponding env var is read.
+/// </summary>
+public sealed class InitContainerConfigOptions
+{
+    /// <summary>
+    /// The schema for this service. Required so the handle can validate which
+    /// keys exist and which tier each belongs to. Every declared key is treated
+    /// as <b>required</b> in container mode by default — see
+    /// <see cref="OptionalKeys"/>.
+    /// </summary>
+    public required ContainerConfigSchema Schema { get; init; }
+
+    /// <summary>Config API base URL. Falls back to <c>SMOOAI_CONFIG_API_URL</c>.</summary>
+    public string? ApiUrl { get; init; }
+
+    /// <summary>
+    /// OAuth issuer base URL. Falls back to <c>SMOOAI_CONFIG_AUTH_URL</c>, then
+    /// legacy <c>SMOOAI_AUTH_URL</c>, then <c>https://auth.smoo.ai</c>.
+    /// </summary>
+    public string? AuthUrl { get; init; }
+
+    /// <summary>M2M OAuth client id. Falls back to <c>SMOOAI_CONFIG_CLIENT_ID</c>.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// M2M OAuth client secret. Falls back to <c>SMOOAI_CONFIG_CLIENT_SECRET</c>,
+    /// then legacy <c>SMOOAI_CONFIG_API_KEY</c>.
+    /// </summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>Org id whose config to fetch. Falls back to <c>SMOOAI_CONFIG_ORG_ID</c>.</summary>
+    public string? OrgId { get; init; }
+
+    /// <summary>Environment name (e.g. <c>production</c>). Falls back to <c>SMOOAI_CONFIG_ENV</c>.</summary>
+    public string? Environment { get; init; }
+
+    /// <summary>
+    /// Config value cache TTL in milliseconds. Default
+    /// <see cref="ContainerConfig.DefaultCacheTtlMs"/> (30s). A background
+    /// refresh failure serves the last-good value until this TTL hard-expires,
+    /// at which point <see cref="ContainerConfigHandle.Health"/> reports
+    /// <c>unhealthy</c> (spec §5).
+    /// </summary>
+    public int CacheTtlMs { get; init; } = ContainerConfig.DefaultCacheTtlMs;
+
+    /// <summary>
+    /// Seconds before token expiry to proactively refresh. Default
+    /// <see cref="ContainerConfig.DefaultTokenRefreshBufferSeconds"/> (60s).
+    /// Forwarded to the OAuth <see cref="TokenProvider"/>.
+    /// </summary>
+    public int TokenRefreshBufferSeconds { get; init; } = ContainerConfig.DefaultTokenRefreshBufferSeconds;
+
+    /// <summary>
+    /// Keys that are allowed to be absent. A read of any of these returns the
+    /// absent value (<c>null</c> / <c>default</c>) instead of throwing
+    /// <see cref="ConfigKeyUnresolvedException"/>. Everything else declared in
+    /// <see cref="Schema"/> is required (container mode's default-required
+    /// posture).
+    /// </summary>
+    public IReadOnlyList<string>? OptionalKeys { get; init; }
+
+    /// <summary>
+    /// Test / embedding seam — inject a pre-built <see cref="SmooConfigClient"/>.
+    /// When supplied, <c>ApiUrl</c>/<c>AuthUrl</c>/<c>ClientId</c>/
+    /// <c>ClientSecret</c>/<c>OrgId</c> env validation is skipped (the client
+    /// already carries them) but <c>Environment</c> is still required.
+    /// </summary>
+    public SmooConfigClient? ConfigClient { get; init; }
+
+    /// <summary>
+    /// Test / embedding seam — inject a pre-built <see cref="TokenProvider"/>.
+    /// Used only when <see cref="ConfigClient"/> is not supplied.
+    /// </summary>
+    public TokenProvider? TokenProvider { get; init; }
+
+    /// <summary>
+    /// Test-only seam — override the env-var lookup. Defaults to
+    /// <see cref="System.Environment.GetEnvironmentVariable(string)"/>.
+    /// </summary>
+    internal Func<string, string?>? GetEnv { get; init; }
+}
+
+/// <summary>
+/// Status returned by <see cref="ContainerConfigHandle.Health"/> and
+/// <see cref="ContainerConfig.Health"/>. Never thrown — always inspected.
+/// </summary>
+public sealed class ConfigHealth
+{
+    /// <summary><c>"healthy"</c> or <c>"unhealthy"</c>.</summary>
+    public string Status { get; }
+
+    /// <summary>Human-readable reason when <see cref="Status"/> is <c>"unhealthy"</c>; otherwise null.</summary>
+    public string? Reason { get; }
+
+    private ConfigHealth(string status, string? reason)
+    {
+        Status = status;
+        Reason = reason;
+    }
+
+    /// <summary>Whether the active config source is usable.</summary>
+    public bool IsHealthy => Status == HealthyStatus;
+
+    internal const string HealthyStatus = "healthy";
+    internal const string UnhealthyStatus = "unhealthy";
+
+    /// <summary>A healthy status.</summary>
+    public static ConfigHealth Healthy() => new(HealthyStatus, null);
+
+    /// <summary>An unhealthy status with the given reason.</summary>
+    public static ConfigHealth Unhealthy(string reason) => new(UnhealthyStatus, reason);
+}

--- a/dotnet/src/SmooAI.Config/README.md
+++ b/dotnet/src/SmooAI.Config/README.md
@@ -142,6 +142,50 @@ JsonElement value = await client.GetValueAsync("moonshotApiKey");
 Dictionary<string, JsonElement> all = await client.GetAllValuesAsync();
 ```
 
+## Container / Runtime Mode
+
+Running in a long-lived **container** (EKS/ECS) instead of Lambda? Use **container mode** — it makes the HTTP config API the first-class, **fail-loud** path instead of the Lambda-oriented baked blob. A missing required value becomes an immediate, typed `ConfigKeyUnresolvedException` at startup, not a silent `null` that detonates downstream and CrashLoops your pod (the SMOODEV-1478 incident).
+
+> **Rule of thumb: containers use container mode, not the baked blob.**
+
+The behavior and environment contract are identical across the TypeScript, Python, Rust, Go, and .NET SDKs — idioms differ, behavior does not. The canonical, language-agnostic guide (env contract, an ExternalSecret recipe for the External Secrets Operator, and a readiness-probe example) lives in **[`docs/Container-Runtime-Mode.md`](https://github.com/SmooAI/config/blob/main/docs/Container-Runtime-Mode.md)**.
+
+```csharp
+using SmooAI.Config.Container;
+
+// Declare which keys exist (every key is REQUIRED by default in container mode;
+// use OptionalKeys to opt out). Or parse a schema.json via
+// ContainerConfigSchema.FromSchemaFile(...).
+var schema = new ContainerConfigSchema(
+    publicKeys: new[] { "apiBaseUrl" },
+    secretKeys: new[] { "stripeApiKey" });
+
+// Validates the env contract, mints an M2M token, and does an initial
+// fetch-all-values — so auth/network failures surface HERE, at startup,
+// not on first read. Throws ConfigBootstrapException if required env is missing.
+var config = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+{
+    Schema = schema,
+    OptionalKeys = new[] { "someOptionalKey" }, // these return null instead of throwing
+});
+
+// Fail-loud: a required secret that doesn't resolve throws ConfigKeyUnresolvedException.
+var stripeKey = await config.SecretConfig.GetAsync("stripeApiKey");
+
+// Kubernetes readiness/liveness probe — never throws:
+app.MapGet("/healthz/config", () =>
+{
+    var h = ContainerConfig.Health(config);   // or config.Health()
+    return h.IsHealthy ? Results.Ok() : Results.StatusCode(503);
+});
+```
+
+**Environment contract** (the exact same names every SDK uses): `SMOOAI_CONFIG_API_URL`, `SMOOAI_CONFIG_CLIENT_ID`, `SMOOAI_CONFIG_CLIENT_SECRET`, `SMOOAI_CONFIG_ORG_ID`, and `SMOOAI_CONFIG_ENV` are required; `SMOOAI_CONFIG_AUTH_URL` defaults to `https://auth.smoo.ai`. A set-but-blank value counts as missing. An explicit `UPPER_SNAKE_CASE(key)` process env var wins over the HTTP value (env-tier precedence). `ContainerConfig.SelectMode()` decides container vs. default mode per the spec (explicit `SMOOAI_CONFIG_MODE=container`, blob/file present → default, or auto-select when the M2M creds are all set).
+
+Values are cached with a 30s TTL; the OAuth token is refreshed 60s before expiry and a 401 invalidates + retries once. A background refresh failure serves the last-good value until the TTL hard-expires, at which point `Health()` reports `unhealthy`.
+
+> **Design note (matches the TypeScript reference):** the schema carries no required/optional metadata, so container mode treats **every** declared key as **required** by default. `InitContainerConfigOptions.OptionalKeys` is the opt-out.
+
 ## Under the hood
 
 If you want the protocol detail — auth is OAuth2 client-credentials against `{baseUrl}/token` (the `api.` subdomain rewrites to `auth.`), tokens are cached in-memory and refreshed 60s before expiry, and the client retries 401 once after re-auth. The baked bundle format is `nonce (12 bytes) || ciphertext || authTag (16 bytes)` with AES-256-GCM — wire-identical to the TS / Python / Rust / Go runtimes so a bundle baked in any language decrypts in any other.

--- a/dotnet/src/SmooAI.Config/SmooConfigClient.cs
+++ b/dotnet/src/SmooAI.Config/SmooConfigClient.cs
@@ -78,6 +78,11 @@ public sealed class SmooConfigClient : IDisposable
     /// callers can stub it without hitting the auth server.
     /// </summary>
     internal SmooConfigClient(SmooConfigClientOptions options, HttpClient httpClient, TokenProvider tokenProvider)
+        : this(options, httpClient, tokenProvider, disposeHttpClient: false)
+    {
+    }
+
+    private SmooConfigClient(SmooConfigClientOptions options, HttpClient httpClient, TokenProvider tokenProvider, bool disposeHttpClient)
     {
         ArgumentNullException.ThrowIfNull(options);
         options.Validate();
@@ -87,7 +92,20 @@ public sealed class SmooConfigClient : IDisposable
         _defaultEnvironment = options.DefaultEnvironment;
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
-        _disposeHttpClient = false;
+        _disposeHttpClient = disposeHttpClient;
+    }
+
+    /// <summary>
+    /// Build a client that uses a caller-supplied <see cref="TokenProvider"/>
+    /// (so the M2M token is minted/refreshed by the injected provider) over a
+    /// fresh, self-owned <see cref="HttpClient"/> for the config REST calls.
+    /// Used by container mode's token-provider injection seam.
+    /// </summary>
+    internal static SmooConfigClient CreateWithTokenProvider(SmooConfigClientOptions options, TokenProvider tokenProvider)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        return new SmooConfigClient(options, new HttpClient(), tokenProvider, disposeHttpClient: true);
     }
 
     /// <summary>Invalidate the cached OAuth token so the next call re-exchanges.</summary>

--- a/dotnet/tests/SmooAI.Config.Tests/Container/ContainerConfigTests.cs
+++ b/dotnet/tests/SmooAI.Config.Tests/Container/ContainerConfigTests.cs
@@ -1,0 +1,577 @@
+using System.Net;
+using SmooAI.Config.Container;
+using SmooAI.Config.OAuth;
+
+namespace SmooAI.Config.Tests.Container;
+
+/// <summary>
+/// Tests for container / runtime mode (SMOODEV-1491). Behavioral parity with
+/// the TypeScript reference suite
+/// (<c>src/container/__tests__/container.test.ts</c>): bootstrap-missing-env
+/// throws and lists the missing vars; required-key-unresolved throws (not
+/// absent); optional-key-absent returns null; happy-path fetch+cache;
+/// 401 → refresh → retry; <c>Health</c> healthy/unhealthy.
+/// </summary>
+public class ContainerConfigTests
+{
+    private const string TestOrgId = "550e8400-e29b-41d4-a716-446655440000";
+    private const string TestEnv = "production";
+
+    // A minimal schema with one public + two secret + one flag key.
+    private static ContainerConfigSchema Schema() => new(
+        publicKeys: new[] { "apiBaseUrl" },
+        secretKeys: new[] { "stripeApiKey", "sendgridApiKey" },
+        featureFlagKeys: new[] { "newCheckout" });
+
+    /// <summary>An env lookup that returns null for everything (clean room).</summary>
+    private static Func<string, string?> EmptyEnv() => _ => null;
+
+    /// <summary>An env lookup backed by an explicit map.</summary>
+    private static Func<string, string?> EnvFrom(IDictionary<string, string?> map)
+        => name => map.TryGetValue(name, out var v) ? v : null;
+
+    private static (SmooConfigClient client, StubHttpMessageHandler handler, HttpClient http) CreateClient()
+    {
+        var handler = new StubHttpMessageHandler();
+        var http = new HttpClient(handler);
+        var options = new SmooConfigClientOptions
+        {
+            ClientId = "cid",
+            ClientSecret = "csec",
+            OrgId = TestOrgId,
+            BaseUrl = "https://api.smoo.ai",
+            AuthUrl = "https://auth.smoo.ai",
+            DefaultEnvironment = TestEnv,
+        };
+        var tp = new TokenProvider(http, options.AuthUrl!, options.ClientId, options.ClientSecret);
+        var client = new SmooConfigClient(options, http, tp);
+        return (client, handler, http);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bootstrap validation (§3)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Init_throws_ConfigBootstrapException_listing_every_missing_required_var()
+    {
+        var err = await Assert.ThrowsAsync<ConfigBootstrapException>(() =>
+            ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                GetEnv = EmptyEnv(),
+            }));
+
+        Assert.Contains("SMOOAI_CONFIG_API_URL", err.Missing);
+        Assert.Contains("SMOOAI_CONFIG_CLIENT_ID", err.Missing);
+        Assert.Contains("SMOOAI_CONFIG_CLIENT_SECRET", err.Missing);
+        Assert.Contains("SMOOAI_CONFIG_ORG_ID", err.Missing);
+        Assert.Contains("SMOOAI_CONFIG_ENV", err.Missing);
+        Assert.Contains("SMOOAI_CONFIG_API_URL", err.Message);
+    }
+
+    [Fact]
+    public async Task Init_lists_only_the_actually_missing_vars()
+    {
+        var env = EnvFrom(new Dictionary<string, string?>
+        {
+            ["SMOOAI_CONFIG_API_URL"] = "https://api.smooai.test",
+            ["SMOOAI_CONFIG_CLIENT_ID"] = "id",
+            ["SMOOAI_CONFIG_ORG_ID"] = "org-1",
+            ["SMOOAI_CONFIG_ENV"] = "production",
+            // CLIENT_SECRET missing.
+        });
+
+        var err = await Assert.ThrowsAsync<ConfigBootstrapException>(() =>
+            ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions { Schema = Schema(), GetEnv = env }));
+
+        Assert.Equal(new[] { "SMOOAI_CONFIG_CLIENT_SECRET" }, err.Missing);
+    }
+
+    [Fact]
+    public async Task Init_treats_a_blank_whitespace_env_var_as_missing()
+    {
+        var env = EnvFrom(new Dictionary<string, string?>
+        {
+            ["SMOOAI_CONFIG_API_URL"] = "https://api.smooai.test",
+            ["SMOOAI_CONFIG_CLIENT_ID"] = "   ",
+            ["SMOOAI_CONFIG_CLIENT_SECRET"] = "secret",
+            ["SMOOAI_CONFIG_ORG_ID"] = "org-1",
+            ["SMOOAI_CONFIG_ENV"] = "production",
+        });
+
+        var err = await Assert.ThrowsAsync<ConfigBootstrapException>(() =>
+            ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions { Schema = Schema(), GetEnv = env }));
+
+        Assert.Equal(new[] { "SMOOAI_CONFIG_CLIENT_ID" }, err.Missing);
+    }
+
+    [Fact]
+    public async Task Init_accepts_legacy_SMOOAI_CONFIG_API_KEY_as_the_client_secret()
+    {
+        var env = EnvFrom(new Dictionary<string, string?>
+        {
+            ["SMOOAI_CONFIG_API_URL"] = "https://api.smooai.test",
+            ["SMOOAI_CONFIG_CLIENT_ID"] = "id",
+            ["SMOOAI_CONFIG_API_KEY"] = "legacy-secret",
+            ["SMOOAI_CONFIG_ORG_ID"] = "org-1",
+            ["SMOOAI_CONFIG_ENV"] = "production",
+        });
+
+        // Bootstrap should pass env validation (the legacy alias satisfies the
+        // secret). The initial fetch will fail at the network layer since there
+        // is no server — but the failure is NOT a bootstrap error, proving the
+        // env contract was satisfied.
+        var ex = await Record.ExceptionAsync(() =>
+            ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions { Schema = Schema(), GetEnv = env }));
+
+        Assert.NotNull(ex);
+        Assert.IsNotType<ConfigBootstrapException>(ex);
+    }
+
+    [Fact]
+    public async Task Init_with_injected_client_only_requires_SMOOAI_CONFIG_ENV()
+    {
+        var (client, _, http) = CreateClient();
+        try
+        {
+            var err = await Assert.ThrowsAsync<ConfigBootstrapException>(() =>
+                ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+                {
+                    Schema = Schema(),
+                    ConfigClient = client,
+                    GetEnv = EmptyEnv(),
+                }));
+
+            Assert.Equal(new[] { "SMOOAI_CONFIG_ENV" }, err.Missing);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Startup fetch — fail at boot, not first read (§4)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Init_throws_when_the_initial_config_fetch_fails()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            // Token mint OK, then GetAllValues -> 500.
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.InternalServerError, "boom");
+
+            var ex = await Assert.ThrowsAsync<SmooConfigApiException>(() =>
+                ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+                {
+                    Schema = Schema(),
+                    Environment = TestEnv,
+                    ConfigClient = client,
+                }));
+
+            Assert.Equal(500, ex.StatusCode);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task HappyPath_initial_fetch_seeds_cache_and_reads_without_a_second_http_call()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk_live_123","apiBaseUrl":"https://x"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            var callsAfterInit = handler.Requests.Count;
+            Assert.Equal("sk_live_123", await handle.SecretConfig.GetAsync("stripeApiKey"));
+            Assert.Equal("https://x", await handle.PublicConfig.GetAsync("apiBaseUrl"));
+            // getAllValues seeded the cache, so no extra fetches.
+            Assert.Equal(callsAfterInit, handler.Requests.Count);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Fail-loud reads (§3)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Required_secret_unresolved_throws_ConfigKeyUnresolvedException()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{}}""");          // initial getAllValues empty
+            handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");          // per-key getValue absent
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            var err = await Assert.ThrowsAsync<ConfigKeyUnresolvedException>(() => handle.SecretConfig.GetAsync("stripeApiKey"));
+            Assert.Equal("stripeApiKey", err.Key);
+            Assert.Equal(TestEnv, err.Env);
+            Assert.Equal(new[] { "env", "http" }, err.TriedTiers);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Optional_key_absent_returns_null_does_not_throw()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{}}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"value":null}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+                OptionalKeys = new[] { "sendgridApiKey" },
+                GetEnv = EmptyEnv(),
+            });
+
+            Assert.Null(await handle.SecretConfig.GetAsync("sendgridApiKey"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task GetSync_for_an_unresolved_required_key_throws()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            Assert.Throws<ConfigKeyUnresolvedException>(() => handle.SecretConfig.GetSync("stripeApiKey"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task GetSync_returns_a_cached_value_when_present()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk_cached"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            Assert.Equal("sk_cached", handle.SecretConfig.GetSync("stripeApiKey"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Env_override_wins_over_http()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk_from_http"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+                GetEnv = EnvFrom(new Dictionary<string, string?> { ["STRIPE_API_KEY"] = "sk_from_env" }),
+            });
+
+            Assert.Equal("sk_from_env", await handle.SecretConfig.GetAsync("stripeApiKey"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Reading_a_key_not_in_the_tier_throws_ArgumentException()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            // stripeApiKey is a secret, not a public key.
+            await Assert.ThrowsAsync<ArgumentException>(() => handle.PublicConfig.GetAsync("stripeApiKey"));
+            await Assert.ThrowsAsync<ArgumentException>(() => handle.SecretConfig.GetAsync("notDeclared"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // 401 -> refresh -> retry (§5)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Read_invalidates_token_and_retries_once_on_a_401()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-1","expires_in":3600}""");   // initial token mint
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{}}""");                                   // initial getAllValues
+            handler.Enqueue(HttpStatusCode.Unauthorized, "expired");                                   // per-key getValue -> 401
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"tok-2","expires_in":3600}""");      // re-mint after invalidate
+            handler.Enqueue(HttpStatusCode.OK, """{"value":"sk_after_refresh"}""");                    // retry succeeds
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            var v = await handle.SecretConfig.GetAsync("stripeApiKey");
+            Assert.Equal("sk_after_refresh", v);
+            // The 401 invalidated the cached token, forcing a re-mint; the
+            // successful retry GET carried the fresh tok-2 (proves invalidate+retry).
+            var lastGet = handler.Requests[^1];
+            Assert.Equal("tok-2", lastGet.Headers.Authorization!.Parameter);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Health (§4)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Health_reports_healthy_after_a_successful_initial_fetch()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+            GetEnv = EmptyEnv(),
+            });
+
+            Assert.True(handle.Health().IsHealthy);
+            Assert.Equal("healthy", handle.Health().Status);
+            Assert.True(ContainerConfig.Health(handle).IsHealthy);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Health_serves_healthy_within_TTL_then_unhealthy_past_hard_expiry_on_refresh_failure()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"stripeApiKey":"sk_initial"}}""");
+            // Subsequent per-key refresh fails (503) repeatedly.
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("network down"),
+            });
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("network down"),
+            });
+
+            var now = DateTimeOffset.UtcNow;
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+                CacheTtlMs = 30_000,
+                GetEnv = EmptyEnv(),
+            });
+            handle.UtcNow = () => now;
+
+            Assert.True(handle.Health().IsHealthy);
+
+            // Advance past the per-key TTL so the cached last-good is gone AND
+            // the HTTP refresh fails -> required key resolves absent.
+            now = now.AddMilliseconds(31_000);
+            var err = await Assert.ThrowsAsync<ConfigKeyUnresolvedException>(() => handle.SecretConfig.GetAsync("stripeApiKey"));
+            Assert.Equal("stripeApiKey", err.Key);
+
+            // Health: last refresh failed and we're past the TTL window -> unhealthy.
+            var h = handle.Health();
+            Assert.Equal("unhealthy", h.Status);
+            Assert.Contains("network down", h.Reason ?? string.Empty);
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // SelectMode (§2)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void SelectMode_container_when_mode_is_container()
+    {
+        Assert.Equal("container", ContainerConfig.SelectMode(new SelectModeInputs { Mode = "container", GetEnv = EmptyEnv() }));
+        Assert.Equal("container", ContainerConfig.SelectMode(new SelectModeInputs { Mode = "CONTAINER", GetEnv = EmptyEnv() }));
+    }
+
+    [Fact]
+    public void SelectMode_default_when_a_blob_or_file_source_is_present()
+    {
+        Assert.Equal("default", ContainerConfig.SelectMode(new SelectModeInputs
+        {
+            BlobPresent = true,
+            ClientId = "id",
+            ClientSecret = "s",
+            ApiUrl = "u",
+            GetEnv = EmptyEnv(),
+        }));
+        Assert.Equal("default", ContainerConfig.SelectMode(new SelectModeInputs
+        {
+            FilePresent = true,
+            ClientId = "id",
+            ClientSecret = "s",
+            ApiUrl = "u",
+            GetEnv = EmptyEnv(),
+        }));
+    }
+
+    [Fact]
+    public void SelectMode_auto_selects_container_on_complete_m2m_creds()
+    {
+        Assert.Equal("container", ContainerConfig.SelectMode(new SelectModeInputs
+        {
+            ClientId = "id",
+            ClientSecret = "s",
+            ApiUrl = "u",
+            GetEnv = EmptyEnv(),
+        }));
+    }
+
+    [Fact]
+    public void SelectMode_falls_back_to_default_when_m2m_creds_incomplete()
+    {
+        Assert.Equal("default", ContainerConfig.SelectMode(new SelectModeInputs { ClientId = "id", ApiUrl = "u", GetEnv = EmptyEnv() }));
+        Assert.Equal("default", ContainerConfig.SelectMode(new SelectModeInputs { GetEnv = EmptyEnv() }));
+    }
+
+    [Theory]
+    [InlineData("stripeApiKey", "STRIPE_API_KEY")]
+    [InlineData("apiBaseUrl", "API_BASE_URL")]
+    [InlineData("newCheckout", "NEW_CHECKOUT")]
+    [InlineData("url", "URL")]
+    public void EnvVarNameFor_converts_camelCase_to_UPPER_SNAKE_CASE(string key, string expected)
+    {
+        Assert.Equal(expected, ContainerConfig.EnvVarNameFor(key));
+    }
+
+    // -------------------------------------------------------------------------
+    // Typed reads + feature flags
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Typed_GetAsync_deserializes_non_string_values()
+    {
+        var (client, handler, http) = CreateClient();
+        try
+        {
+            handler.Enqueue(HttpStatusCode.OK, """{"access_token":"T","expires_in":3600}""");
+            handler.Enqueue(HttpStatusCode.OK, """{"values":{"newCheckout":true,"apiBaseUrl":"https://x"}}""");
+
+            var handle = await ContainerConfig.InitContainerConfigAsync(new InitContainerConfigOptions
+            {
+                Schema = Schema(),
+                Environment = TestEnv,
+                ConfigClient = client,
+                GetEnv = EmptyEnv(),
+            });
+
+            Assert.True(await handle.FeatureFlag.GetAsync<bool>("newCheckout"));
+            Assert.True(handle.FeatureFlag.GetSync<bool>("newCheckout"));
+            Assert.Equal("https://x", await handle.PublicConfig.GetAsync<string>("apiBaseUrl"));
+        }
+        finally { client.Dispose(); http.Dispose(); }
+    }
+
+    // -------------------------------------------------------------------------
+    // ContainerConfigSchema parsing
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Schema_parses_defineConfig_shape()
+    {
+        var schema = ContainerConfigSchema.FromSchemaJson(
+            """{"publicConfigSchema":{"apiBaseUrl":{}},"secretConfigSchema":{"stripeApiKey":{}},"featureFlagSchema":{"newCheckout":{}}}""");
+
+        Assert.True(schema.ContainsInTier("apiBaseUrl", ConfigKeyTier.Public));
+        Assert.True(schema.ContainsInTier("stripeApiKey", ConfigKeyTier.Secret));
+        Assert.True(schema.ContainsInTier("newCheckout", ConfigKeyTier.FeatureFlag));
+        Assert.False(schema.Contains("nope"));
+    }
+
+    [Fact]
+    public void Schema_parses_json_schema_shape()
+    {
+        var schema = ContainerConfigSchema.FromSchemaJson(
+            """{"properties":{"public":{"properties":{"apiBaseUrl":{}}},"secret":{"properties":{"stripeApiKey":{}}},"featureFlags":{"properties":{"newCheckout":{}}}}}""");
+
+        Assert.True(schema.ContainsInTier("apiBaseUrl", ConfigKeyTier.Public));
+        Assert.True(schema.ContainsInTier("stripeApiKey", ConfigKeyTier.Secret));
+        Assert.True(schema.ContainsInTier("newCheckout", ConfigKeyTier.FeatureFlag));
+    }
+
+    [Fact]
+    public void Schema_rejects_a_key_declared_in_two_tiers()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new ContainerConfigSchema(publicKeys: new[] { "dup" }, secretKeys: new[] { "dup" }));
+    }
+}


### PR DESCRIPTION
## Problem

Container/runtime mode (SMOODEV-1489 epic) makes the HTTP config API the first-class, **fail-loud** path for long-lived containers (EKS/ECS) instead of the Lambda-oriented baked blob — so a missing required value is an immediate typed error at startup, not a silent \`null\` that CrashLoops the pod (the SMOODEV-1478 incident). The TS reference shipped in SMOODEV-1490 (#92). This brings the **.NET (C#)** SDK to parity.

## Solution

New \`SmooAI.Config.Container\` namespace mirroring the TS contract with idiomatic C# (async \`Task\`, exceptions, PascalCase):

- **\`ContainerConfig.InitContainerConfigAsync(options)\`** — validates the §1 env contract, builds the M2M token provider + HTTP config client, and performs an **initial token mint + fetch-all-values** so auth/network failures surface at init (throws). Missing/blank required env throws \`ConfigBootstrapException\` carrying \`Missing\` (no partial init). With an injected \`ConfigClient\`, only \`SMOOAI_CONFIG_ENV\` is required.
- **Handle** exposes \`SecretConfig\`/\`PublicConfig\`/\`FeatureFlag\`, each with \`GetAsync(key)\` + \`GetSync(key)\` (both **fail-loud**, plus typed \`GetAsync<T>\`/\`GetSync<T>\`), \`Health()\`, and the underlying \`Client\`.
- **Fail-loud reads** — a required key that resolves absent throws \`ConfigKeyUnresolvedException { Key, Env, TriedTiers }\` (container → \`["env","http"]\`) instead of returning null/default. \`OptionalKeys\` opts specific keys out.
- **\`ContainerConfig.Health(handle)\`** (static, never throws) → \`ConfigHealth { Status, Reason }\` for k8s readiness/liveness probes; serves last-good within the 30s TTL, \`unhealthy\` past hard-expiry.
- **\`ContainerConfig.SelectMode(inputs)\`** → \`"container"|"default"\` per §2.
- Same SMOOAI_CONFIG_* env names (+ legacy \`SMOOAI_AUTH_URL\` / \`SMOOAI_CONFIG_API_KEY\`), env-over-http precedence, \`UPPER_SNAKE_CASE(key)\` overrides, 30s cache TTL, 60s token refresh buffer, 401 → refresh → retry.
- **Design fork (matches TS):** the schema has no required/optional metadata, so container mode treats **all** declared keys as required by default; \`OptionalKeys\` is the opt-out.

## Verification

- 28 new container tests (parity with the TS suite: bootstrap-missing-env, required-key-unresolved, optional-key-absent, happy-path fetch+cache, 401→refresh→retry, Health healthy/unhealthy, SelectMode, schema parsing, typed reads). Full dotnet suite green (127 tests, net8/9/10).
- \`dotnet pack\` verified. Full multi-language pre-commit gate (lint, typecheck, all-language test/build, format) passed.

## Docs / versioning

- README "Container / Runtime Mode" section linking the shared \`docs/Container-Runtime-Mode.md\` with a C# snippet.
- Changeset (\`minor\`); the release \`version:sync\` bumps the NuGet csproj version alongside the other languages.

Jira: [SMOODEV-1491](https://smooai.atlassian.net/browse/SMOODEV-1491)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-1491]: https://smooai.atlassian.net/browse/SMOODEV-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ