### PR TITLE
SMOODEV-1527: Fix eso-refresher keep-alive (don't unref the interval)

### DIFF
--- a/.changeset/eso-refresher-keepalive.md
+++ b/.changeset/eso-refresher-keepalive.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config': patch
+---
+
+SMOODEV-1527: Fix the eso-refresher exiting immediately after its initial mint (it `unref()`'d the interval timer, and a pending `await new Promise(() => {})` doesn't hold Node's event loop open — so the process exited 0 → CrashLoopBackOff). The production interval now keeps the daemon alive; tests inject their own scheduler so they're unaffected.

--- a/src/eso-refresher/index.ts
+++ b/src/eso-refresher/index.ts
@@ -147,8 +147,12 @@ export interface EsoRefresherHandle {
 
 function defaultScheduler(fn: () => void, ms: number): { clear: () => void } {
     const t = setInterval(fn, ms);
-    // Don't keep the event loop alive solely for the timer in tests/CLI teardown.
-    if (typeof t.unref === 'function') t.unref();
+    // SMOODEV-1527: do NOT unref() — the interval is what keeps the daemon's
+    // event loop alive. A pending `await new Promise(() => {})` in main() does
+    // NOT hold the loop open by itself, so unref'ing here let the process exit 0
+    // right after the initial mint → CrashLoopBackOff. Tests inject their own
+    // scheduler, so this only affects the real CLI/sidecar (where we WANT it
+    // to keep running). `stop()` still calls clear() for clean shutdown.
     return { clear: () => clearInterval(t) };
 }
 


### PR DESCRIPTION
The refresher exited 0 right after its initial mint — it `unref()`'d the interval timer, and `await new Promise(() => {})` doesn't hold Node's event loop open. Result: CrashLoopBackOff (it re-minted on each restart, masking it). Don't unref the production interval. Tests inject their own scheduler. Part of the ESO cutover (SMOODEV-1527 / epic SMOODEV-1522).