### PR TITLE
SMOODEV-1526: Fix Python ruff lint on ESO parity modules (green main)

### DIFF
--- a/python/src/smooai_config/__init__.py
+++ b/python/src/smooai_config/__init__.py
@@ -22,6 +22,7 @@ from smooai_config.container import (
     init_container_config,
     select_mode,
 )
+from smooai_config.env_config import find_and_process_env_config
 from smooai_config.eso_manifests import (
     BootstrapSecretRef,
     ExternalSecretOptions,
@@ -36,7 +37,6 @@ from smooai_config.eso_refresher import (
     TokenSource,
     run_eso_refresher,
 )
-from smooai_config.env_config import find_and_process_env_config
 from smooai_config.file_config import find_and_process_file_config, find_config_directory
 from smooai_config.local import LocalConfigManager
 from smooai_config.merge import merge_replace_arrays
@@ -47,6 +47,7 @@ from smooai_config.utils import SmooaiConfigError, camel_to_upper_snake, coerce_
 __all__ = [
     "DEFAULT_CACHE_TTL_MS",
     "DEFAULT_TOKEN_REFRESH_BUFFER_SECONDS",
+    "BootstrapSecretRef",
     "BuildBundleResult",
     "CloudRegionResult",
     "ConfigBootstrapError",
@@ -56,15 +57,22 @@ __all__ = [
     "ConfigManager",
     "ConfigTier",
     "ContainerConfigHandle",
+    "EsoRefresherHandle",
     "EvaluateFeatureFlagResponse",
+    "ExternalSecretOptions",
     "FeatureFlagContextError",
     "FeatureFlagEvaluationError",
     "FeatureFlagNotFoundError",
     "LocalConfigManager",
+    "SecretMapping",
+    "SecretWriter",
     "SelectModeInputs",
     "SmooaiConfigError",
+    "TokenSource",
     "UndefinedKeyError",
     "build_bundle",
+    "build_cluster_secret_store",
+    "build_external_secret",
     "build_config_runtime",
     "camel_to_upper_snake",
     "classify_from_schema",
@@ -79,5 +87,7 @@ __all__ = [
     "init_container_config",
     "merge_replace_arrays",
     "read_baked_config",
+    "resolve_secret_mapping",
+    "run_eso_refresher",
     "select_mode",
 ]

--- a/python/src/smooai_config/eso_manifests.py
+++ b/python/src/smooai_config/eso_manifests.py
@@ -64,7 +64,8 @@ def build_cluster_secret_store(
 
     ref = bootstrap_secret or BootstrapSecretRef()
     base = api_url.rstrip("/")
-    url = f"{base}/organizations/{org_id}/config/values/{{{{ .remoteRef.key }}}}?environment={quote(environment, safe='')}"
+    env = quote(environment, safe="")
+    url = f"{base}/organizations/{org_id}/config/values/{{{{ .remoteRef.key }}}}?environment={env}"
 
     return {
         "apiVersion": ESO_API_VERSION,

--- a/python/src/smooai_config/eso_refresher.py
+++ b/python/src/smooai_config/eso_refresher.py
@@ -17,8 +17,9 @@ deployable; this gives the refresh ALGORITHM parity in Python.
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Protocol
+from typing import Protocol
 
 from smooai_config.utils import SmooaiConfigError
 

--- a/python/tests/test_eso_manifests.py
+++ b/python/tests/test_eso_manifests.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from smooai_config.eso_manifests import (
     BootstrapSecretRef,
     ExternalSecretOptions,
@@ -40,7 +41,8 @@ def test_cluster_secret_store_overrides():
         bootstrap_secret=BootstrapSecretRef(name="s", namespace="ns", key="k"),
     )
     assert store["metadata"]["name"] == "smooai-config-prod"
-    assert store["spec"]["provider"]["webhook"]["secrets"][0]["secretRef"] == {"name": "s", "namespace": "ns", "key": "k"}
+    ref = store["spec"]["provider"]["webhook"]["secrets"][0]["secretRef"]
+    assert ref == {"name": "s", "namespace": "ns", "key": "k"}
 
 
 def test_cluster_secret_store_required_fields():
@@ -76,7 +78,12 @@ def test_build_external_secret_maps_keys():
 
 def test_build_external_secret_distinct_target():
     es = build_external_secret(
-        ExternalSecretOptions(name="litellm-config-eso", namespace="smooai-litellm", secrets=["mimoApiKey"], target_secret_name="litellm-config-eso")
+        ExternalSecretOptions(
+            name="litellm-config-eso",
+            namespace="smooai-litellm",
+            secrets=["mimoApiKey"],
+            target_secret_name="litellm-config-eso",
+        )
     )
     assert es["spec"]["target"]["name"] == "litellm-config-eso"
 

--- a/python/tests/test_eso_refresher.py
+++ b/python/tests/test_eso_refresher.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
+
 from smooai_config.eso_refresher import run_eso_refresher
 from smooai_config.utils import SmooaiConfigError
 
@@ -115,5 +116,10 @@ def test_required_fields():
 
 def test_honors_interval_override():
     sched = ManualScheduler()
-    run_eso_refresher(token_source=FakeTokenSource(["t"]), secret_writer=RecordingWriter(), interval_seconds=123.0, scheduler=sched)
+    run_eso_refresher(
+        token_source=FakeTokenSource(["t"]),
+        secret_writer=RecordingWriter(),
+        interval_seconds=123.0,
+        scheduler=sched,
+    )
     assert sched.interval == 123.0


### PR DESCRIPTION
Follow-up to #105 — the ESO parity merge turned config main red on the Python `ruff check` step (F401: new `__init__` re-exports not in `__all__`; the local pre-commit runs `ruff format` not `ruff check`). Adds the re-exports to `__all__` + wraps 3 over-length lines. `ruff check` clean, 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)